### PR TITLE
Add default theme parameter

### DIFF
--- a/packages/widgetbook/lib/src/models/organizers/expandable_organizer.dart
+++ b/packages/widgetbook/lib/src/models/organizers/expandable_organizer.dart
@@ -1,6 +1,4 @@
 import 'package:collection/collection.dart';
-
-import 'package:widgetbook/src/models/organizers/organizer.dart';
 import 'package:widgetbook/src/models/organizers/organizers.dart';
 
 /// ExpandableOrganizer is an abstract model which can host

--- a/packages/widgetbook/lib/src/models/organizers/widgetbook_folder.dart
+++ b/packages/widgetbook/lib/src/models/organizers/widgetbook_folder.dart
@@ -1,6 +1,4 @@
-import 'package:widgetbook/src/models/organizers/expandable_organizer.dart';
 import 'package:widgetbook/src/models/organizers/organizers.dart';
-import 'package:widgetbook/src/models/organizers/widgetbook_widget.dart';
 
 /// A folder in the folder tree.
 class WidgetbookFolder extends ExpandableOrganizer {

--- a/packages/widgetbook/lib/src/models/organizers/widgetbook_widget.dart
+++ b/packages/widgetbook/lib/src/models/organizers/widgetbook_widget.dart
@@ -1,8 +1,5 @@
 import 'package:collection/collection.dart';
-
-import 'package:widgetbook/src/models/organizers/expandable_organizer.dart';
 import 'package:widgetbook/src/models/organizers/organizers.dart';
-import 'package:widgetbook/src/models/organizers/widgetbook_use_case.dart';
 
 ///
 class WidgetbookWidget extends ExpandableOrganizer {

--- a/packages/widgetbook/lib/src/navigation/ui/navigation_panel.dart
+++ b/packages/widgetbook/lib/src/navigation/ui/navigation_panel.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:widgetbook/src/constants/radii.dart';
 import 'package:widgetbook/src/models/app_info.dart';

--- a/packages/widgetbook/lib/src/providers/theme_provider.dart
+++ b/packages/widgetbook/lib/src/providers/theme_provider.dart
@@ -4,10 +4,12 @@ import 'package:widgetbook/src/providers/provider.dart';
 class ThemeBuilder extends StatefulWidget {
   const ThemeBuilder({
     Key? key,
+    this.themeMode = ThemeMode.system,
     required this.child,
   }) : super(key: key);
 
   final Widget child;
+  final ThemeMode themeMode;
 
   @override
   _ThemeBuilderState createState() => _ThemeBuilderState();
@@ -15,6 +17,12 @@ class ThemeBuilder extends StatefulWidget {
 
 class _ThemeBuilderState extends State<ThemeBuilder> {
   ThemeMode state = ThemeMode.dark;
+
+  @override
+  void initState() {
+    state = widget.themeMode;
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'package:widgetbook/src/configure_non_web.dart'

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -36,6 +36,7 @@ class Widgetbook extends StatefulWidget {
     required this.appInfo,
     this.lightTheme,
     this.darkTheme,
+    this.defaultTheme = ThemeMode.system,
   }) : super(key: key);
 
   /// Categories which host Folders and WidgetElements.
@@ -54,6 +55,9 @@ class Widgetbook extends StatefulWidget {
 
   /// The `ThemeData` that is shown when the dark theme is active.
   final ThemeData? darkTheme;
+
+  /// The default theme mode Widgetbook starts with
+  final ThemeMode defaultTheme;
 
   @override
   _WidgetbookState createState() => _WidgetbookState();
@@ -100,6 +104,7 @@ class _WidgetbookState extends State<Widgetbook> {
         storyRepository: storyRepository,
         child: ZoomBuilder(
           child: ThemeBuilder(
+            themeMode: widget.defaultTheme,
             child: DeviceBuilder(
               availableDevices: widget.devices,
               currentDevice: widget.devices.first,

--- a/packages/widgetbook/lib/src/widgets/controls_bar.dart
+++ b/packages/widgetbook/lib/src/widgets/controls_bar.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:widgetbook/src/constants/constants.dart';
 import 'package:widgetbook/src/widgets/device_bar.dart';
 import 'package:widgetbook/src/widgets/theme_handle.dart';

--- a/packages/widgetbook/lib/src/widgets/tiles/story_tile.dart
+++ b/packages/widgetbook/lib/src/widgets/tiles/story_tile.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:widgetbook/src/models/organizers/organizers.dart';
 import 'package:widgetbook/src/providers/canvas_provider.dart';

--- a/packages/widgetbook/lib/src/widgets/tiles/tile.dart
+++ b/packages/widgetbook/lib/src/widgets/tiles/tile.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:widgetbook/src/constants/radii.dart';
 import 'package:widgetbook/src/models/organizers/organizer.dart';
 import 'package:widgetbook/src/providers/canvas_provider.dart';
-import 'package:widgetbook/src/utils/styles.dart';
 import 'package:widgetbook/src/utils/utils.dart';
 
 class Tile extends StatefulWidget {

--- a/packages/widgetbook/test/src/providers/theme_provider_test.dart
+++ b/packages/widgetbook/test/src/providers/theme_provider_test.dart
@@ -70,13 +70,13 @@ void main() {
       );
 
       testWidgets(
-        '.state defaults to ${ThemeMode.dark}',
+        '.state defaults to ${ThemeMode.system}',
         (WidgetTester tester) async {
           final provider = await tester.pumpProvider();
 
           expect(
             provider.state,
-            equals(ThemeMode.dark),
+            equals(ThemeMode.system),
           );
         },
       );

--- a/packages/widgetbook_annotation/README.md
+++ b/packages/widgetbook_annotation/README.md
@@ -51,6 +51,9 @@ From the `name` parameter, the generator will create the `AppInfo` property of [
 
 From the `devices` parameter, the generator will create the devices in which one can preview the widgets. 
 
+You can set default theme mode by `defaultTheme` parameter. If not specified, system theme mode is used. 
+Valid values are `WidgetbookTheme.dark()` and `WidgetbookTheme.light()`.
+
 ### Example
 
 For the following app structure 

--- a/packages/widgetbook_annotation/lib/src/widgetbook_app.dart
+++ b/packages/widgetbook_annotation/lib/src/widgetbook_app.dart
@@ -1,3 +1,4 @@
+import 'package:widgetbook_annotation/src/widgetbook_theme.dart';
 import 'package:widgetbook_models/widgetbook_models.dart';
 
 /// Annotates a code element to create the widgetbook main file in the same
@@ -10,6 +11,7 @@ class WidgetbookApp {
   const WidgetbookApp({
     required this.name,
     this.devices = const <Device>[],
+    this.defaultTheme,
   });
 
   /// The devices shown in the Widgetbook
@@ -18,4 +20,7 @@ class WidgetbookApp {
   /// The name of the widgetbook.
   /// This information will be displayed at the top left corner in the UI.
   final String name;
+
+  /// Set default theme mode. If not specified, system theme mode is used.
+  final WidgetbookTheme? defaultTheme;
 }

--- a/packages/widgetbook_generator/lib/code_generators/instances/theme_mode_instance.dart
+++ b/packages/widgetbook_generator/lib/code_generators/instances/theme_mode_instance.dart
@@ -1,0 +1,14 @@
+import 'package:widgetbook_generator/code_generators/instances/base_instance.dart';
+
+/// Implements a material ThemeMode instance
+class ThemeModeInstance extends BaseInstance {
+  /// Creates a new instance of [ThemeModeInstance]
+  const ThemeModeInstance({
+    required this.name,
+  });
+
+  final String name;
+
+  @override
+  String toCode() => 'ThemeMode.$name';
+}

--- a/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_instance.dart
+++ b/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_instance.dart
@@ -3,19 +3,21 @@ import 'package:widgetbook_generator/code_generators/instances/device_instance.d
 import 'package:widgetbook_generator/code_generators/instances/instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/theme_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/theme_mode_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/widgetbook_category_instance.dart';
 import 'package:widgetbook_generator/code_generators/properties/property.dart';
 
 /// An instance for Widgetbook
 class WidgetbookInstance extends Instance {
   /// Creates a new instance of [WidgetbookInstance]
-  WidgetbookInstance({
-    required AppInfoInstance appInfoInstance,
-    required List<WidgetbookCategoryInstance> categories,
-    ThemeInstance? lightThemeInstance,
-    ThemeInstance? darkThemeInstance,
-    List<DeviceInstance> devices = const <DeviceInstance>[],
-  }) : super(
+  WidgetbookInstance(
+      {required AppInfoInstance appInfoInstance,
+      required List<WidgetbookCategoryInstance> categories,
+      ThemeInstance? lightThemeInstance,
+      ThemeInstance? darkThemeInstance,
+      ThemeModeInstance? defaultThemeInstance,
+      List<DeviceInstance> devices = const <DeviceInstance>[]})
+      : super(
           name: 'Widgetbook',
           properties: [
             Property(key: 'appInfo', instance: appInfoInstance),
@@ -23,6 +25,8 @@ class WidgetbookInstance extends Instance {
               Property(key: 'lightTheme', instance: lightThemeInstance),
             if (darkThemeInstance != null)
               Property(key: 'darkTheme', instance: darkThemeInstance),
+            if (defaultThemeInstance != null)
+              Property(key: 'defaultTheme', instance: defaultThemeInstance),
             if (devices.isNotEmpty)
               Property(
                 key: 'devices',

--- a/packages/widgetbook_generator/lib/generators/app_generator.dart
+++ b/packages/widgetbook_generator/lib/generators/app_generator.dart
@@ -1,6 +1,7 @@
 import 'package:widgetbook_generator/code_generators/instances/app_info_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/device_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/theme_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/theme_mode_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/widgetbook_category_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/widgetbook_instance.dart';
 import 'package:widgetbook_generator/models/widgetbook_story_data.dart';
@@ -15,6 +16,7 @@ String generateWidgetbook({
   required List<Device> devices,
   WidgetbookThemeData? lightTheme,
   WidgetbookThemeData? darkTheme,
+  bool? defaultThemeIsDark,
 }) {
   final category = _generateCategoryInstance(stories);
   final widgetbookInstanceCode = WidgetbookInstance(
@@ -23,6 +25,9 @@ String generateWidgetbook({
         lightTheme != null ? ThemeInstance(name: lightTheme.name) : null,
     darkThemeInstance:
         darkTheme != null ? ThemeInstance(name: darkTheme.name) : null,
+    defaultThemeInstance: defaultThemeIsDark != null
+        ? ThemeModeInstance(name: defaultThemeIsDark ? 'dark' : 'light')
+        : null,
     devices: devices.map((device) => DeviceInstance(device: device)).toList(),
     categories: [
       category,

--- a/packages/widgetbook_generator/lib/generators/widgetbook_generator.dart
+++ b/packages/widgetbook_generator/lib/generators/widgetbook_generator.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
@@ -44,6 +45,7 @@ class WidgetbookGenerator extends GeneratorForAnnotation<WidgetbookApp> {
         themeData.firstWhereOrDefault((element) => !element.isDarkTheme);
     final darkTheme =
         themeData.firstWhereOrDefault((element) => element.isDarkTheme);
+    final defaultThemeIsDark = _getDefaultTheme(annotation);
 
     final buffer = StringBuffer()
       ..writeln(
@@ -62,6 +64,7 @@ class WidgetbookGenerator extends GeneratorForAnnotation<WidgetbookApp> {
           name: name,
           lightTheme: lightTheme,
           darkTheme: darkTheme,
+          defaultThemeIsDark: defaultThemeIsDark,
           stories: stories,
           devices: devices,
         ),
@@ -84,6 +87,13 @@ List<Device> _getDevices(ConstantReader annotation) {
 
 String _getName(ConstantReader annotation) {
   return annotation.read('name').stringValue;
+}
+
+bool? _getDefaultTheme(ConstantReader annotation) {
+  final defaultTheme = annotation.read('defaultTheme');
+  return defaultTheme.isNull
+      ? null
+      : defaultTheme.objectValue.getField('isDarkTheme')?.toBoolValue();
 }
 
 Future<List<T>> _loadDataFromJson<T>(

--- a/packages/widgetbook_generator/lib/generators/widgetbook_generator.dart
+++ b/packages/widgetbook_generator/lib/generators/widgetbook_generator.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
@@ -13,7 +12,6 @@ import 'package:widgetbook_generator/generators/main_generator.dart';
 import 'package:widgetbook_generator/models/widgetbook_story_data.dart';
 import 'package:widgetbook_generator/models/widgetbook_theme_data.dart';
 import 'package:widgetbook_generator/readers/device_reader.dart';
-import 'package:widgetbook_models/widgetbook_models.dart';
 
 /// Generates the code for Widgetbook
 ///

--- a/packages/widgetbook_generator/test/src/code_generators/instance_helper.dart
+++ b/packages/widgetbook_generator/test/src/code_generators/instance_helper.dart
@@ -1,4 +1,3 @@
-import 'package:test/expect.dart';
 import 'package:test/test.dart';
 import 'package:widgetbook_generator/code_generators/instances/instance.dart';
 

--- a/packages/widgetbook_generator/test/src/code_generators/instances/device_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code_generators/instances/device_instance_test.dart
@@ -11,7 +11,7 @@ void main() {
   group(
     '$DeviceInstance',
     () {
-      final phone = Apple.iPhone11;
+      const phone = Apple.iPhone11;
       final instance = DeviceInstance(device: phone);
 
       testName('$Device', instance: instance);

--- a/packages/widgetbook_generator/test/src/code_generators/instances/theme_mode_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code_generators/instances/theme_mode_instance_test.dart
@@ -1,0 +1,23 @@
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+import 'package:widgetbook_generator/code_generators/instances/double_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/theme_mode_instance.dart';
+
+void main() {
+  group(
+    '$ThemeModeInstance',
+    () {
+      test(
+        '.toCode returns correct code',
+        () {
+          const instance = ThemeModeInstance(name: 'dark');
+
+          expect(
+            instance.toCode(),
+            equals('ThemeMode.dark'),
+          );
+        },
+      );
+    },
+  );
+}

--- a/packages/widgetbook_generator/test/src/code_generators/instances/theme_mode_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code_generators/instances/theme_mode_instance_test.dart
@@ -1,6 +1,5 @@
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
-import 'package:widgetbook_generator/code_generators/instances/double_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/theme_mode_instance.dart';
 
 void main() {

--- a/packages/widgetbook_generator/test/src/code_generators/instances/tree_service_test.dart
+++ b/packages/widgetbook_generator/test/src/code_generators/instances/tree_service_test.dart
@@ -1,11 +1,5 @@
 import 'package:test/test.dart';
-import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/widgetbook_folder_instance.dart';
-import 'package:widgetbook_generator/code_generators/instances/widgetbook_widget_instance.dart';
-import 'package:widgetbook_generator/code_generators/properties/property.dart';
 import 'package:widgetbook_generator/services/tree_service.dart';
-
-import '../instance_helper.dart';
 
 void main() {
   group('$TreeService', () {

--- a/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_instance_test.dart
@@ -4,6 +4,7 @@ import 'package:widgetbook_generator/code_generators/instances/app_info_instance
 import 'package:widgetbook_generator/code_generators/instances/device_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/list_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/theme_instance.dart';
+import 'package:widgetbook_generator/code_generators/instances/theme_mode_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/widgetbook_category_instance.dart';
 import 'package:widgetbook_generator/code_generators/instances/widgetbook_instance.dart';
 import 'package:widgetbook_generator/code_generators/properties/property.dart';
@@ -91,6 +92,56 @@ void main() {
                 ],
               ),
             ),
+            expectedCategoryInstance,
+          ]),
+        );
+      },
+    );
+
+    const expectedThemeModeInstanceDark = Property(
+      key: 'defaultTheme',
+      instance: ThemeModeInstance(name: 'dark'),
+    );
+
+    const expectedThemeModeInstanceLight = Property(
+      key: 'defaultTheme',
+      instance: ThemeModeInstance(name: 'light'),
+    );
+
+    test(
+      '.properties returns $AppInfoInstance, '
+      'List<$WidgetbookCategoryInstance> and dark theme',
+      () {
+        final instance = WidgetbookInstance(
+            appInfoInstance: AppInfoInstance(name: appInfoName),
+            categories: const [],
+            defaultThemeInstance: const ThemeModeInstance(name: 'dark'));
+
+        expect(
+          instance.properties,
+          equals([
+            expectedAppInfoProperty,
+            expectedThemeModeInstanceDark,
+            expectedCategoryInstance,
+          ]),
+        );
+      },
+    );
+
+    test(
+      '.properties returns $AppInfoInstance, '
+      'List<$WidgetbookCategoryInstance> and light theme',
+      () {
+        final instance = WidgetbookInstance(
+            appInfoInstance: AppInfoInstance(name: appInfoName),
+            categories: const [],
+            defaultThemeInstance: const ThemeModeInstance(name: 'light'));
+
+        expect(
+          instance.properties,
+          equals([
+            expectedAppInfoProperty,
+            expectedThemeModeInstanceLight,
             expectedCategoryInstance,
           ]),
         );


### PR DESCRIPTION
The widgetbook has always been started in dark mode. You can now set default startup theme mode in `@WidgetbookApp` annotation or in the `Widgetbook` class. 

### List of issues which are fixed by the PR
#60 How to set a default theme?

### Screenshots
<img width="397" alt="Képernyőfotó 2021-12-19 - 22 14 29" src="https://user-images.githubusercontent.com/536799/146690992-bf7da9e0-4cce-4744-83e5-4fbbce796e16.png">

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.
