### PR TITLE
docs(widgetbook-cloud): :bug: removed faulty markdown from review documentation

### DIFF
--- a/docs/widgetbook-cloud/review.mdx
+++ b/docs/widgetbook-cloud/review.mdx
@@ -58,8 +58,6 @@ The CLI extracts information from `widgetbook_generator` and also obtains branch
 For this to work properly make sure to checkout your code with `fetch-depth: '0'`. 
 Also make sure to run the `build_runner` before calling the `CLI`.
 
-> Note: In the example below you'll find the `--base-commit` parameter which is just set to `$`. This is incorrect and should be the following value: ${{ github.event.pull_request.base.sha }}. This is a problem with our documentation and we're already working on a fix.
-
 ```yaml
 name: Build 
 on: [pull_request]


### PR DESCRIPTION
Removed faulty markdown from review documentation. 

This is related to https://github.com/invertase/docs.page/issues/215