### PR TITLE
fix: app annotation exposes theme type property

### DIFF
--- a/packages/widgetbook_annotation/lib/src/widgetbook_app.dart
+++ b/packages/widgetbook_annotation/lib/src/widgetbook_app.dart
@@ -29,8 +29,7 @@ class WidgetbookApp {
     this.foldersExpanded = false,
     this.widgetsExpanded = false,
     this.constructor = WidgetbookConstructor.material,
-    this.themeType,
-  });
+  }) : themeType = null;
 
   /// Annotates a code element to creat a Cupertino-themed widgetbook main
   /// file in the same folder in which the annotated element is defined.
@@ -42,8 +41,7 @@ class WidgetbookApp {
     this.foldersExpanded = false,
     this.widgetsExpanded = false,
     this.constructor = WidgetbookConstructor.cupertino,
-    this.themeType,
-  });
+  }) : themeType = null;
 
   /// The type of the ThemeData.
   final Type? themeType;


### PR DESCRIPTION
removed `themeType` from the `WidgetbookApp.material` and `WidgetbookApp.cupertino` annotation constructors.

*Replace this paragraph with a description of what this PR is changing or adding, and why.*

### List of issues which are fixed by the PR
closes #129

### Checklist

- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.