### PR TITLE
Renamed organizers

### DIFF
--- a/examples/widgetbook_annotation_example/lib/app.widgetbook.dart
+++ b/examples/widgetbook_annotation_example/lib/app.widgetbook.dart
@@ -5,21 +5,21 @@
 // **************************************************************************
 
 import 'package:meal_app/themes/light_theme.dart';
-import 'package:meal_app/constants/border.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
+import 'package:flutter/material.dart';
 import 'dart:core';
 import 'package:meal_app/constants/color.dart';
-import 'package:flutter/material.dart';
+import 'package:meal_app/constants/border.dart';
 import 'package:meal_app/themes/dark_theme.dart';
 import 'package:meal_app/widgets/attributes/attribute.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:meal_app/widgets/meal_detail.dart';
-import 'package:meal_app/widgets/ingredients.dart';
 import 'package:meal_app/widgets/attributes/weight_attribute.dart';
-import 'package:meal_app/widgets/new_tag.dart';
 import 'package:meal_app/widgets/rotated_image.dart';
-import 'package:meal_app/models/meal.dart';
 import 'package:meal_app/widgets/attributes/price_attribute.dart';
+import 'package:meal_app/models/meal.dart';
+import 'package:meal_app/widgets/new_tag.dart';
+import 'package:meal_app/widgets/ingredients.dart';
 import 'package:widgetbook/widgetbook.dart';
 
 void main() {
@@ -27,27 +27,31 @@ void main() {
 }
 
 class HotReload extends StatelessWidget {
+  const HotReload({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Widgetbook(
-      appInfo: AppInfo(name: 'Meal App'),
+      appInfo: AppInfo(
+        name: 'Meal App',
+      ),
       lightTheme: getLightThemeData(),
       darkTheme: getDarkThemeData(),
       categories: [
-        Category(
+        WidgetbookCategory(
           name: 'stories',
           folders: [
-            Folder(
+            WidgetbookFolder(
               name: 'widgets',
               widgets: [
-                WidgetElement(
+                WidgetbookWidget(
                   name: 'MealDetail',
                   stories: [
-                    Story(
+                    WidgetbookUseCase(
                       name: 'short name',
                       builder: (context) => mealDetailShort(context),
                     ),
-                    Story(
+                    WidgetbookUseCase(
                       name: 'long name',
                       builder: (context) => mealDetailLong(context),
                     ),
@@ -55,23 +59,25 @@ class HotReload extends StatelessWidget {
                 ),
               ],
               folders: [
-                Folder(
+                WidgetbookFolder(
                   name: 'attributes',
                   widgets: [
-                    WidgetElement(
+                    WidgetbookWidget(
                       name: 'Attribute',
                       stories: [
-                        Story(
+                        WidgetbookUseCase(
                           name: 'weight',
                           builder: (context) => attributeStory(context),
                         ),
                       ],
                     ),
                   ],
+                  folders: [],
                 ),
               ],
-            )
+            ),
           ],
+          widgets: [],
         ),
       ],
     );

--- a/examples/widgetbook_annotation_example/pubspec.lock
+++ b/examples/widgetbook_annotation_example/pubspec.lock
@@ -482,28 +482,28 @@ packages:
       name: widgetbook
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.13"
+    version: "1.0.0-beta.1"
   widgetbook_annotation:
     dependency: "direct main"
     description:
       name: widgetbook_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.3"
+    version: "0.0.4"
   widgetbook_generator:
     dependency: "direct dev"
     description:
       name: widgetbook_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.3"
+    version: "1.0.0-beta.1"
   widgetbook_models:
     dependency: transitive
     description:
       name: widgetbook_models
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.2"
+    version: "0.0.3"
   yaml:
     dependency: transitive
     description:

--- a/examples/widgetbook_annotation_example/pubspec.lock
+++ b/examples/widgetbook_annotation_example/pubspec.lock
@@ -482,7 +482,7 @@ packages:
       name: widgetbook
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0-beta.1"
+    version: "1.0.0"
   widgetbook_annotation:
     dependency: "direct main"
     description:
@@ -496,7 +496,7 @@ packages:
       name: widgetbook_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0-beta.1"
+    version: "1.0.0"
   widgetbook_models:
     dependency: transitive
     description:

--- a/examples/widgetbook_annotation_example/pubspec.yaml
+++ b/examples/widgetbook_annotation_example/pubspec.yaml
@@ -16,11 +16,11 @@ dependencies:
     sdk: flutter
   flutter_bloc: ^7.1.0
   font_awesome_flutter: ^9.1.0
-  widgetbook: ^0.0.13
+  widgetbook: 1.0.0-beta.1
   widgetbook_annotation: ^0.0.3
 
 dev_dependencies:
-  widgetbook_generator: ^0.0.3
+  widgetbook_generator: 1.0.0-beta.1
   flutter_test:
     sdk: flutter
   build_runner: ^2.1.4

--- a/examples/widgetbook_annotation_example/pubspec.yaml
+++ b/examples/widgetbook_annotation_example/pubspec.yaml
@@ -16,11 +16,11 @@ dependencies:
     sdk: flutter
   flutter_bloc: ^7.1.0
   font_awesome_flutter: ^9.1.0
-  widgetbook: 1.0.0-beta.1
+  widgetbook: ^1.0.0
   widgetbook_annotation: ^0.0.3
 
 dev_dependencies:
-  widgetbook_generator: 1.0.0-beta.1
+  widgetbook_generator: ^1.0.0
   flutter_test:
     sdk: flutter
   build_runner: ^2.1.4

--- a/examples/widgetbook_example/pubspec.lock
+++ b/examples/widgetbook_example/pubspec.lock
@@ -206,10 +206,10 @@ packages:
   widgetbook:
     dependency: "direct main"
     description:
-      path: "../../packages/widgetbook"
-      relative: true
-    source: path
-    version: "0.0.15"
+      name: widgetbook
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   widgetbook_models:
     dependency: transitive
     description:

--- a/examples/widgetbook_example/pubspec.yaml
+++ b/examples/widgetbook_example/pubspec.yaml
@@ -16,8 +16,7 @@ dependencies:
     sdk: flutter
   flutter_bloc: ^7.1.0
   font_awesome_flutter: ^9.1.0
-  widgetbook: 
-    path: ../../packages/widgetbook
+  widgetbook: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/examples/widgetbook_example/stories/storybook.dart
+++ b/examples/widgetbook_example/stories/storybook.dart
@@ -20,6 +20,7 @@ class Storyboard extends StatelessWidget {
         Apple.iPhone12,
         Samsung.s10,
         Samsung.s21ultra,
+        Apple.iMacM1,
       ],
       categories: [
         WidgetbookCategory(

--- a/examples/widgetbook_example/stories/storybook.dart
+++ b/examples/widgetbook_example/stories/storybook.dart
@@ -22,35 +22,35 @@ class Storyboard extends StatelessWidget {
         Samsung.s21ultra,
       ],
       categories: [
-        Category(
+        WidgetbookCategory(
           name: 'widgets test',
           folders: [
-            Folder(
+            WidgetbookFolder(
               name: 'attributes',
               widgets: [
-                WidgetElement(
+                WidgetbookWidget(
                   name: 'PriceAttribute',
                   stories: [
-                    Story(
+                    WidgetbookUseCase(
                       name: 'Short price',
                       builder: (context) => PriceAttribute(price: 8.5),
                     ),
-                    Story(
+                    WidgetbookUseCase(
                       name: 'Long price',
                       builder: (context) => PriceAttribute(price: 108.5),
                     ),
                   ],
                 ),
-                WidgetElement(
+                WidgetbookWidget(
                   name: 'WeightAttribute',
                   stories: [
-                    Story(
+                    WidgetbookUseCase(
                       name: 'Short weight',
                       builder: (context) => WeightAttribute(
                         weight: 320,
                       ),
                     ),
-                    Story(
+                    WidgetbookUseCase(
                       name: 'Long weight',
                       builder: (context) => WeightAttribute(
                         weight: 1050,
@@ -62,10 +62,10 @@ class Storyboard extends StatelessWidget {
             ),
           ],
           widgets: [
-            WidgetElement(
+            WidgetbookWidget(
               name: 'Ingredients',
               stories: [
-                Story(
+                WidgetbookUseCase(
                   name: 'Short list',
                   builder: (context) => Ingredients(
                     ingredients: [
@@ -75,7 +75,7 @@ class Storyboard extends StatelessWidget {
                     ],
                   ),
                 ),
-                Story(
+                WidgetbookUseCase(
                   name: 'Medium list',
                   builder: (context) => Ingredients(
                     ingredients: [
@@ -88,7 +88,7 @@ class Storyboard extends StatelessWidget {
                     ],
                   ),
                 ),
-                Story(
+                WidgetbookUseCase(
                   name: 'Long list',
                   builder: (context) => Ingredients(
                     ingredients: [
@@ -106,19 +106,19 @@ class Storyboard extends StatelessWidget {
                 ),
               ],
             ),
-            WidgetElement(
+            WidgetbookWidget(
               name: 'New tag',
               stories: [
-                Story(
+                WidgetbookUseCase(
                   name: 'Default',
                   builder: (context) => NewTag(),
                 ),
               ],
             ),
-            WidgetElement(
+            WidgetbookWidget(
               name: 'Rotated image',
               stories: [
-                Story(
+                WidgetbookUseCase(
                   name: 'Default',
                   builder: (context) => RotatedImage(
                     assetPath: 'assets/burger.jpg',
@@ -126,10 +126,10 @@ class Storyboard extends StatelessWidget {
                 ),
               ],
             ),
-            WidgetElement(
+            WidgetbookWidget(
               name: 'MealDetail',
               stories: [
-                Story(
+                WidgetbookUseCase(
                   name: 'Short name',
                   builder: (context) => MealDetail(
                     meal: Meal(
@@ -145,7 +145,7 @@ class Storyboard extends StatelessWidget {
                     ),
                   ),
                 ),
-                Story(
+                WidgetbookUseCase(
                   name: 'Long name',
                   builder: (context) => MealDetail(
                     meal: Meal(
@@ -165,7 +165,7 @@ class Storyboard extends StatelessWidget {
             ),
           ],
         ),
-        Category(
+        WidgetbookCategory(
           name: 'pages',
         ),
       ],

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.0
+
+renamed organizer elements to make them less generic. Renamed to the following:
+
+- `Category` renamed to `WidgetbookCategory`
+- `Folder` renamed to `WidgetbookFolder`
+- `WidgetElement` renamed to `WidgetbookWidget`
+- `Story` renamed to `WidgetbookUseCase`
+
 ## 0.0.16
 
 - fixed error thrown when switching to a theme that is not defined

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0
+## 1.0.0-beta.1
 
 renamed organizer elements to make them less generic. Renamed to the following:
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-beta.1
+## 1.0.0
 
 renamed organizer elements to make them less generic. Renamed to the following:
 

--- a/packages/widgetbook/README.md
+++ b/packages/widgetbook/README.md
@@ -135,7 +135,7 @@ class HotReload extends StatelessWidget {
 }
 ```
 
-## Set storybook name
+## Set Widgetbook name
 
 Customize `Widgetbook`'s name according to the project by using appInfo:
 

--- a/packages/widgetbook/README.md
+++ b/packages/widgetbook/README.md
@@ -84,7 +84,7 @@ Run the `Widgetbook` main method by executing `flutter run -t stories/main.dart`
 
 # Inject your widgets
 
-Your widgets can be organized into different areas of interest by using `Category`, `Folder`, `WidgetElement` and `Story`.
+Your widgets can be organized into different areas of interest by using `WidgetbookCategory`, `WidgetbookFolder`, `WidgetbookWidget` and `WidgetbookUseCase`.
 
 ```dart
 class HotReload extends StatelessWidget {
@@ -94,13 +94,13 @@ class HotReload extends StatelessWidget {
   Widget build(BuildContext context) {
     return Widgetbook(
       categories: [
-        Category(
+        WidgetbookCategory(
           name: 'widgets',
           widgets: [
-            WidgetElement(
+            WidgetbookWidget(
               name: '$CustomWidget',
               stories: [
-                Story(
+                WidgetbookUseCase(
                   name: 'Default',
                   builder: (context) => CustomWidget(),
                 ),
@@ -108,13 +108,13 @@ class HotReload extends StatelessWidget {
             ),
           ],
           folders: [
-            Folder(
+            WidgetbookFolder(
               name: 'Texts',
               widgets: [
-                WidgetElement(
+                WidgetbookWidget(
                   name: 'Normal Text',
                   stories: [
-                    Story(
+                    WidgetbookUseCase(
                       name: 'Default',
                       builder: (context) => Text(
                         'The brown fox ...',
@@ -156,6 +156,10 @@ Widgetbook(
   darkTheme: darkTheme,
 )
 ```
+
+A preview in Widgetbook's light or dark mode is only shown when the appropriate theme is set. 
+
+If you are in development and haven't defined a theme yet, you can use `ThemeData.light()` or `ThemeData.dark()` to use a default theme.
 
 ## Add devices
 

--- a/packages/widgetbook/example/main.dart
+++ b/packages/widgetbook/example/main.dart
@@ -20,13 +20,13 @@ class HotReload extends StatelessWidget {
   Widget build(BuildContext context) {
     return Widgetbook(
       categories: [
-        Category(
+        WidgetbookCategory(
           name: 'widgets',
           widgets: [
-            WidgetElement(
+            WidgetbookWidget(
               name: '$CustomWidget',
               stories: [
-                Story(
+                WidgetbookUseCase(
                   name: 'Default',
                   builder: (context) => const CustomWidget(),
                 ),
@@ -34,13 +34,13 @@ class HotReload extends StatelessWidget {
             ),
           ],
           folders: [
-            Folder(
+            WidgetbookFolder(
               name: 'Texts',
               widgets: [
-                WidgetElement(
+                WidgetbookWidget(
                   name: 'Normal Text',
                   stories: [
-                    Story(
+                    WidgetbookUseCase(
                       name: 'Default',
                       builder: (context) => const Text(
                         'The brown fox ...',

--- a/packages/widgetbook/lib/src/models/models.dart
+++ b/packages/widgetbook/lib/src/models/models.dart
@@ -1,5 +1,5 @@
 export 'package:widgetbook/src/models/app_info.dart';
-export 'package:widgetbook/src/models/organizers/category.dart';
+export 'package:widgetbook/src/models/organizers/widgetbook_category.dart';
 export 'package:widgetbook/src/models/organizers/organizers.dart';
-export 'package:widgetbook/src/models/organizers/story.dart';
-export 'package:widgetbook/src/models/organizers/widget_element.dart';
+export 'package:widgetbook/src/models/organizers/widgetbook_use_case.dart';
+export 'package:widgetbook/src/models/organizers/widgetbook_widget.dart';

--- a/packages/widgetbook/lib/src/models/models.dart
+++ b/packages/widgetbook/lib/src/models/models.dart
@@ -1,5 +1,5 @@
 export 'package:widgetbook/src/models/app_info.dart';
-export 'package:widgetbook/src/models/organizers/widgetbook_category.dart';
 export 'package:widgetbook/src/models/organizers/organizers.dart';
+export 'package:widgetbook/src/models/organizers/widgetbook_category.dart';
 export 'package:widgetbook/src/models/organizers/widgetbook_use_case.dart';
 export 'package:widgetbook/src/models/organizers/widgetbook_widget.dart';

--- a/packages/widgetbook/lib/src/models/organizers/expandable_organizer.dart
+++ b/packages/widgetbook/lib/src/models/organizers/expandable_organizer.dart
@@ -9,10 +9,10 @@ abstract class ExpandableOrganizer extends Organizer {
   ExpandableOrganizer({
     required String name,
     required this.isExpanded,
-    List<Folder>? folders,
-    List<WidgetElement>? widgets,
-  })  : folders = folders ?? List<Folder>.empty(),
-        widgets = widgets ?? List<WidgetElement>.empty(),
+    List<WidgetbookFolder>? folders,
+    List<WidgetbookWidget>? widgets,
+  })  : folders = folders ?? List<WidgetbookFolder>.empty(),
+        widgets = widgets ?? List<WidgetbookWidget>.empty(),
         super(
           name,
         );
@@ -22,11 +22,11 @@ abstract class ExpandableOrganizer extends Organizer {
 
   /// The folders of one level in the folder tree.
   /// Folders will be shown above widgets.
-  final List<Folder> folders;
+  final List<WidgetbookFolder> folders;
 
   /// The widgets of one level in the folder tree.
   /// Widgets will be shown below folders;
-  final List<WidgetElement> widgets;
+  final List<WidgetbookWidget> widgets;
 
   /// Abstract class for organizer panel in the left.
 

--- a/packages/widgetbook/lib/src/models/organizers/organizer_helper/folder_helper.dart
+++ b/packages/widgetbook/lib/src/models/organizers/organizer_helper/folder_helper.dart
@@ -2,8 +2,9 @@ import 'package:widgetbook/widgetbook.dart';
 
 /// Helper to navigate the folder tree.
 class FolderHelper {
-  static List<Folder> getAllFoldersFromCategories(List<Category> categories) {
-    final folders = <Folder>[];
+  static List<WidgetbookFolder> getAllFoldersFromCategories(
+      List<WidgetbookCategory> categories) {
+    final folders = <WidgetbookFolder>[];
     for (final category in categories) {
       folders.addAll(
         getAllFoldersFromCategory(category),
@@ -12,12 +13,14 @@ class FolderHelper {
     return folders;
   }
 
-  static List<Folder> getAllFoldersFromCategory(Category category) {
+  static List<WidgetbookFolder> getAllFoldersFromCategory(
+      WidgetbookCategory category) {
     return getAllFoldersFromFolders(category.folders);
   }
 
-  static List<Folder> getAllFoldersFromFolders(List<Folder> folders) {
-    final folderList = <Folder>[];
+  static List<WidgetbookFolder> getAllFoldersFromFolders(
+      List<WidgetbookFolder> folders) {
+    final folderList = <WidgetbookFolder>[];
     for (final folder in folders) {
       folderList.addAll(
         getAllFoldersFromFolder(folder),
@@ -26,9 +29,10 @@ class FolderHelper {
     return folderList;
   }
 
-  static List<Folder> getAllFoldersFromFolder(Folder folder) {
-    final folderList = List<Folder>.from(
-      <Folder>[folder],
+  static List<WidgetbookFolder> getAllFoldersFromFolder(
+      WidgetbookFolder folder) {
+    final folderList = List<WidgetbookFolder>.from(
+      <WidgetbookFolder>[folder],
     )..addAll(
         getAllFoldersFromFolders(folder.folders),
       );

--- a/packages/widgetbook/lib/src/models/organizers/organizer_helper/story_helper.dart
+++ b/packages/widgetbook/lib/src/models/organizers/organizer_helper/story_helper.dart
@@ -3,12 +3,13 @@ import 'package:widgetbook/src/models/organizers/organizers.dart';
 
 /// Helper to obtain all Stories in the navigation tree.
 class StoryHelper {
-  static List<Story> getAllStoriesFromCategories(List<Category> categories) {
+  static List<WidgetbookUseCase> getAllStoriesFromCategories(
+      List<WidgetbookCategory> categories) {
     final widgets = WidgetHelper.getAllWidgetElementsFromCategories(
       categories,
     );
 
-    final stories = List<Story>.empty(growable: true);
+    final stories = List<WidgetbookUseCase>.empty(growable: true);
     for (final widget in widgets) {
       stories.addAll(widget.stories);
     }

--- a/packages/widgetbook/lib/src/models/organizers/organizer_helper/widget_helper.dart
+++ b/packages/widgetbook/lib/src/models/organizers/organizer_helper/widget_helper.dart
@@ -2,9 +2,9 @@ import 'package:widgetbook/widgetbook.dart';
 
 /// helper to obtain all WidgetElements in the navigation tree.
 class WidgetHelper {
-  static List<WidgetElement> getAllWidgetElementsFromCategories(
-      List<Category> categories) {
-    final widgets = <WidgetElement>[];
+  static List<WidgetbookWidget> getAllWidgetElementsFromCategories(
+      List<WidgetbookCategory> categories) {
+    final widgets = <WidgetbookWidget>[];
     for (final category in categories) {
       widgets.addAll(
         getAllWidgetElementsFromCategory(category),
@@ -13,9 +13,9 @@ class WidgetHelper {
     return widgets;
   }
 
-  static List<WidgetElement> getAllWidgetElementsFromCategory(
-      Category category) {
-    final widgetList = List<WidgetElement>.from(
+  static List<WidgetbookWidget> getAllWidgetElementsFromCategory(
+      WidgetbookCategory category) {
+    final widgetList = List<WidgetbookWidget>.from(
       category.widgets,
     )..addAll(
         getAllWidgetElementsFromFolders(category.folders),
@@ -23,9 +23,9 @@ class WidgetHelper {
     return widgetList;
   }
 
-  static List<WidgetElement> getAllWidgetElementsFromFolders(
-      List<Folder> folders) {
-    final widgetList = <WidgetElement>[];
+  static List<WidgetbookWidget> getAllWidgetElementsFromFolders(
+      List<WidgetbookFolder> folders) {
+    final widgetList = <WidgetbookWidget>[];
     for (final folder in folders) {
       widgetList.addAll(
         getAllWidgetElementsFromFolder(folder),
@@ -34,8 +34,9 @@ class WidgetHelper {
     return widgetList;
   }
 
-  static List<WidgetElement> getAllWidgetElementsFromFolder(Folder folder) {
-    final widgetList = List<WidgetElement>.from(folder.widgets)
+  static List<WidgetbookWidget> getAllWidgetElementsFromFolder(
+      WidgetbookFolder folder) {
+    final widgetList = List<WidgetbookWidget>.from(folder.widgets)
       ..addAll(
         getAllWidgetElementsFromFolders(folder.folders),
       );

--- a/packages/widgetbook/lib/src/models/organizers/organizers.dart
+++ b/packages/widgetbook/lib/src/models/organizers/organizers.dart
@@ -1,6 +1,6 @@
 export 'expandable_organizer.dart';
 export 'organizer.dart';
-export 'widgetbook_use_case.dart';
 export 'widgetbook_category.dart';
 export 'widgetbook_folder.dart';
+export 'widgetbook_use_case.dart';
 export 'widgetbook_widget.dart';

--- a/packages/widgetbook/lib/src/models/organizers/organizers.dart
+++ b/packages/widgetbook/lib/src/models/organizers/organizers.dart
@@ -1,6 +1,6 @@
-export 'category.dart';
 export 'expandable_organizer.dart';
-export 'folder.dart';
 export 'organizer.dart';
-export 'story.dart';
-export 'widget_element.dart';
+export 'widgetbook_use_case.dart';
+export 'widgetbook_category.dart';
+export 'widgetbook_folder.dart';
+export 'widgetbook_widget.dart';

--- a/packages/widgetbook/lib/src/models/organizers/widgetbook_category.dart
+++ b/packages/widgetbook/lib/src/models/organizers/widgetbook_category.dart
@@ -1,13 +1,13 @@
 import 'package:widgetbook/src/models/organizers/expandable_organizer.dart';
-import 'package:widgetbook/src/models/organizers/folder.dart';
-import 'package:widgetbook/src/models/organizers/widget_element.dart';
+import 'package:widgetbook/src/models/organizers/widgetbook_folder.dart';
+import 'package:widgetbook/src/models/organizers/widgetbook_widget.dart';
 
 /// Categories help to organize WidgetElements and Stories into different areas.
-class Category extends ExpandableOrganizer {
-  Category({
+class WidgetbookCategory extends ExpandableOrganizer {
+  WidgetbookCategory({
     required String name,
-    List<Folder>? folders,
-    List<WidgetElement>? widgets,
+    List<WidgetbookFolder>? folders,
+    List<WidgetbookWidget>? widgets,
   }) : super(
           name: name,
           folders: folders,

--- a/packages/widgetbook/lib/src/models/organizers/widgetbook_folder.dart
+++ b/packages/widgetbook/lib/src/models/organizers/widgetbook_folder.dart
@@ -1,13 +1,13 @@
 import 'package:widgetbook/src/models/organizers/expandable_organizer.dart';
 import 'package:widgetbook/src/models/organizers/organizers.dart';
-import 'package:widgetbook/src/models/organizers/widget_element.dart';
+import 'package:widgetbook/src/models/organizers/widgetbook_widget.dart';
 
 /// A folder in the folder tree.
-class Folder extends ExpandableOrganizer {
-  Folder({
+class WidgetbookFolder extends ExpandableOrganizer {
+  WidgetbookFolder({
     required String name,
-    List<Folder>? folders,
-    List<WidgetElement>? widgets,
+    List<WidgetbookFolder>? folders,
+    List<WidgetbookWidget>? widgets,
     bool isExpanded = false,
   }) : super(
           name: name,

--- a/packages/widgetbook/lib/src/models/organizers/widgetbook_use_case.dart
+++ b/packages/widgetbook/lib/src/models/organizers/widgetbook_use_case.dart
@@ -3,25 +3,27 @@ import 'package:flutter/material.dart';
 import 'package:widgetbook/src/models/model.dart';
 import 'package:widgetbook/src/models/organizers/organizer.dart';
 
-/// Stories represent a specific configuration of a widget.
-class Story extends Organizer implements Model {
-  Story({required String name, required this.builder}) : super(name);
+/// UseCases represent a specific configuration of a widget and can be used
+/// to check edge cases of a Widget.
+class WidgetbookUseCase extends Organizer implements Model {
+  WidgetbookUseCase({required String name, required this.builder})
+      : super(name);
 
-  factory Story.center({
+  factory WidgetbookUseCase.center({
     required String name,
     required Widget child,
   }) {
-    return Story(
+    return WidgetbookUseCase(
       name: name,
       builder: (_) => Center(child: child),
     );
   }
 
-  factory Story.child({
+  factory WidgetbookUseCase.child({
     required String name,
     required Widget child,
   }) {
-    return Story(
+    return WidgetbookUseCase(
       name: name,
       builder: (_) => child,
     );
@@ -36,7 +38,7 @@ class Story extends Organizer implements Model {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
 
-    return other is Story && other.builder == builder;
+    return other is WidgetbookUseCase && other.builder == builder;
   }
 
   @override

--- a/packages/widgetbook/lib/src/models/organizers/widgetbook_widget.dart
+++ b/packages/widgetbook/lib/src/models/organizers/widgetbook_widget.dart
@@ -2,11 +2,11 @@ import 'package:collection/collection.dart';
 
 import 'package:widgetbook/src/models/organizers/expandable_organizer.dart';
 import 'package:widgetbook/src/models/organizers/organizers.dart';
-import 'package:widgetbook/src/models/organizers/story.dart';
+import 'package:widgetbook/src/models/organizers/widgetbook_use_case.dart';
 
 ///
-class WidgetElement extends ExpandableOrganizer {
-  WidgetElement({
+class WidgetbookWidget extends ExpandableOrganizer {
+  WidgetbookWidget({
     required String name,
     required this.stories,
     bool isExpanded = false,
@@ -24,14 +24,14 @@ class WidgetElement extends ExpandableOrganizer {
   // class name changes
   //
   // This could be avoided alltogether by using annotations
-  final List<Story> stories;
+  final List<WidgetbookUseCase> stories;
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     final listEquals = const DeepCollectionEquality().equals;
 
-    return other is WidgetElement && listEquals(other.stories, stories);
+    return other is WidgetbookWidget && listEquals(other.stories, stories);
   }
 
   @override

--- a/packages/widgetbook/lib/src/navigation/ui/navigation_panel.dart
+++ b/packages/widgetbook/lib/src/navigation/ui/navigation_panel.dart
@@ -16,7 +16,7 @@ class NavigationPanel extends StatefulWidget {
   }) : super(key: key);
 
   final AppInfo appInfo;
-  final List<Category> categories;
+  final List<WidgetbookCategory> categories;
 
   @override
   _NavigationPanelState createState() => _NavigationPanelState();
@@ -24,7 +24,7 @@ class NavigationPanel extends StatefulWidget {
 
 class _NavigationPanelState extends State<NavigationPanel> {
   final ScrollController controller = ScrollController();
-  Story? selectedComponent;
+  WidgetbookUseCase? selectedComponent;
 
   final TextEditingController search = TextEditingController();
   String query = '';

--- a/packages/widgetbook/lib/src/providers/canvas_provider.dart
+++ b/packages/widgetbook/lib/src/providers/canvas_provider.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:widgetbook/src/models/organizers/story.dart';
+import 'package:widgetbook/src/models/organizers/widgetbook_use_case.dart';
 import 'package:widgetbook/src/providers/canvas_state.dart';
 import 'package:widgetbook/src/providers/provider.dart';
 import 'package:widgetbook/src/repositories/selected_story_repository.dart';
@@ -90,7 +90,7 @@ class CanvasProvider extends Provider<CanvasState> {
     }
   }
 
-  void selectStory(Story? story) {
+  void selectStory(WidgetbookUseCase? story) {
     selectedStoryRepository.setItem(story);
     emit(
       CanvasState(

--- a/packages/widgetbook/lib/src/providers/canvas_state.dart
+++ b/packages/widgetbook/lib/src/providers/canvas_state.dart
@@ -1,4 +1,4 @@
-import 'package:widgetbook/src/models/organizers/story.dart';
+import 'package:widgetbook/src/models/organizers/widgetbook_use_case.dart';
 
 class CanvasState {
   CanvasState({
@@ -9,7 +9,7 @@ class CanvasState {
     return CanvasState(selectedStory: null);
   }
 
-  final Story? selectedStory;
+  final WidgetbookUseCase? selectedStory;
   bool get isStorySelected => selectedStory != null;
 
   @override

--- a/packages/widgetbook/lib/src/providers/organizer_provider.dart
+++ b/packages/widgetbook/lib/src/providers/organizer_provider.dart
@@ -37,7 +37,9 @@ class _OrganizerBuilderState extends State<OrganizerBuilder> {
     state = widget.initialState;
     setProvider();
 
-    widget.selectedStoryRepository.getStream().forEach((Story? story) {
+    widget.selectedStoryRepository
+        .getStream()
+        .forEach((WidgetbookUseCase? story) {
       provider.openStory(story);
     });
 
@@ -90,7 +92,7 @@ class OrganizerProvider extends Provider<OrganizerState> {
     return context.dependOnInheritedWidgetOfExactType<OrganizerProvider>();
   }
 
-  void openStory(Story? story) {
+  void openStory(WidgetbookUseCase? story) {
     if (story == null) {
       return;
     }
@@ -101,17 +103,17 @@ class OrganizerProvider extends Provider<OrganizerState> {
     }
   }
 
-  void _updateFolders(List<Category> categories) {
+  void _updateFolders(List<WidgetbookCategory> categories) {
     final oldFolders = FolderHelper.getAllFoldersFromCategories(
       state.allCategories,
     );
     final newFolders = FolderHelper.getAllFoldersFromCategories(
       categories,
     );
-    final oldFolderMap = HashMap<String, Folder>.fromIterable(
+    final oldFolderMap = HashMap<String, WidgetbookFolder>.fromIterable(
       oldFolders,
       key: (dynamic k) => k.path as String,
-      value: (dynamic v) => v as Folder,
+      value: (dynamic v) => v as WidgetbookFolder,
     );
 
     for (final folder in newFolders) {
@@ -122,17 +124,17 @@ class OrganizerProvider extends Provider<OrganizerState> {
     }
   }
 
-  void _updateWidgets(List<Category> categories) {
+  void _updateWidgets(List<WidgetbookCategory> categories) {
     final oldWidgets = WidgetHelper.getAllWidgetElementsFromCategories(
       state.allCategories,
     );
     final newWidgets = WidgetHelper.getAllWidgetElementsFromCategories(
       categories,
     );
-    final oldFolderMap = HashMap<String, WidgetElement>.fromIterable(
+    final oldFolderMap = HashMap<String, WidgetbookWidget>.fromIterable(
       oldWidgets,
       key: (dynamic k) => k.path as String,
-      value: (dynamic v) => v as WidgetElement,
+      value: (dynamic v) => v as WidgetbookWidget,
     );
 
     for (final widget in newWidgets) {
@@ -143,7 +145,7 @@ class OrganizerProvider extends Provider<OrganizerState> {
     }
   }
 
-  void update(List<Category> categories) {
+  void update(List<WidgetbookCategory> categories) {
     _updateFolders(categories);
     _updateWidgets(categories);
     emit(

--- a/packages/widgetbook/lib/src/providers/organizer_state.dart
+++ b/packages/widgetbook/lib/src/providers/organizer_state.dart
@@ -10,7 +10,7 @@ class OrganizerState {
   });
 
   factory OrganizerState.unfiltered({
-    required List<Category> categories,
+    required List<WidgetbookCategory> categories,
   }) {
     return OrganizerState(
       allCategories: categories,
@@ -19,8 +19,8 @@ class OrganizerState {
     );
   }
 
-  final List<Category> allCategories;
-  final List<Category> filteredCategories;
+  final List<WidgetbookCategory> allCategories;
+  final List<WidgetbookCategory> filteredCategories;
   final String searchTerm;
 
   @override

--- a/packages/widgetbook/lib/src/repositories/selected_story_repository.dart
+++ b/packages/widgetbook/lib/src/repositories/selected_story_repository.dart
@@ -1,4 +1,4 @@
 import 'package:widgetbook/src/repositories/value_repository.dart';
 import 'package:widgetbook/widgetbook.dart';
 
-class SelectedStoryRepository extends ValueRepository<Story> {}
+class SelectedStoryRepository extends ValueRepository<WidgetbookUseCase> {}

--- a/packages/widgetbook/lib/src/repositories/story_repository.dart
+++ b/packages/widgetbook/lib/src/repositories/story_repository.dart
@@ -1,9 +1,9 @@
 import 'package:widgetbook/src/repositories/memory_repository.dart';
 import 'package:widgetbook/widgetbook.dart';
 
-class StoryRepository extends MemoryRepository<Story> {
+class StoryRepository extends MemoryRepository<WidgetbookUseCase> {
   StoryRepository({
-    Map<String, Story>? initialConfiguration,
+    Map<String, WidgetbookUseCase>? initialConfiguration,
   }) : super(
           initialConfiguration: initialConfiguration,
         );

--- a/packages/widgetbook/lib/src/services/filter_service.dart
+++ b/packages/widgetbook/lib/src/services/filter_service.dart
@@ -3,9 +3,9 @@ import 'package:widgetbook/src/models/models.dart';
 class FilterService {
   const FilterService();
 
-  List<Category> filter(
+  List<WidgetbookCategory> filter(
     String searchTerm,
-    List<Category> categories,
+    List<WidgetbookCategory> categories,
   ) {
     return _filterCategories(
       RegExp(
@@ -16,13 +16,13 @@ class FilterService {
     );
   }
 
-  List<Category> _filterCategories(
+  List<WidgetbookCategory> _filterCategories(
     RegExp regExp,
-    List<Category> categories,
+    List<WidgetbookCategory> categories,
   ) {
-    final matchingOrganizers = <Category>[];
+    final matchingOrganizers = <WidgetbookCategory>[];
     for (final category in categories) {
-      final result = _filterOrganizer(regExp, category) as Category?;
+      final result = _filterOrganizer(regExp, category) as WidgetbookCategory?;
       if (_isMatch(result)) {
         matchingOrganizers.add(result!);
       }
@@ -36,19 +36,19 @@ class FilterService {
       return organizer;
     }
 
-    final matchingFolders = <Folder>[];
+    final matchingFolders = <WidgetbookFolder>[];
     for (final subOrganizer in organizer.folders) {
       final result = _filterOrganizer(regExp, subOrganizer);
       if (_isMatch(result)) {
-        matchingFolders.add(result! as Folder);
+        matchingFolders.add(result! as WidgetbookFolder);
       }
     }
 
-    final matchingWidgets = <WidgetElement>[];
+    final matchingWidgets = <WidgetbookWidget>[];
     for (final subOrganizer in organizer.widgets) {
       final result = _filterOrganizer(regExp, subOrganizer);
       if (_isMatch(result)) {
-        matchingWidgets.add(result! as WidgetElement);
+        matchingWidgets.add(result! as WidgetbookWidget);
       }
     }
 
@@ -65,11 +65,11 @@ class FilterService {
 
   ExpandableOrganizer _createFilteredSubtree(
     ExpandableOrganizer organizer,
-    List<Folder> folders,
-    List<WidgetElement> widgets,
+    List<WidgetbookFolder> folders,
+    List<WidgetbookWidget> widgets,
   ) {
-    if (organizer is Category) {
-      return Category(
+    if (organizer is WidgetbookCategory) {
+      return WidgetbookCategory(
         name: organizer.name,
         widgets: widgets,
         folders: folders,
@@ -77,7 +77,7 @@ class FilterService {
     }
 
     // otherwise it can only be a folder
-    return Folder(
+    return WidgetbookFolder(
       name: organizer.name,
       widgets: widgets,
       folders: folders,

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -41,7 +41,7 @@ class Widgetbook extends StatefulWidget {
   /// Categories which host Folders and WidgetElements.
   /// This can be used to organize the structure of the Widgetbook on a large
   /// scale.
-  final List<Category> categories;
+  final List<WidgetbookCategory> categories;
 
   /// The devices on which Stories are previewed.
   final List<Device> devices;
@@ -142,12 +142,12 @@ class _WidgetbookState extends State<Widgetbook> {
     );
   }
 
-  Story? selectStoryFromPath(
+  WidgetbookUseCase? selectStoryFromPath(
     String? path,
-    List<Story> stories,
+    List<WidgetbookUseCase> stories,
   ) {
     final storyPath = path?.replaceFirst('/stories/', '') ?? '';
-    Story? story;
+    WidgetbookUseCase? story;
     for (final element in stories) {
       if (element.path == storyPath) {
         story = element;

--- a/packages/widgetbook/lib/src/widgets/device_render.dart
+++ b/packages/widgetbook/lib/src/widgets/device_render.dart
@@ -11,7 +11,7 @@ class DeviceRender extends StatelessWidget {
     required this.story,
   }) : super(key: key);
 
-  final Story story;
+  final WidgetbookUseCase story;
 
   ThemeData getInjectedTheme(BuildContext context, InjectedThemeState state) {
     final brightness = ThemeProvider.of(context)!.state;

--- a/packages/widgetbook/lib/src/widgets/story_render.dart
+++ b/packages/widgetbook/lib/src/widgets/story_render.dart
@@ -44,7 +44,7 @@ class _StoryState extends State<StoryRender> {
     controller = TransformationController(oldMatrix);
   }
 
-  Widget _buildCanvas(Story story) {
+  Widget _buildCanvas(WidgetbookUseCase story) {
     _updateController();
 
     return InteractiveViewer(

--- a/packages/widgetbook/lib/src/widgets/tiles/category_tile.dart
+++ b/packages/widgetbook/lib/src/widgets/tiles/category_tile.dart
@@ -6,7 +6,7 @@ import 'package:widgetbook/src/widgets/tiles/tile_helper_methods.dart';
 class CategoryTile extends StatelessWidget {
   const CategoryTile({Key? key, required this.category}) : super(key: key);
 
-  final Category category;
+  final WidgetbookCategory category;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/widgetbook/lib/src/widgets/tiles/folder_tile.dart
+++ b/packages/widgetbook/lib/src/widgets/tiles/folder_tile.dart
@@ -14,7 +14,7 @@ class FolderTile extends StatefulWidget {
     required this.level,
   }) : super(key: key);
 
-  final Folder folder;
+  final WidgetbookFolder folder;
   final int level;
 
   @override

--- a/packages/widgetbook/lib/src/widgets/tiles/story_tile.dart
+++ b/packages/widgetbook/lib/src/widgets/tiles/story_tile.dart
@@ -12,7 +12,7 @@ class StoryTile extends StatefulWidget {
     required this.level,
   }) : super(key: key);
 
-  final Story story;
+  final WidgetbookUseCase story;
   final int level;
 
   @override

--- a/packages/widgetbook/lib/src/widgets/tiles/tile_helper_methods.dart
+++ b/packages/widgetbook/lib/src/widgets/tiles/tile_helper_methods.dart
@@ -4,12 +4,12 @@ import 'package:widgetbook/src/widgets/tiles/folder_tile.dart';
 import 'package:widgetbook/src/widgets/tiles/widget_tile.dart';
 
 List<Widget> buildFolders({
-  required List<Folder> folders,
+  required List<WidgetbookFolder> folders,
   required int currentLevel,
 }) {
   return folders
       .map(
-        (Folder folder) => FolderTile(
+        (WidgetbookFolder folder) => FolderTile(
           folder: folder,
           level: currentLevel,
         ),
@@ -18,12 +18,12 @@ List<Widget> buildFolders({
 }
 
 List<Widget> buildWidgets({
-  required List<WidgetElement> widgets,
+  required List<WidgetbookWidget> widgets,
   required int currentLevel,
 }) {
   return widgets
       .map(
-        (WidgetElement widgetElement) => WidgetTile(
+        (WidgetbookWidget widgetElement) => WidgetTile(
           widgetElement: widgetElement,
           level: currentLevel,
         ),

--- a/packages/widgetbook/lib/src/widgets/tiles/widget_tile.dart
+++ b/packages/widgetbook/lib/src/widgets/tiles/widget_tile.dart
@@ -12,7 +12,7 @@ class WidgetTile extends StatefulWidget {
     required this.level,
   }) : super(key: key);
 
-  final WidgetElement widgetElement;
+  final WidgetbookWidget widgetElement;
   final int level;
 
   @override
@@ -28,7 +28,7 @@ class _WidgetTileState extends State<WidgetTile> {
 
     return stories
         .map(
-          (Story story) => StoryTile(
+          (WidgetbookUseCase story) => StoryTile(
             story: story,
             level: level,
           ),

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widgetbook
 description: A flutter storybook that helps professionals and teams to catalogue their widgets.
-version: 1.0.0
+version: 1.0.0-beta.1
 homepage: https://www.widgetbook.io?utm_source=youtube&utm_medium=link&utm_campaign=widgetbook
 repository: https://github.com/widgetbook/widgetbook
 issue_tracker: https://github.com/widgetbook/widgetbook/issues

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widgetbook
 description: A flutter storybook that helps professionals and teams to catalogue their widgets.
-version: 1.0.0-beta.1
+version: 1.0.0
 homepage: https://www.widgetbook.io?utm_source=youtube&utm_medium=link&utm_campaign=widgetbook
 repository: https://github.com/widgetbook/widgetbook
 issue_tracker: https://github.com/widgetbook/widgetbook/issues

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widgetbook
 description: A flutter storybook that helps professionals and teams to catalogue their widgets.
-version: 0.0.16
+version: 1.0.0
 homepage: https://www.widgetbook.io?utm_source=youtube&utm_medium=link&utm_campaign=widgetbook
 repository: https://github.com/widgetbook/widgetbook
 issue_tracker: https://github.com/widgetbook/widgetbook/issues

--- a/packages/widgetbook/test/src/providers/canvas_provider_test.dart
+++ b/packages/widgetbook/test/src/providers/canvas_provider_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:widgetbook/src/models/organizers/story.dart';
+import 'package:widgetbook/src/models/organizers/widgetbook_use_case.dart';
 import 'package:widgetbook/src/providers/canvas_provider.dart';
 import 'package:widgetbook/src/providers/canvas_state.dart';
 import 'package:widgetbook/src/repositories/selected_story_repository.dart';
@@ -29,12 +29,12 @@ void main() {
   late StoryRepository storyRepository;
   late SelectedStoryRepository selectedStoryRepository;
 
-  final story1 = Story(
+  final story1 = WidgetbookUseCase(
     name: '1',
     builder: (context) => Container(),
   );
 
-  final story2 = Story(
+  final story2 = WidgetbookUseCase(
     name: '2',
     builder: (context) => Container(),
   );
@@ -42,7 +42,7 @@ void main() {
   setUp(
     () {
       storyRepository = StoryRepository(
-        initialConfiguration: <String, Story>{
+        initialConfiguration: <String, WidgetbookUseCase>{
           story1.name: story1,
           story2.name: story2,
         },
@@ -55,7 +55,7 @@ void main() {
     '$CanvasProvider',
     () {
       testWidgets(
-        'emits $Story when selectStory is called',
+        'emits $WidgetbookUseCase when selectStory is called',
         (WidgetTester tester) async {
           var provider = await tester.pumpProvider(
             selectedStoryRepository: selectedStoryRepository,
@@ -109,7 +109,7 @@ void main() {
       );
 
       testWidgets(
-        'emits $Story $SelectedStoryRepository emits new $Story',
+        'emits $WidgetbookUseCase $SelectedStoryRepository emits new $WidgetbookUseCase',
         (WidgetTester tester) async {
           var provider = await tester.pumpProvider(
             selectedStoryRepository: selectedStoryRepository,
@@ -122,7 +122,7 @@ void main() {
             },
           );
 
-          final newStory = Story(
+          final newStory = WidgetbookUseCase(
             name: story1.name,
             builder: (context) {
               return const Text('');
@@ -147,7 +147,7 @@ void main() {
       );
 
       testWidgets(
-        'emits $Story $SelectedStoryRepository emits new $Story',
+        'emits $WidgetbookUseCase $SelectedStoryRepository emits new $WidgetbookUseCase',
         (WidgetTester tester) async {
           var provider = await tester.pumpProvider(
             selectedStoryRepository: selectedStoryRepository,

--- a/packages/widgetbook/test/src/providers/canvas_state_test.dart
+++ b/packages/widgetbook/test/src/providers/canvas_state_test.dart
@@ -13,7 +13,7 @@ void main() {
         'the hashCodes of two instances with the same values are compared',
         () {
           const name = 'Name';
-          final story = Story.child(
+          final story = WidgetbookUseCase.child(
             name: name,
             child: Container(),
           );

--- a/packages/widgetbook/test/src/providers/organizer_provider_test.dart
+++ b/packages/widgetbook/test/src/providers/organizer_provider_test.dart
@@ -37,12 +37,12 @@ void main() {
   late StoryRepository storyRepository;
   late SelectedStoryRepository selectedStoryRepository;
 
-  final story1 = Story(
+  final story1 = WidgetbookUseCase(
     name: 'Story 1',
     builder: (context) => Container(),
   );
 
-  final story2 = Story(
+  final story2 = WidgetbookUseCase(
     name: 'Story 2',
     builder: (context) => Container(),
   );
@@ -50,7 +50,7 @@ void main() {
   setUp(
     () {
       storyRepository = StoryRepository(
-        initialConfiguration: <String, Story>{
+        initialConfiguration: <String, WidgetbookUseCase>{
           story1.name: story1,
           story2.name: story2,
         },
@@ -63,15 +63,15 @@ void main() {
     '$OrganizerProvider',
     () {
       testWidgets(
-        'expands $WidgetElement when the selected story changes',
+        'expands $WidgetbookWidget when the selected story changes',
         (WidgetTester tester) async {
           var provider = await tester.pumpProvider(
             initialState: OrganizerState.unfiltered(
               categories: [
-                Category(
+                WidgetbookCategory(
                   name: 'Category 1',
                   widgets: [
-                    WidgetElement(
+                    WidgetbookWidget(
                       name: 'Widget 1',
                       stories: [
                         story1,
@@ -99,16 +99,16 @@ void main() {
       );
 
       testWidgets(
-        'togglesExpander of $WidgetElement',
+        'togglesExpander of $WidgetbookWidget',
         (WidgetTester tester) async {
-          final widgetElement = WidgetElement(
+          final widgetElement = WidgetbookWidget(
             name: 'Widget 1',
             stories: [],
           );
           var provider = await tester.pumpProvider(
             initialState: OrganizerState.unfiltered(
               categories: [
-                Category(
+                WidgetbookCategory(
                   name: 'Category 1',
                   widgets: [widgetElement],
                 ),
@@ -129,10 +129,10 @@ void main() {
             equals(
               OrganizerState.unfiltered(
                 categories: [
-                  Category(
+                  WidgetbookCategory(
                     name: 'Category 1',
                     widgets: [
-                      WidgetElement(
+                      WidgetbookWidget(
                         name: 'Widget 1',
                         isExpanded: true,
                         stories: [],
@@ -147,20 +147,20 @@ void main() {
       );
 
       testWidgets(
-        'expands $WidgetElement when the selected story changes',
+        'expands $WidgetbookWidget when the selected story changes',
         (WidgetTester tester) async {
           var provider = await tester.pumpProvider(
             initialState: OrganizerState.unfiltered(
               categories: [
-                Category(
+                WidgetbookCategory(
                   name: 'Category 1',
                   folders: [
-                    Folder(
+                    WidgetbookFolder(
                       name: 'Folder 1',
                     ),
                   ],
                   widgets: [
-                    WidgetElement(
+                    WidgetbookWidget(
                       name: 'Widget 1',
                       isExpanded: true,
                       stories: [story1, story2],
@@ -177,17 +177,17 @@ void main() {
             () {
               provider.update(
                 [
-                  Category(
+                  WidgetbookCategory(
                     name: 'Category 1',
                     folders: [
-                      Folder(
+                      WidgetbookFolder(
                         name: 'Folder 1',
                       ),
                     ],
                     widgets: [
                       // Note that this WidgetElement does not have the isExpanded
                       // property set to true
-                      WidgetElement(
+                      WidgetbookWidget(
                         name: 'Widget 1',
                         stories: [
                           story1,
@@ -207,17 +207,17 @@ void main() {
             equals(
               OrganizerState.unfiltered(
                 categories: [
-                  Category(
+                  WidgetbookCategory(
                     name: 'Category 1',
                     folders: [
-                      Folder(
+                      WidgetbookFolder(
                         name: 'Folder 1',
                       ),
                     ],
                     widgets: [
                       // Note that this WidgetElement does have the isExpanded
                       // property set to true
-                      WidgetElement(
+                      WidgetbookWidget(
                         name: 'Widget 1',
                         isExpanded: true,
                         stories: [
@@ -236,16 +236,16 @@ void main() {
       testWidgets(
         'resets filter when resetFilter is called',
         (WidgetTester tester) async {
-          final folder = Folder(
+          final folder = WidgetbookFolder(
             name: 'Folder 1',
           );
-          final category = Category(
+          final category = WidgetbookCategory(
             name: 'Category 1',
             folders: [
               folder,
             ],
             widgets: [
-              WidgetElement(
+              WidgetbookWidget(
                 name: 'Widget 1',
                 isExpanded: true,
                 stories: [
@@ -256,7 +256,7 @@ void main() {
             ],
           );
 
-          final filteredCategory = Category(
+          final filteredCategory = WidgetbookCategory(
             name: 'Category 1',
             folders: [
               folder,
@@ -299,16 +299,16 @@ void main() {
       testWidgets(
         'invokes $FilterService when filter is called',
         (WidgetTester tester) async {
-          final folder = Folder(
+          final folder = WidgetbookFolder(
             name: 'Folder 1',
           );
-          final category = Category(
+          final category = WidgetbookCategory(
             name: 'Category 1',
             folders: [
               folder,
             ],
             widgets: [
-              WidgetElement(
+              WidgetbookWidget(
                 name: 'Widget 1',
                 isExpanded: true,
                 stories: [

--- a/packages/widgetbook/test/src/services/filter_service_test.dart
+++ b/packages/widgetbook/test/src/services/filter_service_test.dart
@@ -4,12 +4,12 @@ import 'package:widgetbook/src/models/models.dart';
 import 'package:widgetbook/src/services/filter_service.dart';
 
 void main() {
-  final story1 = Story(
+  final story1 = WidgetbookUseCase(
     name: 'Story 1',
     builder: (context) => Container(),
   );
 
-  final story2 = Story(
+  final story2 = WidgetbookUseCase(
     name: 'Story 2',
     builder: (context) => Container(),
   );
@@ -18,9 +18,9 @@ void main() {
     '$FilterService',
     () {
       test(
-        'filters $WidgetElement',
+        'filters $WidgetbookWidget',
         () async {
-          final widget1 = WidgetElement(
+          final widget1 = WidgetbookWidget(
             name: 'Widget 1',
             isExpanded: true,
             stories: [
@@ -29,7 +29,7 @@ void main() {
             ],
           );
 
-          final widget2 = WidgetElement(
+          final widget2 = WidgetbookWidget(
             name: 'Widget 2',
             isExpanded: true,
             stories: [
@@ -38,10 +38,10 @@ void main() {
             ],
           );
 
-          final category = Category(
+          final category = WidgetbookCategory(
             name: 'Category 1',
             folders: [
-              Folder(
+              WidgetbookFolder(
                 name: 'Folder 1',
               ),
             ],
@@ -65,7 +65,7 @@ void main() {
             result,
             equals(
               [
-                Category(
+                WidgetbookCategory(
                   name: 'Category 1',
                   folders: [],
                   widgets: [
@@ -79,20 +79,20 @@ void main() {
       );
 
       test(
-        'filters $Folder',
+        'filters $WidgetbookFolder',
         () async {
-          final folder1_1 = Folder(name: 'Folder1.1');
-          final folder1_2 = Folder(name: 'Folder1.2');
-          final folder1 = Folder(
+          final folder1_1 = WidgetbookFolder(name: 'Folder1.1');
+          final folder1_2 = WidgetbookFolder(name: 'Folder1.2');
+          final folder1 = WidgetbookFolder(
             name: 'Folder 1',
             folders: [
               folder1_1,
               folder1_2,
             ],
           );
-          final folder2 = Folder(name: 'Folder 2');
+          final folder2 = WidgetbookFolder(name: 'Folder 2');
 
-          final widget1 = WidgetElement(
+          final widget1 = WidgetbookWidget(
             name: 'Widget 1',
             isExpanded: true,
             stories: [
@@ -101,7 +101,7 @@ void main() {
             ],
           );
 
-          final category = Category(
+          final category = WidgetbookCategory(
             name: 'Category 1',
             folders: [
               folder1,
@@ -126,10 +126,10 @@ void main() {
             result,
             equals(
               [
-                Category(
+                WidgetbookCategory(
                   name: 'Category 1',
                   folders: [
-                    Folder(
+                    WidgetbookFolder(
                       name: 'Folder 1',
                       folders: [
                         folder1_1,

--- a/packages/widgetbook/test/src/widgets/device_render_test.dart
+++ b/packages/widgetbook/test/src/widgets/device_render_test.dart
@@ -55,7 +55,7 @@ Widget getMaterialApp(Brightness brightness) {
           ),
           onStateChanged: (_) {},
           child: DeviceRender(
-            story: Story(
+            story: WidgetbookUseCase(
               name: storyName,
               builder: (context) => const ThemedWidget(),
             ),
@@ -93,7 +93,7 @@ void main() {
     '$DeviceRender',
     () {
       testWidgets(
-        'renders $Story with lightColor when brightness is set to ${Brightness.light}',
+        'renders $WidgetbookUseCase with lightColor when brightness is set to ${Brightness.light}',
         (tester) async {
           await expectColorForSetBrightness(
             tester: tester,
@@ -104,7 +104,7 @@ void main() {
       );
 
       testWidgets(
-        'renders $Story with darkColor when brightness is set to ${Brightness.dark}',
+        'renders $WidgetbookUseCase with darkColor when brightness is set to ${Brightness.dark}',
         (tester) async {
           await expectColorForSetBrightness(
             tester: tester,

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0
+## 1.0.0-beta.1
 
 - changed generator to create code for Widgetbook 1.0.0
 

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-beta.1
+## 1.0.0
 
 - changed generator to create code for Widgetbook 1.0.0
 

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+- changed generator to create code for Widgetbook 1.0.0
+
 ## 0.0.6
 
 - refactored code

--- a/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_category_instance.dart
+++ b/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_category_instance.dart
@@ -1,26 +1,26 @@
-import 'package:widgetbook_generator/code_generators/instances/folder_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_folder_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/widget_element_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_widget_instance.dart';
 import 'package:widgetbook_generator/code_generators/properties/property.dart';
 import 'package:widgetbook_generator/services/tree_service.dart';
 
 /// An instance for Category
-class CategoryInstance extends Instance {
-  /// Creates a new instance of [CategoryInstance]
-  CategoryInstance({
+class WidgetbookCategoryInstance extends Instance {
+  /// Creates a new instance of [WidgetbookCategoryInstance]
+  WidgetbookCategoryInstance({
     required String name,
     List<Folder> folders = const <Folder>[],
     List<Widget> widgets = const <Widget>[],
   }) : super(
-          name: 'Category',
+          name: 'WidgetbookCategory',
           properties: [
             Property.string(key: 'name', value: name),
             Property(
               key: 'folders',
               instance: ListInstance(
                 instances: folders
-                    .map((folder) => FolderInstance(folder: folder))
+                    .map((folder) => WidgetbookFolderInstance(folder: folder))
                     .toList(),
               ),
             ),
@@ -28,7 +28,7 @@ class CategoryInstance extends Instance {
               key: 'widgets',
               instance: ListInstance(
                 instances: widgets
-                    .map((widget) => WidgetElementInstance(
+                    .map((widget) => WidgetbookWidgetInstance(
                           name: widget.name,
                           stories: widget.stories,
                         ))

--- a/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_category_instance.dart
+++ b/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_category_instance.dart
@@ -1,6 +1,6 @@
-import 'package:widgetbook_generator/code_generators/instances/widgetbook_folder_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_folder_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/widgetbook_widget_instance.dart';
 import 'package:widgetbook_generator/code_generators/properties/property.dart';
 import 'package:widgetbook_generator/services/tree_service.dart';

--- a/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_folder_instance.dart
+++ b/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_folder_instance.dart
@@ -1,23 +1,23 @@
 import 'package:widgetbook_generator/code_generators/instances/instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/widget_element_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_widget_instance.dart';
 import 'package:widgetbook_generator/code_generators/properties/property.dart';
 import 'package:widgetbook_generator/services/tree_service.dart';
 
 /// Defines an instance to create code for a [Folder]
-class FolderInstance extends Instance {
-  /// Creates a new instance of [FolderInstance]
-  FolderInstance({required Folder folder})
+class WidgetbookFolderInstance extends Instance {
+  /// Creates a new instance of [WidgetbookFolderInstance]
+  WidgetbookFolderInstance({required Folder folder})
       : super(
-          name: 'Folder',
+          name: 'WidgetbookFolder',
           properties: [
             Property.string(key: 'name', value: folder.name),
             Property(
               key: 'widgets',
-              instance: ListInstance<WidgetElementInstance>(
+              instance: ListInstance<WidgetbookWidgetInstance>(
                 instances: folder.widgets.values
                     .map(
-                      (widget) => WidgetElementInstance(
+                      (widget) => WidgetbookWidgetInstance(
                         name: widget.name,
                         stories: widget.stories,
                       ),
@@ -27,9 +27,9 @@ class FolderInstance extends Instance {
             ),
             Property(
               key: 'folders',
-              instance: ListInstance<FolderInstance>(
+              instance: ListInstance<WidgetbookFolderInstance>(
                 instances: folder.subFolders.values
-                    .map((folder) => FolderInstance(folder: folder))
+                    .map((folder) => WidgetbookFolderInstance(folder: folder))
                     .toList(),
               ),
             ),

--- a/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_instance.dart
+++ b/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_instance.dart
@@ -1,5 +1,5 @@
 import 'package:widgetbook_generator/code_generators/instances/app_info_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/category_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_category_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/device_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
@@ -11,7 +11,7 @@ class WidgetbookInstance extends Instance {
   /// Creates a new instance of [WidgetbookInstance]
   WidgetbookInstance({
     required AppInfoInstance appInfoInstance,
-    required List<CategoryInstance> categories,
+    required List<WidgetbookCategoryInstance> categories,
     ThemeInstance? lightThemeInstance,
     ThemeInstance? darkThemeInstance,
     List<DeviceInstance> devices = const <DeviceInstance>[],

--- a/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_instance.dart
+++ b/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_instance.dart
@@ -1,9 +1,9 @@
 import 'package:widgetbook_generator/code_generators/instances/app_info_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/widgetbook_category_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/device_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/theme_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_category_instance.dart';
 import 'package:widgetbook_generator/code_generators/properties/property.dart';
 
 /// An instance for Widgetbook

--- a/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_use_case_instance.dart
+++ b/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_use_case_instance.dart
@@ -9,7 +9,7 @@ class StoryInstance extends Instance {
     required String storyName,
     required String functionName,
   }) : super(
-          name: 'Story',
+          name: 'WidgetbookUseCase',
           properties: [
             Property.string(
               key: 'name',

--- a/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_widget_instance.dart
+++ b/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_widget_instance.dart
@@ -1,17 +1,17 @@
 import 'package:widgetbook_generator/code_generators/instances/instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/story_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_use_case_instance.dart';
 import 'package:widgetbook_generator/code_generators/properties/property.dart';
 import 'package:widgetbook_generator/models/widgetbook_story_data.dart';
 
 /// An instance for WidgetElementInstance
-class WidgetElementInstance extends Instance {
-  /// Creates a new instance of [WidgetElementInstance]
-  WidgetElementInstance({
+class WidgetbookWidgetInstance extends Instance {
+  /// Creates a new instance of [WidgetbookWidgetInstance]
+  WidgetbookWidgetInstance({
     required String name,
     required List<WidgetbookStoryData> stories,
   }) : super(
-          name: 'WidgetElement',
+          name: 'WidgetbookWidget',
           properties: [
             Property.string(key: 'name', value: name),
             Property(

--- a/packages/widgetbook_generator/lib/generators/app_generator.dart
+++ b/packages/widgetbook_generator/lib/generators/app_generator.dart
@@ -1,5 +1,5 @@
 import 'package:widgetbook_generator/code_generators/instances/app_info_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/category_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_category_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/device_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/theme_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/widgetbook_instance.dart';
@@ -41,7 +41,8 @@ class HotReload extends StatelessWidget {
   ''';
 }
 
-CategoryInstance _generateCategoryInstance(List<WidgetbookStoryData> stories) {
+WidgetbookCategoryInstance _generateCategoryInstance(
+    List<WidgetbookStoryData> stories) {
   final service = TreeService();
 
   for (final story in stories) {
@@ -49,7 +50,7 @@ CategoryInstance _generateCategoryInstance(List<WidgetbookStoryData> stories) {
     service.addStoryToFolder(folder, story);
   }
 
-  return CategoryInstance(
+  return WidgetbookCategoryInstance(
     name: 'stories',
     folders: service.folders.values.toList(),
     widgets: service.rootFolder.widgets.values.toList(),

--- a/packages/widgetbook_generator/lib/generators/app_generator.dart
+++ b/packages/widgetbook_generator/lib/generators/app_generator.dart
@@ -1,7 +1,7 @@
 import 'package:widgetbook_generator/code_generators/instances/app_info_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/widgetbook_category_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/device_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/theme_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_category_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/widgetbook_instance.dart';
 import 'package:widgetbook_generator/models/widgetbook_story_data.dart';
 import 'package:widgetbook_generator/models/widgetbook_theme_data.dart';

--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widgetbook_generator
 description: A package to automate setup and maintanance of the widgetbook package by using code generation.
-version: 1.0.0
+version: 1.0.0-beta.1
 homepage: https://www.widgetbook.io?utm_source=pub.dev&utm_medium=link&utm_campaign=widgetbook_generator
 repository: https://github.com/widgetbook/widgetbook
 issue_tracker: https://github.com/widgetbook/widgetbook/issues

--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widgetbook_generator
 description: A package to automate setup and maintanance of the widgetbook package by using code generation.
-version: 0.0.6
+version: 1.0.0
 homepage: https://www.widgetbook.io?utm_source=pub.dev&utm_medium=link&utm_campaign=widgetbook_generator
 repository: https://github.com/widgetbook/widgetbook
 issue_tracker: https://github.com/widgetbook/widgetbook/issues

--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widgetbook_generator
 description: A package to automate setup and maintanance of the widgetbook package by using code generation.
-version: 1.0.0-beta.1
+version: 1.0.0
 homepage: https://www.widgetbook.io?utm_source=pub.dev&utm_medium=link&utm_campaign=widgetbook_generator
 repository: https://github.com/widgetbook/widgetbook
 issue_tracker: https://github.com/widgetbook/widgetbook/issues

--- a/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_category_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_category_instance_test.dart
@@ -1,8 +1,8 @@
 import 'package:test/test.dart';
-import 'package:widgetbook_generator/code_generators/instances/category_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/folder_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/widget_element_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_category_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_folder_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_widget_instance.dart';
 import 'package:widgetbook_generator/code_generators/properties/property.dart';
 import 'package:widgetbook_generator/services/tree_service.dart';
 
@@ -10,7 +10,7 @@ import '../instance_helper.dart';
 
 void main() {
   group(
-    '$CategoryInstance',
+    '$WidgetbookCategoryInstance',
     () {
       final folder = Folder(name: 'Folder');
       final folder1 = Folder(
@@ -47,12 +47,15 @@ void main() {
 
       const categoryName = 'stories';
 
-      testName('Category', instance: CategoryInstance(name: categoryName));
+      testName(
+        'WidgetbookCategory',
+        instance: WidgetbookCategoryInstance(name: categoryName),
+      );
 
       test(
         ".name returns 'stories'",
         () {
-          final instance = CategoryInstance(
+          final instance = WidgetbookCategoryInstance(
             name: categoryName,
             folders: folders,
             widgets: widgets,
@@ -64,22 +67,22 @@ void main() {
                   Property.string(key: 'name', value: categoryName),
                   Property(
                     key: 'folders',
-                    instance: ListInstance<FolderInstance>(
+                    instance: ListInstance<WidgetbookFolderInstance>(
                       instances: [
-                        FolderInstance(folder: folder1),
-                        FolderInstance(folder: folder2),
+                        WidgetbookFolderInstance(folder: folder1),
+                        WidgetbookFolderInstance(folder: folder2),
                       ],
                     ),
                   ),
                   Property(
                     key: 'widgets',
-                    instance: ListInstance<WidgetElementInstance>(
+                    instance: ListInstance<WidgetbookWidgetInstance>(
                       instances: [
-                        WidgetElementInstance(
+                        WidgetbookWidgetInstance(
                           name: widget1.name,
                           stories: widget1.stories,
                         ),
-                        WidgetElementInstance(
+                        WidgetbookWidgetInstance(
                           name: widget2.name,
                           stories: widget2.stories,
                         ),

--- a/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_folder_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_folder_instance_test.dart
@@ -1,6 +1,6 @@
 import 'package:test/test.dart';
-import 'package:widgetbook_generator/code_generators/instances/widgetbook_folder_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_folder_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/widgetbook_widget_instance.dart';
 import 'package:widgetbook_generator/code_generators/properties/property.dart';
 import 'package:widgetbook_generator/services/tree_service.dart';

--- a/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_folder_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_folder_instance_test.dart
@@ -1,7 +1,7 @@
 import 'package:test/test.dart';
-import 'package:widgetbook_generator/code_generators/instances/folder_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_folder_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/widget_element_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_widget_instance.dart';
 import 'package:widgetbook_generator/code_generators/properties/property.dart';
 import 'package:widgetbook_generator/services/tree_service.dart';
 
@@ -9,7 +9,7 @@ import '../instance_helper.dart';
 
 void main() {
   group(
-    '$FolderInstance',
+    '$WidgetbookFolderInstance',
     () {
       final folder = Folder(name: 'Folder');
       final folder1 = Folder(
@@ -34,9 +34,9 @@ void main() {
         ..putIfAbsent(widget1.name, () => widget1)
         ..putIfAbsent(widget2.name, () => widget2);
 
-      final instance = FolderInstance(folder: folder);
+      final instance = WidgetbookFolderInstance(folder: folder);
 
-      testName('Folder', instance: instance);
+      testName('WidgetbookFolder', instance: instance);
 
       test(
         '.properties returns a StringProperty and Property containing a list',
@@ -56,11 +56,11 @@ void main() {
                       // Somehow the order of instances injected are in a
                       // reversed order. Since the order doesn't really matter
                       // the test has been left like this
-                      WidgetElementInstance(
+                      WidgetbookWidgetInstance(
                         name: widget2.name,
                         stories: widget2.stories,
                       ),
-                      WidgetElementInstance(
+                      WidgetbookWidgetInstance(
                         name: widget1.name,
                         stories: widget1.stories,
                       ),
@@ -71,8 +71,8 @@ void main() {
                   key: 'folders',
                   instance: ListInstance(
                     instances: [
-                      FolderInstance(folder: folder1),
-                      FolderInstance(folder: folder2),
+                      WidgetbookFolderInstance(folder: folder1),
+                      WidgetbookFolderInstance(folder: folder2),
                     ],
                   ),
                 ),

--- a/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_instance_test.dart
@@ -1,7 +1,7 @@
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 import 'package:widgetbook_generator/code_generators/instances/app_info_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/category_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_category_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/device_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/theme_instance.dart';
@@ -32,13 +32,13 @@ void main() {
 
     const expectedCategoryInstance = Property(
       key: 'categories',
-      instance: ListInstance<CategoryInstance>(
+      instance: ListInstance<WidgetbookCategoryInstance>(
         instances: [],
       ),
     );
 
     test(
-      '.properties returns $AppInfoInstance and List<$CategoryInstance>',
+      '.properties returns $AppInfoInstance and List<$WidgetbookCategoryInstance>',
       () {
         final instance = WidgetbookInstance(
           appInfoInstance: AppInfoInstance(name: appInfoName),

--- a/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_instance_test.dart
@@ -1,10 +1,10 @@
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 import 'package:widgetbook_generator/code_generators/instances/app_info_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/widgetbook_category_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/device_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/theme_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_category_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/widgetbook_instance.dart';
 import 'package:widgetbook_generator/code_generators/properties/property.dart';
 import 'package:widgetbook_models/widgetbook_models.dart';
@@ -38,7 +38,8 @@ void main() {
     );
 
     test(
-      '.properties returns $AppInfoInstance and List<$WidgetbookCategoryInstance>',
+      '.properties returns $AppInfoInstance and '
+      'List<$WidgetbookCategoryInstance>',
       () {
         final instance = WidgetbookInstance(
           appInfoInstance: AppInfoInstance(name: appInfoName),

--- a/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_use_case_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_use_case_instance_test.dart
@@ -1,6 +1,6 @@
 import 'package:test/test.dart';
 import 'package:widgetbook_generator/code_generators/instances/lambda_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/story_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_use_case_instance.dart';
 import 'package:widgetbook_generator/code_generators/properties/property.dart';
 
 import '../instance_helper.dart';
@@ -17,7 +17,7 @@ void main() {
         functionName: storyBuilder,
       );
 
-      testName('Story', instance: instance);
+      testName('WidgetbookUseCase', instance: instance);
 
       test(
         ".properties returns a name and a function 'builder'",

--- a/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_widget_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_widget_instance_test.dart
@@ -1,7 +1,7 @@
 import 'package:test/test.dart';
 import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/story_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/widget_element_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_use_case_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_widget_instance.dart';
 import 'package:widgetbook_generator/code_generators/properties/property.dart';
 import 'package:widgetbook_generator/models/widgetbook_story_data.dart';
 
@@ -9,11 +9,11 @@ import '../instance_helper.dart';
 
 void main() {
   group(
-    '$WidgetElementInstance',
+    '$WidgetbookWidgetInstance',
     () {
       const widgetName = 'CustomWidget';
 
-      final instance = WidgetElementInstance(
+      final instance = WidgetbookWidgetInstance(
         name: widgetName,
         stories: [
           WidgetbookStoryData(
@@ -35,7 +35,7 @@ void main() {
         ],
       );
 
-      testName('WidgetElement', instance: instance);
+      testName('WidgetbookWidget', instance: instance);
 
       test(
         '.properties returns a StringProperty and Property containing a list',


### PR DESCRIPTION
renamed organizer elements to make them less generic. Renamed to the following:

- `Category` renamed to `WidgetbookCategory`
- `Folder` renamed to `WidgetbookFolder`
- `WidgetElement` renamed to `WidgetbookWidget`
- `Story` renamed to `WidgetbookUseCase`