### PR TITLE
docs(knobs): link to example file properly

### DIFF
--- a/docs/widgetbook/knobs.mdx
+++ b/docs/widgetbook/knobs.mdx
@@ -45,4 +45,4 @@ All `Knob`s have the following inherited properties to customize how the knobs a
 | options         | `T`       |
 
 You can see an example of this and different knobs available
-[here](examples/knobs_example/lib/widgetbook.dart).
+[here](https://github.com/widgetbook/widgetbook/blob/main/examples/knobs_example/lib/widgetbook.dart).


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why.*

This PR changes link to example file for knobs because the link is broken.

### List of issues which are fixed by the PR

- #207 

### Checklist

- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] All existing and new tests are passing.