### PR TITLE
fix(widgetbook): useCaseBuilder is called with old context

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.2
+
+- fix: `useCaseBuilder` is called with old context ([#180](https://github.com/widgetbook/widgetbook/issues/180))
+
 ## 2.1.1
 
 - fix: knob values do not update when usecase changes ([#170](https://github.com/widgetbook/widgetbook/issues/170))

--- a/packages/widgetbook/lib/src/workbench/renderer.dart
+++ b/packages/widgetbook/lib/src/workbench/renderer.dart
@@ -80,7 +80,9 @@ class Renderer<CustomTheme> extends StatelessWidget {
                             Builder(builder: (context) {
                               return renderingState.useCaseBuilder(
                                 context,
-                                useCaseBuilder(context),
+                                Builder(
+                                  builder: useCaseBuilder,
+                                ),
                               );
                             }),
                           );

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widgetbook
 description: A flutter storybook that helps professionals and teams to catalogue their widgets.
-version: 2.1.0
+version: 2.1.2
 homepage: https://www.widgetbook.io?utm_source=youtube&utm_medium=link&utm_campaign=widgetbook
 repository: https://github.com/widgetbook/widgetbook
 issue_tracker: https://github.com/widgetbook/widgetbook/issues


### PR DESCRIPTION
- fixes reference to old `context`.

### List of issues which are fixed by the PR
closes #180 

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Discord]: https://discord.com/invite/zT4AMStAJA
