### PR TITLE
Export desktop screens

### DIFF
--- a/packages/widgetbook_models/lib/widgetbook_models.dart
+++ b/packages/widgetbook_models/lib/widgetbook_models.dart
@@ -6,3 +6,4 @@ export './src/devices/device_size.dart';
 export './src/devices/device_type.dart';
 export './src/devices/resolution.dart';
 export './src/devices/samsung_devices.dart';
+export './src/devices/desktop_screens.dart';

--- a/packages/widgetbook_models/lib/widgetbook_models.dart
+++ b/packages/widgetbook_models/lib/widgetbook_models.dart
@@ -1,9 +1,9 @@
 library widgetbook_models;
 
 export './src/devices/apple_devices.dart';
+export './src/devices/desktop_screens.dart';
 export './src/devices/device.dart';
 export './src/devices/device_size.dart';
 export './src/devices/device_type.dart';
 export './src/devices/resolution.dart';
 export './src/devices/samsung_devices.dart';
-export './src/devices/desktop_screens.dart';


### PR DESCRIPTION
Desktop screens is not exported in widgetbook_models

### List of issues which are fixed by the PR
[#78 ](https://github.com/widgetbook/widgetbook/issues/78)

### Screenshots
<img width="433" alt="Képernyőfotó 2021-12-19 - 10 58 21" src="https://user-images.githubusercontent.com/536799/146670906-ee09366d-c908-4f47-8fd4-0cbee5d33c5a.png">

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

