### PR TITLE
fix: :bug: rename cli to widgetbook

### DIFF
--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-beta.7
+
+- fix: change name of executable from `widgetbook-cli` to `widgetbook`.
+
 ## 2.0.0-beta.6
 
 - Initial version.

--- a/packages/widgetbook_cli/README.md
+++ b/packages/widgetbook_cli/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-`widgetbook-cli` allows developers to upload their Widgetbook to Widgetbook Cloud.
+`widgetbook_cli` allows developers to upload their Widgetbook to Widgetbook Cloud.
 
 Currently the CLI supports two features:
 - uploading a [Widgetbook Build](/widgetbook-cloud/hosting)
@@ -22,7 +22,7 @@ dart pub global activate widgetbook_cli
 
 Run the CLI by using
 ```bash
-widgetbook-cli [<options>]
+widgetbook [<options>]
 ```
 
 ### Arguments

--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widgetbook_cli
 description: A command-line application to upload Widgetbook builds to Widgetbook Cloud.
-version: 2.0.0-beta.6
+version: 2.0.0-beta.7
 homepage: https://www.widgetbook.io?utm_source=pub.dev&utm_medium=link&utm_campaign=widgetbook_models
 repository: https://github.com/widgetbook/widgetbook
 issue_tracker: https://github.com/widgetbook/widgetbook/issues
@@ -29,6 +29,6 @@ dependencies:
   version: ^2.0.0
 
 executables:
-  widgetbook-cli: cli_production
-  widgetbook-cli-staging: cli_staging
-  widgetbook-cli-debug: cli_debug
+  widgetbook: cli_production
+  widgetbook_staging: cli_staging
+  widgetbook_debug: cli_debug


### PR DESCRIPTION
rename executable of `widgetbook_cli` from `widgetbook-cli` to `widgetbook`.

### List of issues which are fixed by the PR
- closes #254 