### PR TITLE
Switch to device_frame

### DIFF
--- a/examples/widgetbook_example/pubspec.lock
+++ b/examples/widgetbook_example/pubspec.lock
@@ -57,6 +57,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
+  device_frame:
+    dependency: transitive
+    description:
+      name: device_frame
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.1"
   equatable:
     dependency: "direct main"
     description:
@@ -100,6 +107,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "9.1.0"
+  freezed_annotation:
+    dependency: transitive
+    description:
+      name: freezed_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.0"
   js:
     dependency: transitive
     description:
@@ -107,6 +121,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.3"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.3.0"
   matcher:
     dependency: transitive
     description:
@@ -206,17 +227,10 @@ packages:
   widgetbook:
     dependency: "direct main"
     description:
-      name: widgetbook
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.1-beta.1"
-  widgetbook_models:
-    dependency: transitive
-    description:
-      name: widgetbook_models
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.3"
+      path: "../../packages/widgetbook"
+      relative: true
+    source: path
+    version: "1.0.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/examples/widgetbook_example/pubspec.yaml
+++ b/examples/widgetbook_example/pubspec.yaml
@@ -16,7 +16,8 @@ dependencies:
     sdk: flutter
   flutter_bloc: ^7.1.0
   font_awesome_flutter: ^9.1.0
-  widgetbook: ^1.0.1-beta.1
+  widgetbook:
+    path: ../../packages/widgetbook
 
 dev_dependencies:
   flutter_test:

--- a/examples/widgetbook_example/stories/storybook.dart
+++ b/examples/widgetbook_example/stories/storybook.dart
@@ -16,11 +16,11 @@ class Storyboard extends StatelessWidget {
   Widget buildStorybook(BuildContext context) {
     return Widgetbook(
       devices: [
-        Apple.iPhone11,
-        Apple.iPhone12,
-        Samsung.s10,
-        Samsung.s21ultra,
-        Apple.iMacM1,
+        Devices.ios.iPhone12,
+        Devices.ios.iPhone12Mini,
+        Devices.ios.iPhone12ProMax,
+        Devices.android.samsungS20,
+        Devices.linux.laptop,
       ],
       categories: [
         WidgetbookCategory(

--- a/examples/widgetbook_example/windows/flutter/generated_plugin_registrant.cc
+++ b/examples/widgetbook_example/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,6 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-  UrlLauncherWindowsRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/examples/widgetbook_example/windows/flutter/generated_plugins.cmake
+++ b/examples/widgetbook_example/windows/flutter/generated_plugins.cmake
@@ -3,7 +3,6 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  url_launcher_windows
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/packages/widgetbook/example/main.dart
+++ b/packages/widgetbook/example/main.dart
@@ -19,6 +19,13 @@ class HotReload extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Widgetbook(
+      devices: [
+        Devices.ios.iPhone12,
+        Devices.ios.iPhone12Mini,
+        Devices.ios.iPhone12ProMax,
+        Devices.android.samsungS20,
+        Devices.linux.laptop,
+      ],
       categories: [
         WidgetbookCategory(
           name: 'widgets',

--- a/packages/widgetbook/lib/src/providers/device_provider.dart
+++ b/packages/widgetbook/lib/src/providers/device_provider.dart
@@ -1,3 +1,4 @@
+import 'package:device_frame/device_frame.dart';
 import 'package:flutter/material.dart';
 import 'package:widgetbook/src/providers/device_state.dart';
 import 'package:widgetbook/src/providers/provider.dart';
@@ -12,8 +13,8 @@ class DeviceBuilder extends StatefulWidget {
   }) : super(key: key);
 
   final Widget child;
-  final List<Device> availableDevices;
-  final Device currentDevice;
+  final List<DeviceInfo> availableDevices;
+  final DeviceInfo currentDevice;
 
   @override
   _DeviceBuilderState createState() => _DeviceBuilderState();
@@ -27,6 +28,9 @@ class _DeviceBuilderState extends State<DeviceBuilder> {
     state = DeviceState(
       availableDevices: widget.availableDevices,
       currentDevice: widget.currentDevice,
+      orientation: Orientation.portrait,
+      showKeyboard: false,
+      isFrameVisible: true,
     );
     super.initState();
   }
@@ -62,7 +66,7 @@ class DeviceProvider extends Provider<DeviceState> {
     return context.dependOnInheritedWidgetOfExactType<DeviceProvider>();
   }
 
-  void update(List<Device> devices) {
+  void update(List<DeviceInfo> devices) {
     if (devices.isEmpty) {
       throw ArgumentError.value(
         devices,
@@ -75,15 +79,21 @@ class DeviceProvider extends Provider<DeviceState> {
       DeviceState(
         availableDevices: devices,
         currentDevice: devices.first,
+        orientation: state.orientation,
+        showKeyboard: state.showKeyboard,
+        isFrameVisible: state.isFrameVisible,
       ),
     );
   }
 
-  void selectDevice(Device device) {
+  void selectDevice(DeviceInfo device) {
     emit(
       DeviceState(
         availableDevices: state.availableDevices,
         currentDevice: device,
+        orientation: state.orientation,
+        showKeyboard: state.showKeyboard,
+        isFrameVisible: state.isFrameVisible,
       ),
     );
   }
@@ -96,6 +106,9 @@ class DeviceProvider extends Provider<DeviceState> {
       DeviceState(
         availableDevices: state.availableDevices,
         currentDevice: nextDevice,
+        orientation: state.orientation,
+        showKeyboard: state.showKeyboard,
+        isFrameVisible: state.isFrameVisible,
       ),
     );
   }
@@ -109,6 +122,51 @@ class DeviceProvider extends Provider<DeviceState> {
       DeviceState(
         availableDevices: state.availableDevices,
         currentDevice: previousDevice,
+        orientation: state.orientation,
+        showKeyboard: state.showKeyboard,
+        isFrameVisible: state.isFrameVisible,
+      ),
+    );
+  }
+
+  void toggleKeyBoard() {
+    final currentState = state.showKeyboard;
+
+    emit(
+      DeviceState(
+        availableDevices: state.availableDevices,
+        currentDevice: state.currentDevice,
+        orientation: state.orientation,
+        showKeyboard: !currentState,
+        isFrameVisible: state.isFrameVisible,
+      ),
+    );
+  }
+
+  void toggleOrientation() {
+    final orientation = state.orientation == Orientation.portrait
+        ? Orientation.landscape
+        : Orientation.portrait;
+
+    emit(
+      DeviceState(
+        availableDevices: state.availableDevices,
+        currentDevice: state.currentDevice,
+        orientation: orientation,
+        showKeyboard: state.showKeyboard,
+        isFrameVisible: state.isFrameVisible,
+      ),
+    );
+  }
+
+  void toggleFrameVisibility() {
+    emit(
+      DeviceState(
+        availableDevices: state.availableDevices,
+        currentDevice: state.currentDevice,
+        orientation: state.orientation,
+        showKeyboard: state.showKeyboard,
+        isFrameVisible: !state.isFrameVisible,
       ),
     );
   }

--- a/packages/widgetbook/lib/src/providers/device_state.dart
+++ b/packages/widgetbook/lib/src/providers/device_state.dart
@@ -1,15 +1,21 @@
 import 'package:collection/collection.dart';
-
-import 'package:widgetbook_models/widgetbook_models.dart';
+import 'package:device_frame/device_frame.dart';
+import 'package:flutter/material.dart';
 
 class DeviceState {
   DeviceState({
     required this.availableDevices,
     required this.currentDevice,
+    required this.orientation,
+    required this.showKeyboard,
+    required this.isFrameVisible,
   });
 
-  final List<Device> availableDevices;
-  final Device currentDevice;
+  final List<DeviceInfo> availableDevices;
+  final DeviceInfo currentDevice;
+  final Orientation orientation;
+  final bool showKeyboard;
+  final bool isFrameVisible;
 
   @override
   bool operator ==(Object other) {
@@ -18,7 +24,10 @@ class DeviceState {
 
     return other is DeviceState &&
         listEquals(other.availableDevices, availableDevices) &&
-        other.currentDevice == currentDevice;
+        other.currentDevice == currentDevice &&
+        other.showKeyboard == showKeyboard &&
+        other.orientation == orientation &&
+        other.isFrameVisible == isFrameVisible;
   }
 
   @override

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -1,3 +1,4 @@
+import 'package:device_frame/device_frame.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
@@ -19,20 +20,12 @@ import 'package:widgetbook/src/routing/route_information_parser.dart';
 import 'package:widgetbook/src/routing/story_router_delegate.dart';
 import 'package:widgetbook/src/services/filter_service.dart';
 import 'package:widgetbook/src/utils/utils.dart';
-import 'package:widgetbook_models/widgetbook_models.dart';
 
 class Widgetbook extends StatefulWidget {
   const Widgetbook({
     Key? key,
     required this.categories,
-    this.devices = const [
-      Apple.iPhone11,
-      Apple.iPhone12,
-      Apple.iPhone12Mini,
-      Apple.iPhone12Pro,
-      Samsung.s10,
-      Samsung.s21ultra,
-    ],
+    required this.devices,
     required this.appInfo,
     this.lightTheme,
     this.darkTheme,
@@ -44,7 +37,7 @@ class Widgetbook extends StatefulWidget {
   final List<WidgetbookCategory> categories;
 
   /// The devices on which Stories are previewed.
-  final List<Device> devices;
+  final List<DeviceInfo> devices;
 
   /// Information about the app that is catalogued in the Widgetbook.
   final AppInfo appInfo;

--- a/packages/widgetbook/lib/src/widgets/device_bar.dart
+++ b/packages/widgetbook/lib/src/widgets/device_bar.dart
@@ -56,6 +56,77 @@ class DeviceBar extends StatelessWidget {
             color: context.theme.hintColor,
           ),
         ),
+        const SizedBox(
+          width: 40,
+        ),
+        Tooltip(
+          message: 'Change Orientation',
+          child: TextButton(
+            onPressed: deviceProvider.toggleOrientation,
+            style: TextButton.styleFrom(
+              splashFactory: InkRipple.splashFactory,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(90)),
+              minimumSize: Size.zero,
+              padding: const EdgeInsets.all(12),
+            ),
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                Icon(
+                  Icons.sync,
+                  color: state.orientation == Orientation.landscape
+                      ? context.colorScheme.primary
+                      : context.theme.hintColor,
+                  size: 30,
+                ),
+                Icon(
+                  state.orientation == Orientation.portrait
+                      ? Icons.stay_current_portrait
+                      : Icons.stay_current_landscape,
+                  color: state.orientation == Orientation.landscape
+                      ? context.colorScheme.primary
+                      : context.theme.hintColor,
+                  size: 12,
+                ),
+              ],
+            ),
+          ),
+        ),
+        Tooltip(
+          message: 'Show Keyboard',
+          child: TextButton(
+            onPressed: deviceProvider.toggleKeyBoard,
+            style: TextButton.styleFrom(
+              splashFactory: InkRipple.splashFactory,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(90),
+              ),
+              minimumSize: Size.zero,
+              padding: const EdgeInsets.all(12),
+            ),
+            child: Icon(
+              Icons.keyboard,
+              color: state.showKeyboard
+                  ? context.colorScheme.primary
+                  : context.theme.hintColor,
+            ),
+          ),
+        ),
+        Tooltip(
+          message: 'Show Device Frame',
+          child: Column(
+            children: [
+              Switch(
+                activeColor: context.colorScheme.primary,
+                value: state.isFrameVisible,
+                onChanged: (_) {
+                  deviceProvider.toggleFrameVisibility();
+                },
+              ),
+            ],
+          ),
+        ),
       ],
     );
   }

--- a/packages/widgetbook/lib/src/widgets/device_item.dart
+++ b/packages/widgetbook/lib/src/widgets/device_item.dart
@@ -1,7 +1,7 @@
+import 'package:device_frame/device_frame.dart';
 import 'package:flutter/material.dart';
 import 'package:widgetbook/src/providers/device_provider.dart';
 import 'package:widgetbook/src/utils/extensions.dart';
-import 'package:widgetbook_models/widgetbook_models.dart';
 
 class DeviceItem extends StatelessWidget {
   const DeviceItem({
@@ -9,7 +9,7 @@ class DeviceItem extends StatelessWidget {
     required this.device,
   }) : super(key: key);
 
-  final Device device;
+  final DeviceInfo device;
 
   @override
   Widget build(BuildContext context) {
@@ -35,7 +35,7 @@ class DeviceItem extends StatelessWidget {
     return Tooltip(
       message: device.name,
       child: buildIcon(
-        device.type,
+        device.identifier.type,
         isCurrent ? context.colorScheme.primary : context.theme.hintColor,
       ),
     );
@@ -43,16 +43,16 @@ class DeviceItem extends StatelessWidget {
 
   Widget buildIcon(DeviceType type, Color color) {
     switch (type) {
-      case DeviceType.watch:
-        return Icon(
-          Icons.watch,
-          color: color,
-        );
-      case DeviceType.mobile:
-        return Icon(
-          Icons.smartphone,
-          color: color,
-        );
+      // case DeviceType.watch:
+      //   return Icon(
+      //     Icons.watch,
+      //     color: color,
+      //   );
+      // case DeviceType.mobile:
+      //   return Icon(
+      //     Icons.smartphone,
+      //     color: color,
+      //   );
       case DeviceType.tablet:
         return Icon(
           Icons.tablet,
@@ -66,6 +66,21 @@ class DeviceItem extends StatelessWidget {
       case DeviceType.unknown:
         return Icon(
           Icons.quiz,
+          color: color,
+        );
+      case DeviceType.phone:
+        return Icon(
+          Icons.phone_android,
+          color: color,
+        );
+      case DeviceType.tv:
+        return Icon(
+          Icons.tv,
+          color: color,
+        );
+      case DeviceType.laptop:
+        return Icon(
+          Icons.laptop,
           color: color,
         );
     }

--- a/packages/widgetbook/lib/src/widgets/device_render.dart
+++ b/packages/widgetbook/lib/src/widgets/device_render.dart
@@ -42,39 +42,37 @@ class DeviceRender extends StatelessWidget {
         const SizedBox(
           height: 16,
         ),
-        MediaQuery(
-          data: MediaQuery.of(context).copyWith(
-            size: Size(
-              resolution.logicalSize.width,
-              resolution.logicalSize.height,
+        Container(
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: Theme.of(context).brightness == Brightness.dark
+                  ? Colors.white
+                  : Colors.black,
             ),
           ),
-          child: Container(
-            decoration: BoxDecoration(
-              border: Border.all(
-                color: Theme.of(context).brightness == Brightness.dark
-                    ? Colors.white
-                    : Colors.black,
+          width: resolution.logicalSize.width,
+          height: resolution.logicalSize.height,
+          child: MaterialApp(
+            debugShowCheckedModeBanner: false,
+            themeMode: Theme.of(context).brightness == Brightness.light
+                ? ThemeMode.light
+                : ThemeMode.dark,
+            home: AnimatedTheme(
+              duration: Duration.zero,
+              data: getInjectedTheme(context, themeState).copyWith(
+                brightness: Theme.of(context).brightness,
+                pageTransitionsTheme: const PageTransitionsTheme(
+                  builders: {
+                    TargetPlatform.iOS: FadeUpwardsPageTransitionsBuilder(),
+                    TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
+                  },
+                ),
               ),
-            ),
-            width: resolution.logicalSize.width,
-            height: resolution.logicalSize.height,
-            child: MaterialApp(
-              useInheritedMediaQuery: true,
-              debugShowCheckedModeBanner: false,
-              themeMode: Theme.of(context).brightness == Brightness.light
-                  ? ThemeMode.light
-                  : ThemeMode.dark,
-              home: AnimatedTheme(
-                duration: Duration.zero,
-                data: getInjectedTheme(context, themeState).copyWith(
-                  brightness: Theme.of(context).brightness,
-                  pageTransitionsTheme: const PageTransitionsTheme(
-                    builders: {
-                      TargetPlatform.iOS: FadeUpwardsPageTransitionsBuilder(),
-                      TargetPlatform.android:
-                          FadeUpwardsPageTransitionsBuilder(),
-                    },
+              child: MediaQuery(
+                data: MediaQuery.of(context).copyWith(
+                  size: Size(
+                    resolution.logicalSize.width,
+                    resolution.logicalSize.height,
                   ),
                 ),
                 child: Scaffold(

--- a/packages/widgetbook/lib/src/widgets/device_render.dart
+++ b/packages/widgetbook/lib/src/widgets/device_render.dart
@@ -42,35 +42,45 @@ class DeviceRender extends StatelessWidget {
         const SizedBox(
           height: 16,
         ),
-        Container(
-          decoration: BoxDecoration(
-            border: Border.all(
-              color: Theme.of(context).brightness == Brightness.dark
-                  ? Colors.white
-                  : Colors.black,
+        MediaQuery(
+          data: MediaQuery.of(context).copyWith(
+            size: Size(
+              resolution.logicalSize.width,
+              resolution.logicalSize.height,
             ),
           ),
-          width: resolution.logicalSize.width,
-          height: resolution.logicalSize.height,
-          child: MaterialApp(
-            debugShowCheckedModeBanner: false,
-            themeMode: Theme.of(context).brightness == Brightness.light
-                ? ThemeMode.light
-                : ThemeMode.dark,
-            home: AnimatedTheme(
-              duration: Duration.zero,
-              data: getInjectedTheme(context, themeState).copyWith(
-                brightness: Theme.of(context).brightness,
-                pageTransitionsTheme: const PageTransitionsTheme(
-                  builders: {
-                    TargetPlatform.iOS: FadeUpwardsPageTransitionsBuilder(),
-                    TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
-                  },
-                ),
+          child: Container(
+            decoration: BoxDecoration(
+              border: Border.all(
+                color: Theme.of(context).brightness == Brightness.dark
+                    ? Colors.white
+                    : Colors.black,
               ),
-              child: Scaffold(
-                body: story.builder(
-                  context,
+            ),
+            width: resolution.logicalSize.width,
+            height: resolution.logicalSize.height,
+            child: MaterialApp(
+              useInheritedMediaQuery: true,
+              debugShowCheckedModeBanner: false,
+              themeMode: Theme.of(context).brightness == Brightness.light
+                  ? ThemeMode.light
+                  : ThemeMode.dark,
+              home: AnimatedTheme(
+                duration: Duration.zero,
+                data: getInjectedTheme(context, themeState).copyWith(
+                  brightness: Theme.of(context).brightness,
+                  pageTransitionsTheme: const PageTransitionsTheme(
+                    builders: {
+                      TargetPlatform.iOS: FadeUpwardsPageTransitionsBuilder(),
+                      TargetPlatform.android:
+                          FadeUpwardsPageTransitionsBuilder(),
+                    },
+                  ),
+                ),
+                child: Scaffold(
+                  body: story.builder(
+                    context,
+                  ),
                 ),
               ),
             ),

--- a/packages/widgetbook/lib/src/widgets/device_render.dart
+++ b/packages/widgetbook/lib/src/widgets/device_render.dart
@@ -1,3 +1,4 @@
+import 'package:device_frame/device_frame.dart';
 import 'package:flutter/material.dart';
 import 'package:widgetbook/src/models/organizers/organizers.dart';
 import 'package:widgetbook/src/providers/device_provider.dart';
@@ -31,48 +32,33 @@ class DeviceRender extends StatelessWidget {
     final state = deviceProvider.state;
 
     final device = state.currentDevice;
-    final resolution = device.resolution;
 
     final themeState = InjectedThemeProvider.of(context)!.state;
 
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        Text(device.name),
-        const SizedBox(
-          height: 16,
-        ),
-        Container(
-          decoration: BoxDecoration(
-            border: Border.all(
-              color: Theme.of(context).brightness == Brightness.dark
-                  ? Colors.white
-                  : Colors.black,
-            ),
-          ),
-          width: resolution.logicalSize.width,
-          height: resolution.logicalSize.height,
-          child: MaterialApp(
-            debugShowCheckedModeBanner: false,
-            themeMode: Theme.of(context).brightness == Brightness.light
-                ? ThemeMode.light
-                : ThemeMode.dark,
-            home: AnimatedTheme(
-              duration: Duration.zero,
-              data: getInjectedTheme(context, themeState).copyWith(
-                brightness: Theme.of(context).brightness,
-                pageTransitionsTheme: const PageTransitionsTheme(
-                  builders: {
-                    TargetPlatform.iOS: FadeUpwardsPageTransitionsBuilder(),
-                    TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
-                  },
-                ),
-              ),
-              child: MediaQuery(
-                data: MediaQuery.of(context).copyWith(
-                  size: Size(
-                    resolution.logicalSize.width,
-                    resolution.logicalSize.height,
+    final app = DeviceFrame(
+      device: device,
+      orientation: state.orientation,
+      isFrameVisible: state.isFrameVisible,
+      screen: VirtualKeyboard(
+        isEnabled: state.showKeyboard,
+        child: Builder(
+          builder: (context) {
+            return MaterialApp(
+              debugShowCheckedModeBanner: false,
+              useInheritedMediaQuery: true,
+              themeMode: Theme.of(context).brightness == Brightness.light
+                  ? ThemeMode.light
+                  : ThemeMode.dark,
+              home: AnimatedTheme(
+                duration: Duration.zero,
+                data: getInjectedTheme(context, themeState).copyWith(
+                  brightness: Theme.of(context).brightness,
+                  pageTransitionsTheme: const PageTransitionsTheme(
+                    builders: {
+                      TargetPlatform.iOS: FadeUpwardsPageTransitionsBuilder(),
+                      TargetPlatform.android:
+                          FadeUpwardsPageTransitionsBuilder(),
+                    },
                   ),
                 ),
                 child: Scaffold(
@@ -81,9 +67,33 @@ class DeviceRender extends StatelessWidget {
                   ),
                 ),
               ),
-            ),
-          ),
+            );
+          },
         ),
+      ),
+    );
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text(device.name),
+        const SizedBox(
+          height: 16,
+        ),
+        if (!state.isFrameVisible)
+          Container(
+            decoration: BoxDecoration(
+              color: Theme.of(context).backgroundColor,
+              border: Border.all(
+                color: Theme.of(context).brightness == Brightness.dark
+                    ? Colors.white
+                    : Colors.black,
+              ),
+            ),
+            child: app,
+          )
+        else
+          app
       ],
     );
   }

--- a/packages/widgetbook/lib/widgetbook.dart
+++ b/packages/widgetbook/lib/widgetbook.dart
@@ -1,3 +1,3 @@
+export 'package:device_frame/src/devices/devices.dart';
 export 'package:widgetbook/src/models/models.dart';
 export 'package:widgetbook/src/widgetbook.dart';
-export 'package:widgetbook_models/widgetbook_models.dart';

--- a/packages/widgetbook/pubspec.lock
+++ b/packages/widgetbook/pubspec.lock
@@ -92,6 +92,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  device_frame:
+    dependency: "direct main"
+    description:
+      name: device_frame
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.1"
   fake_async:
     dependency: transitive
     description:
@@ -121,6 +128,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed_annotation:
+    dependency: transitive
+    description:
+      name: freezed_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -163,6 +177,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.3"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.3.0"
   logging:
     dependency: transitive
     description:
@@ -392,13 +413,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
-  widgetbook_models:
-    dependency: "direct main"
-    description:
-      name: widgetbook_models
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.3"
   yaml:
     dependency: transitive
     description:

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -12,13 +12,15 @@ environment:
 
 dependencies:
   collection: ^1.15.0
+  device_frame: ^0.6.1
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
   meta: ^1.7.0
   vector_math: ^2.1.0
-  widgetbook_models: ^0.0.3
+  # widgetbook_models: ^0.0.3
+
 
 # for development
 # dependency_override:


### PR DESCRIPTION
This pull request updates WidgetBook to use [device_frame](https://github.com/aloisdeniel/flutter_device_preview/tree/master/device_frame) instead of the built in `widgetbook_models`. 

The main benefits of using `device_frame` are:

- A List of Ready to use Device Frame UI
- Correct MediaQuery data for all devices. (fixes #66)
- User toggable frame
- Built in Virtual Keyboard
- Orientation Switching (fixes #56 )

This changes renders [widgetbook_models](https://github.com/widgetbook/widgetbook/tree/main/packages/widgetbook_models) package completely useless. The only braking change for users is switching from [device.dart](https://github.com/widgetbook/widgetbook/blob/main/packages/widgetbook_models/lib/src/devices/device.dart) to [devices.dart](https://github.com/aloisdeniel/flutter_device_preview/blob/master/device_frame/lib/src/devices/devices.dart) from the `device_frame` library. 

`devices.dart` will be [exposed from widgetbook](https://github.com/edTheGuy00/widgetbook/blob/0b4e4e661bd73584bead61d159279c98f4aecff5/packages/widgetbook/lib/widgetbook.dart#L1) so users do not need to add this dependency separately. The only downside is that `device_frame` does not include watch devices which are included in widgetbook, But I could make a pull request to `device_frame` later on to add more devices into it. 

TODO:

- [ ] Update Documentation
- [ ] Clean Up Code
- [ ] Update Tests


## Preview

<img width="998" alt="Screen Shot 2021-11-28 at 13 41 03" src="https://user-images.githubusercontent.com/16095735/143732709-0160ca33-c3f4-4d58-8739-6d60b614757a.png">

<img width="1001" alt="Screen Shot 2021-11-28 at 13 41 49" src="https://user-images.githubusercontent.com/16095735/143732716-d6752c0b-f5c6-41f4-a663-a47d2261ab65.png">

<img width="991" alt="Screen Shot 2021-11-28 at 13 41 32" src="https://user-images.githubusercontent.com/16095735/143732722-e4da990e-5c9f-472e-a828-0247e5ee172a.png">

