### PR TITLE
docs: added how to use widgetbook with a package

### DIFF
--- a/packages/widgetbook/README.md
+++ b/packages/widgetbook/README.md
@@ -381,7 +381,7 @@ Both the `scaffoldBuilder` and `useCaseBuilder` can be used to wrap the `Widget`
 
 A lot of app projects implement dedicated packages for UI components. These packages often do not define a (desktop) app. Therefore, it's hard to use Widgetbook for these packages. This section will explain how you can get Widgetbook running in such a scenario. 
 
-Lets assume you have set up a monorepo with the following folder structure with two packages `ui_components` and `core_api`:
+Let's assume you have set up a monorepo with the following folder structure with two packages `ui_components` and `core_api`:
 
 ```
 monorepo
@@ -391,7 +391,7 @@ monorepo
 │  ├─ core_api
 ```
 
-To create a widgetbook for the `ui_components` package we recommend to create a new folder named `widgetbooks` in the root of the repository and add a flutter (desktop) app named `ui_components_widgetbook`. The folder structure of your repository will look like this:
+To create a widgetbook for the `ui_components` package, we recommend to create a new folder named `widgetbooks` in the root of the repository and add a flutter (desktop) app named `ui_components_widgetbook`. The folder structure of your repository will look like this:
 
 ```
 monorepo

--- a/packages/widgetbook/README.md
+++ b/packages/widgetbook/README.md
@@ -377,6 +377,46 @@ Widgetbook<CupertinoThemeData>(
 
 Both the `scaffoldBuilder` and `useCaseBuilder` can be used to wrap the `Widget` with e.g. a `Scaffold` or some other `Widget` like a `Center`, `Container` or `Padding`.  
 
+# Using Widgetbook for a package
+
+A lot of app projects implement dedicated packages for UI components. These packages often do not define a (desktop) app. Therefore, it's hard to use Widgetbook for these packages. This section will explain how you can get Widgetbook running in such a scenario. 
+
+Lets assume you have set up a monorepo with the following folder structure with two packages `ui_components` and `core_api`:
+
+```
+monorepo
+├─ docs
+├─ packages
+│  ├─ ui_components
+│  ├─ core_api
+```
+
+To create a widgetbook for the `ui_components` package we recommend to create a new folder named `widgetbooks` in the root of the repository and add a flutter (desktop) app named `ui_components_widgetbook`. The folder structure of your repository will look like this:
+
+```
+monorepo
+├─ docs
+├─ packages
+│  ├─ ui_components
+│  ├─ core_api
+├─ widgetbooks
+│  ├─ ui_components_widgetbook
+│  │  ├─ lib
+│  │  ├─ macos
+│  │  ├─ pubspec.yaml
+```
+
+Make sure to modify `widgetbooks/ui_components_widgetbook/pubspec.yaml` to depend on `ui_components`: 
+
+`pubspec.yaml:`
+```
+dependencies:
+  ui_components:
+    path: ../../packages/ui_components
+```
+
+You can now use all exported `Widget`s from your library to compose your Widgetbook.
+
 # Known Issues
 
 - Hot reloading on web is currently not working properly. This is due to the fact that hot reloading is actually a restart. The problem is tracked in [widgetbook/issues/4](https://github.com/widgetbook/widgetbook/issues/4). For now we recommended to use MacOS or Windows as a platform for development.


### PR DESCRIPTION
Added section in the pub.dev docs on how to use widgetbook with a package that does not define a Flutter app.

### List of issues which are fixed by the PR
#59 