### PR TITLE
fix: scaffold messenger opens in widgetbook

### DIFF
--- a/packages/widgetbook/lib/src/rendering/builders/scaffold_builder.dart
+++ b/packages/widgetbook/lib/src/rendering/builders/scaffold_builder.dart
@@ -7,8 +7,10 @@ ScaffoldBuilderFunction get defaultScaffoldBuilder => (
       Widget child,
     ) {
       if (frame.allowsDevices) {
-        return Scaffold(
-          body: child,
+        return ScaffoldMessenger(
+          child: Scaffold(
+            body: child,
+          ),
         );
       }
 

--- a/packages/widgetbook/lib/src/workbench/renderer.dart
+++ b/packages/widgetbook/lib/src/workbench/renderer.dart
@@ -77,10 +77,12 @@ class Renderer<CustomTheme> extends StatelessWidget {
                           return renderingState.scaffoldBuilder(
                             context,
                             frame,
-                            renderingState.useCaseBuilder(
-                              context,
-                              useCaseBuilder(context),
-                            ),
+                            Builder(builder: (context) {
+                              return renderingState.useCaseBuilder(
+                                context,
+                                useCaseBuilder(context),
+                              );
+                            }),
                           );
                         },
                       ),


### PR DESCRIPTION
Inserted ScaffoldMessenger into the tree based on the default `ScaffoldBuilder`

### List of issues which are fixed by the PR
closes #148 