### PR TITLE
fix: widgetbook theme dark does not exist

### DIFF
--- a/packages/widgetbook_annotation/README.md
+++ b/packages/widgetbook_annotation/README.md
@@ -227,8 +227,8 @@ Generator skips top root `src` folder from navigation panel. Many Flutter projec
 
 ### Example
 
-```dart
-@WidgetbookTheme.dark()
+```
+@WidgetbookTheme(name: 'Dark', isDefault: true)
 ThemeData getDarkTheme() => ThemeData(
       primarySwatch: Colors.blue,
     );

--- a/packages/widgetbook_annotation/example/main.dart
+++ b/packages/widgetbook_annotation/example/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 
-@WidgetbookTheme.dark()
+@WidgetbookTheme(name: 'Dark', isDefault: true)
 ThemeData darkTheme() => ThemeData.dark();
 
 @WidgetbookUseCase(name: 'Default', type: CustomPadding)


### PR DESCRIPTION
Replaced `@WidgetbookTheme.dark()` with `@WidgetbookTheme(name: ...)` for the example file and the documentation. 

### List of issues which are fixed by the PR
closes #133 