### PR TITLE
docs: changed `description` type to `string?`

### DIFF
--- a/docs/widgetbook/knobs.mdx
+++ b/docs/widgetbook/knobs.mdx
@@ -28,7 +28,7 @@ All `Knob`s have the following inherited properties to customize how the knobs a
 | Property | Type | Description |
 | --- | --- | --- |
 | `label` | `String` | Labels the knob by giving it a title. The `label` must be unique for the `WidgetbookUseCase`. |
-| `description` | `String` | A text which describes what the knob does. This can be used as a documentation within Widgetbook and helps your team member understand how to operate the knob. |
+| `description` | `String?` | A text which describes what the knob does. This can be used as a documentation within Widgetbook and helps your team member understand how to operate the knob. |
 
 ## Available Knobs
 


### PR DESCRIPTION
changed the `description from `string` to the actual one from the implementation, which is `string?`.