### PR TITLE
fix: missing error reporting when widgetbook theme is used on properties

### DIFF
--- a/packages/widgetbook_generator/lib/resolvers/theme_resolver.dart
+++ b/packages/widgetbook_generator/lib/resolvers/theme_resolver.dart
@@ -20,11 +20,20 @@ class ThemeResolver extends GeneratorForAnnotation<WidgetbookTheme> {
       );
     }
 
+    if (element.kind != ElementKind.FUNCTION ||
+        !(element as FunctionElement).isStatic) {
+      throw InvalidGenerationSourceError(
+        'The $WidgetbookTheme annotation cannot be applied to static '
+        'functions.',
+        element: element,
+      );
+    }
+
     final isDefault = annotation.read('isDefault').boolValue;
     final name = annotation.read('name').stringValue;
 
     final themeData = WidgetbookThemeData(
-      name: element.name!,
+      name: element.name,
       importStatement: element.importStatement,
       dependencies: element.dependencies,
       isDefault: isDefault,


### PR DESCRIPTION
Added error message when `@WidgetbookTheme` is used on properties or non-static functions.

### List of issues which are fixed by the PR
closes #130