### PR TITLE
Fixed dark theme of example app

### DIFF
--- a/examples/widgetbook_example/lib/themes/dark_theme.dart
+++ b/examples/widgetbook_example/lib/themes/dark_theme.dart
@@ -3,12 +3,11 @@ import 'package:meal_app/constants/border.dart';
 import 'package:meal_app/constants/color.dart';
 
 ThemeData get darkTheme {
-  return ThemeData(
-    primarySwatch: Colors.blue,
+  return ThemeData.dark().copyWith(
     textTheme: TextTheme().apply(
-      bodyColor: Colors.white,
-      displayColor: Colors.white,
-      decorationColor: Colors.white,
+      bodyColor: Colors.yellow,
+      displayColor: Colors.yellow,
+      decorationColor: Colors.yellow,
     ),
     scaffoldBackgroundColor: ColorConstants.backgroundColorDark,
     primaryColor: ColorConstants.primaryColor,

--- a/examples/widgetbook_example/widgetbook/widgetbook.dart
+++ b/examples/widgetbook_example/widgetbook/widgetbook.dart
@@ -68,10 +68,6 @@ class HotreloadWidgetbook extends StatelessWidget {
           data: lightTheme,
         ),
         WidgetbookTheme(
-          name: 'Light',
-          data: lightTheme,
-        ),
-        WidgetbookTheme(
           name: 'Dark',
           data: darkTheme,
         )


### PR DESCRIPTION
Fixed dark theme by 'inheriting' from `ThemeData.dark()`.

### List of issues which are fixed by the PR
#106 
