### PR TITLE
Add constraint and overflow to tile #63

### DIFF
--- a/examples/widgetbook_example/pubspec.yaml
+++ b/examples/widgetbook_example/pubspec.yaml
@@ -18,7 +18,9 @@ dependencies:
   font_awesome_flutter: ^9.1.0
 
 dev_dependencies:
-  widgetbook: ^1.0.1-beta.1
+  widgetbook: 
+    path: 
+      ../../packages/widgetbook/
   flutter_test:
     sdk: flutter
 

--- a/packages/widgetbook/lib/src/widgets/tiles/spaced_tile.dart
+++ b/packages/widgetbook/lib/src/widgets/tiles/spaced_tile.dart
@@ -24,11 +24,13 @@ class SpacedTile extends StatelessWidget {
     return Row(
       children: [
         TileSpacer(level: level),
-        Tile(
-          iconData: iconData,
-          iconColor: iconColor,
-          organizer: organizer,
-          onClicked: onClicked,
+        Expanded(
+          child: Tile(
+            iconData: iconData,
+            iconColor: iconColor,
+            organizer: organizer,
+            onClicked: onClicked,
+          ),
         ),
       ],
     );

--- a/packages/widgetbook/lib/src/widgets/tiles/tile.dart
+++ b/packages/widgetbook/lib/src/widgets/tiles/tile.dart
@@ -29,7 +29,7 @@ class _TileState extends State<Tile> {
 
   Widget _buildTile(BuildContext context) {
     return Tooltip(
-      waitDuration: const Duration(milliseconds: 600),
+      waitDuration: const Duration(milliseconds: 700),
       message: widget.organizer.name,
       child: Padding(
         padding: const EdgeInsets.symmetric(

--- a/packages/widgetbook/lib/src/widgets/tiles/tile.dart
+++ b/packages/widgetbook/lib/src/widgets/tiles/tile.dart
@@ -46,8 +46,7 @@ class _TileState extends State<Tile> {
             const SizedBox(
               width: Tile.spacing,
             ),
-            Container(
-              constraints: const BoxConstraints(minWidth: 25, maxWidth: 300),
+            Expanded(
               child: Text(
                 widget.organizer.name,
                 overflow: TextOverflow.ellipsis,

--- a/packages/widgetbook/lib/src/widgets/tiles/tile.dart
+++ b/packages/widgetbook/lib/src/widgets/tiles/tile.dart
@@ -28,23 +28,33 @@ class _TileState extends State<Tile> {
   bool hovered = false;
 
   Widget _buildTile(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        vertical: 4,
-        horizontal: 8,
-      ),
-      child: Row(
-        children: [
-          Icon(
-            widget.iconData,
-            color: hovered ? context.colorScheme.onPrimary : widget.iconColor,
-            size: 16,
-          ),
-          const SizedBox(
-            width: Tile.spacing,
-          ),
-          Text(widget.organizer.name),
-        ],
+    return Tooltip(
+      waitDuration: const Duration(milliseconds: 600),
+      message: widget.organizer.name,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          vertical: 4,
+          horizontal: 8,
+        ),
+        child: Row(
+          children: [
+            Icon(
+              widget.iconData,
+              color: hovered ? context.colorScheme.onPrimary : widget.iconColor,
+              size: 16,
+            ),
+            const SizedBox(
+              width: Tile.spacing,
+            ),
+            Container(
+              constraints: const BoxConstraints(minWidth: 25, maxWidth: 300),
+              child: Text(
+                widget.organizer.name,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/packages/widgetbook/test/src/widgets/tiles/tile_test.dart
+++ b/packages/widgetbook/test/src/widgets/tiles/tile_test.dart
@@ -19,7 +19,7 @@ const longString =
 
 void _testEllipses() {
   // Tests that rendering does not throw an exception
-  testWidgets('Ellipses display', (WidgetTester tester) async {
+  testWidgets('Tile does not throw exception', (WidgetTester tester) async {
     await tester.pumpWidgetWithMaterialApp(
       CanvasProvider(
         onStateChanged: (_) {},
@@ -58,7 +58,7 @@ void _testEllipses() {
 
 void main() {
   group(
-    '$TileSpacer',
+    'Test rendering',
     _testEllipses,
   );
 }

--- a/packages/widgetbook/test/src/widgets/tiles/tile_test.dart
+++ b/packages/widgetbook/test/src/widgets/tiles/tile_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/src/providers/canvas_provider.dart';
+import 'package:widgetbook/src/providers/canvas_state.dart';
+import 'package:widgetbook/src/repositories/selected_story_repository.dart';
+import 'package:widgetbook/src/repositories/story_repository.dart';
+import 'package:widgetbook/src/widgets/tiles/tile.dart';
+import 'package:widgetbook/src/widgets/tiles/tile_spacer.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import '../../../helper/widget_test_helper.dart';
+
+void _testEllipses() {
+  testWidgets('Ellipses display', (WidgetTester tester) async {
+    await tester.pumpWidgetWithMaterialApp(
+      CanvasProvider(
+        onStateChanged: (_) {},
+        selectedStoryRepository: SelectedStoryRepository(),
+        state: CanvasState.unselected(),
+        storyRepository: StoryRepository(),
+        child: SizedBox(
+          width: 0,
+          child: Tile(
+            organizer: WidgetbookFolder(
+              name:
+                  'this is a very long nasfmasifai dufgnid sngauisdgu asdugh uhiuy ygk yyhjb hajgh sdfjgsdfjlkj lsk asudg',
+            ),
+            iconData: Icons.style,
+            iconColor: Colors.blue,
+          ),
+        ),
+      ),
+    );
+
+    // passes but shouldnt
+    //expect(find.textContaining('asudg'), findsOneWidget);
+    expect(find.textContaining('...'), findsOneWidget);
+  }, skip: true);
+}
+
+void main() {
+  group(
+    '$TileSpacer',
+    _testEllipses,
+  );
+}

--- a/packages/widgetbook/test/src/widgets/tiles/tile_test.dart
+++ b/packages/widgetbook/test/src/widgets/tiles/tile_test.dart
@@ -10,7 +10,15 @@ import 'package:widgetbook/widgetbook.dart';
 
 import '../../../helper/widget_test_helper.dart';
 
+const longString =
+    'This is some text text text text text text text text text text text '
+    'This is some text text text text text text text text text text text '
+    'This is some text text text text text text text text text text text '
+    'This is some text text text text text text text text text text text '
+    'This is some text text text text text text text text text text text ';
+
 void _testEllipses() {
+  // Tests that rendering does not throw an exception
   testWidgets('Ellipses display', (WidgetTester tester) async {
     await tester.pumpWidgetWithMaterialApp(
       CanvasProvider(
@@ -18,24 +26,34 @@ void _testEllipses() {
         selectedStoryRepository: SelectedStoryRepository(),
         state: CanvasState.unselected(),
         storyRepository: StoryRepository(),
-        child: SizedBox(
-          width: 0,
-          child: Tile(
-            organizer: WidgetbookFolder(
-              name:
-                  'this is a very long nasfmasifai dufgnid sngauisdgu asdugh uhiuy ygk yyhjb hajgh sdfjgsdfjlkj lsk asudg',
+        child: Row(
+          children: [
+            const SizedBox(
+              width: 20,
             ),
-            iconData: Icons.style,
-            iconColor: Colors.blue,
-          ),
+            Expanded(
+              child: Row(
+                children: [
+                  const SizedBox(
+                    width: 20,
+                  ),
+                  Expanded(
+                    child: Tile(
+                      organizer: WidgetbookFolder(
+                        name: longString,
+                      ),
+                      iconData: Icons.style,
+                      iconColor: Colors.blue,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
         ),
       ),
     );
-
-    // passes but shouldnt
-    //expect(find.textContaining('asudg'), findsOneWidget);
-    expect(find.textContaining('...'), findsOneWidget);
-  }, skip: true);
+  }, skip: false);
 }
 
 void main() {

--- a/packages/widgetbook/test/src/widgets/tiles/tile_test.dart
+++ b/packages/widgetbook/test/src/widgets/tiles/tile_test.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/src/navigation/ui/navigation_panel.dart';
 import 'package:widgetbook/src/providers/canvas_provider.dart';
 import 'package:widgetbook/src/providers/canvas_state.dart';
+import 'package:widgetbook/src/providers/theme_provider.dart';
 import 'package:widgetbook/src/repositories/selected_story_repository.dart';
 import 'package:widgetbook/src/repositories/story_repository.dart';
-import 'package:widgetbook/src/widgets/tiles/tile.dart';
-import 'package:widgetbook/src/widgets/tiles/tile_spacer.dart';
 import 'package:widgetbook/widgetbook.dart';
-
 import '../../../helper/widget_test_helper.dart';
 
 const longString =
@@ -22,34 +21,32 @@ void _testEllipses() {
   testWidgets('Tile does not throw exception', (WidgetTester tester) async {
     await tester.pumpWidgetWithMaterialApp(
       CanvasProvider(
-        onStateChanged: (_) {},
-        selectedStoryRepository: SelectedStoryRepository(),
-        state: CanvasState.unselected(),
         storyRepository: StoryRepository(),
-        child: Row(
-          children: [
-            const SizedBox(
-              width: 20,
-            ),
-            Expanded(
-              child: Row(
-                children: [
-                  const SizedBox(
-                    width: 20,
-                  ),
-                  Expanded(
-                    child: Tile(
-                      organizer: WidgetbookFolder(
+        onStateChanged: (_) {},
+        state: CanvasState.unselected(),
+        selectedStoryRepository: SelectedStoryRepository(),
+        child: ThemeProvider(
+          state: ThemeMode.dark,
+          onStateChanged: (_) {},
+          child: NavigationPanel(
+            appInfo: AppInfo(name: 'test app'),
+            categories: [
+              WidgetbookCategory(
+                name: 'category',
+                widgets: [
+                  WidgetbookWidget(
+                    name: longString,
+                    useCases: [
+                      WidgetbookUseCase.child(
                         name: longString,
+                        child: const Text('hi'),
                       ),
-                      iconData: Icons.style,
-                      iconColor: Colors.blue,
-                    ),
+                    ],
                   ),
                 ],
-              ),
-            ),
-          ],
+              )
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Shows ellipses when a tile's name is too long, adds a tool tip to tiles that shows the full name. 

### List of issues which are fixed by the PR
#63 

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.
