### PR TITLE
docs: changed file from .dart to .aot

### DIFF
--- a/docs/widgetbook-cloud/hosting.mdx
+++ b/docs/widgetbook-cloud/hosting.mdx
@@ -51,7 +51,7 @@ Since the CLI is AOT-compiled, the `cli-v1.aot` file requires the [`dartaotrunti
 The `dartaotruntime` is located at `<PathToRootFolderOfSdk>/flutter/bin/cache/dart-sdk/bin` and can be executed like this:
 
 ```bash
-dartaotruntime cli-v1.dart 
+dartaotruntime cli-v1.aot 
 ```
 
 ## GitHub


### PR DESCRIPTION
corrected the file size of aot compiled version