### PR TITLE
fix: preview app shows debug banner

### DIFF
--- a/packages/widgetbook/lib/src/rendering/builders/app_builder.dart
+++ b/packages/widgetbook/lib/src/rendering/builders/app_builder.dart
@@ -31,6 +31,7 @@ AppBuilderFunction get materialAppBuilder =>
     (BuildContext context, Widget child) {
       final _router = getRouter(child);
       return MaterialApp.router(
+        debugShowCheckedModeBanner: false,
         routerDelegate: _router.routerDelegate,
         routeInformationParser: _router.routeInformationParser,
       );


### PR DESCRIPTION
Set `debugShowCheckedModeBanner` to `false`. 

### List of issues which are fixed by the PR
closes #202 
closes #212

### Checklist

- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.
