### PR TITLE
Fix setState() during build bug

### DIFF
--- a/packages/widgetbook/lib/src/providers/canvas_provider.dart
+++ b/packages/widgetbook/lib/src/providers/canvas_provider.dart
@@ -90,7 +90,8 @@ class CanvasProvider extends Provider<CanvasState> {
     }
   }
 
-  void selectStory(WidgetbookUseCase? story) {
+  Future<void> selectStory(WidgetbookUseCase? story) async {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
     selectedStoryRepository.setItem(story);
     emit(
       CanvasState(

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -1,5 +1,6 @@
-import 'package:flutter/material.dart';
+import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:widgetbook/src/configure_non_web.dart'
     if (dart.library.html) 'package:widgetbook/src/configure_web.dart';
 import 'package:widgetbook/src/models/app_info.dart';
@@ -124,7 +125,8 @@ class _WidgetbookState extends State<Widgetbook> {
                         );
                         final selectedStory =
                             selectStoryFromPath(path, stories);
-                        CanvasProvider.of(context)!.selectStory(selectedStory);
+                        unawaited(CanvasProvider.of(context)!
+                            .selectStory(selectedStory));
                       },
                     ),
                     routerDelegate: StoryRouterDelegate(


### PR DESCRIPTION
If using Flutter Inspector, exception throws when click select widget. I simply extract and delay setState process in route parse. I don't know it's a good practice, but works. 

### List of issues which are fixed by the PR
#92 setState() during build

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.
