### PR TITLE
Skip src root folder

### DIFF
--- a/packages/widgetbook_annotation/README.md
+++ b/packages/widgetbook_annotation/README.md
@@ -162,6 +162,8 @@ use cases (Category)
 
 If you require multiple use cases for a Widget, feel free to define multiple `@WidgetbookUseCase`s per Widget. The additional use cases will be located in the navigation panel similar to the showcased use case. 
 
+Generator skips top root `src` folder from navigation panel. Many Flutter projects have its source code under a `src` folder, so keep it as a top-level category is unnecessary. If you have the same folder name under `lib` and `src` that folders will be merged. 
+
 ## WidgetbookTheme
 
 `@WidgetbookTheme` allows developers to annotate the light and dark theme of their app. Similar to `@WidgetbookUseCase`, `@WidgetbookTheme` is used on methods returning a `ThemeData` object. 

--- a/packages/widgetbook_generator/lib/services/tree_service.dart
+++ b/packages/widgetbook_generator/lib/services/tree_service.dart
@@ -45,6 +45,10 @@ class TreeService {
     // TODO improve
     // This skips the last element
     elements = elements.reversed.skip(1).toList().reversed.toList();
+    if (elements.isNotEmpty && elements[0] == 'src') {
+      elements = elements.skip(1).toList();
+    }
+
     return addFolder(null, elements);
   }
 

--- a/packages/widgetbook_generator/test/src/code_generators/instances/tree_service_test.dart
+++ b/packages/widgetbook_generator/test/src/code_generators/instances/tree_service_test.dart
@@ -1,0 +1,74 @@
+import 'package:test/test.dart';
+import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_folder_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/widgetbook_widget_instance.dart';
+import 'package:widgetbook_generator/code_generators/properties/property.dart';
+import 'package:widgetbook_generator/services/tree_service.dart';
+
+import '../instance_helper.dart';
+
+void main() {
+  group('$TreeService', () {
+    final instance = TreeService()
+      ..addFolderByImport('package:some_package/foo/bar/sample.dart');
+
+    final instanceSrc = TreeService()
+      ..addFolderByImport('package:some_package/src/foo/bar/sample.dart');
+
+    test('TreeService skips src folder', () {
+      expect(
+        instance.folders.containsKey('foo'),
+        equals(true),
+      );
+
+      expect(
+        instanceSrc.folders.containsKey('src'),
+        equals(false),
+      );
+
+      expect(
+        instance.folders['foo']!.subFolders.containsKey('bar'),
+        equals(true),
+      );
+
+      expect(
+        instanceSrc.folders['foo']!.subFolders.containsKey('bar'),
+        equals(true),
+      );
+
+      expect(
+        instance.folders['foo']!.subFolders['bar']!.subFolders.isEmpty,
+        equals(true),
+      );
+
+      expect(
+        instanceSrc.folders['foo']!.subFolders['bar']!.subFolders.isEmpty,
+        equals(true),
+      );
+    });
+
+    instanceSrc.addFolderByImport('package:some_package/foo/other/widget.dart');
+
+    test('TreeService merge same folder names', () {
+      expect(
+        instanceSrc.folders.containsKey('foo'),
+        equals(true),
+      );
+
+      expect(
+        instanceSrc.folders['foo']!.subFolders.length,
+        equals(2),
+      );
+
+      expect(
+        instanceSrc.folders['foo']!.subFolders.containsKey('bar'),
+        equals(true),
+      );
+
+      expect(
+        instanceSrc.folders['foo']!.subFolders.containsKey('other'),
+        equals(true),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Skip `src` root directory when generating widgetbook

### List of issues which are fixed by the PR
#80 

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.
