### PR TITLE
fix: dialog shows up in Widgetbook instead of the simulated device

### DIFF
--- a/packages/widgetbook/lib/src/rendering/builders/app_builder.dart
+++ b/packages/widgetbook/lib/src/rendering/builders/app_builder.dart
@@ -4,8 +4,8 @@ import 'package:go_router/go_router.dart';
 
 const AppBuilderFunction defaultAppBuilder = _defaultAppBuilderMethod;
 
-Widget _defaultAppBuilderMethod(BuildContext context, Widget child) {
-  final _router = GoRouter(
+GoRouter getRouter(Widget child) {
+  return GoRouter(
     routes: [
       GoRoute(
         path: '/',
@@ -13,6 +13,10 @@ Widget _defaultAppBuilderMethod(BuildContext context, Widget child) {
       ),
     ],
   );
+}
+
+Widget _defaultAppBuilderMethod(BuildContext context, Widget child) {
+  final _router = getRouter(child);
   return WidgetsApp.router(
     color: Colors.transparent,
     builder: (context, childWidget) {
@@ -25,15 +29,19 @@ Widget _defaultAppBuilderMethod(BuildContext context, Widget child) {
 
 AppBuilderFunction get materialAppBuilder =>
     (BuildContext context, Widget child) {
-      return MaterialApp(
-        home: child,
+      final _router = getRouter(child);
+      return MaterialApp.router(
+        routerDelegate: _router.routerDelegate,
+        routeInformationParser: _router.routeInformationParser,
       );
     };
 
 AppBuilderFunction get cupertinoAppBuilder =>
     (BuildContext context, Widget child) {
-      return CupertinoApp(
-        home: child,
+      final _router = getRouter(child);
+      return CupertinoApp.router(
+        routerDelegate: _router.routerDelegate,
+        routeInformationParser: _router.routeInformationParser,
       );
     };
 


### PR DESCRIPTION
Added `Navigator` into the tree of the previewed app which will cause the Dialog to show up within the simulated app. However, for this to work properly showDialog has to be called with its `useRootNavigator` parameter to be set to `false`: 

```
showDialog(
  context: context,
  useRootNavigator: false,
  builder: (_) => const AlertDialog(
    title: Text('Dialog Title'),
    content: Text('This is my content'),
  ),
);
```

### List of issues which are fixed by the PR
closes #172
closes #190 

### Checklist

- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing.