### PR TITLE
fix: navigation tree collapsing and expanding does not work

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.8-beta
+
+- fix: navigation tree collapsing and expanding does not work ([#159](https://github.com/widgetbook/widgetbook/issues/159))
+
 ## 2.0.7-beta
 
 - fix: expanding of elements within the navigation is not working ([#156](https://github.com/widgetbook/widgetbook/issues/156))

--- a/packages/widgetbook/lib/src/navigation/organizer_provider.dart
+++ b/packages/widgetbook/lib/src/navigation/organizer_provider.dart
@@ -118,13 +118,13 @@ class OrganizerProvider extends StateChangeNotifier<OrganizerState> {
   /// the `expanded`
   void setExpandedRecursive(
       List<ExpandableOrganizer> organizers, bool expanded) {
+    // Since this is modifying the object directly instead of modifying via
+    // copyWith, we need to call notifyListeners and are not emmitting a new
+    // state object. The state will be adjusted by adjusted the object.
     for (final e in organizers) {
       _setExpandedRecursive(e, expanded);
     }
-    state = OrganizerState(
-      allCategories: state.allCategories,
-      filteredCategories: state.filteredCategories,
-      searchTerm: state.searchTerm,
-    );
+
+    notifyListeners();
   }
 }

--- a/packages/widgetbook/lib/src/widgets/expanders/expand_button.dart
+++ b/packages/widgetbook/lib/src/widgets/expanders/expand_button.dart
@@ -26,10 +26,10 @@ class _ExpandButtonState extends State<ExpandButton> {
     String tooltip;
     if (widget.expandTo) {
       icon = Icons.expand_more;
-      tooltip = 'Expand';
+      tooltip = 'Expand all';
     } else {
       icon = Icons.expand_less;
-      tooltip = 'Collapse';
+      tooltip = 'Collapse all';
     }
     return Tooltip(
       message: tooltip,

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widgetbook
 description: A flutter storybook that helps professionals and teams to catalogue their widgets.
-version: 2.0.7-beta
+version: 2.0.8-beta
 homepage: https://www.widgetbook.io?utm_source=youtube&utm_medium=link&utm_campaign=widgetbook
 repository: https://github.com/widgetbook/widgetbook
 issue_tracker: https://github.com/widgetbook/widgetbook/issues


### PR DESCRIPTION
fixed emitting of correct states when collapse all and expand all is clicked. 