### PR TITLE
docs: :bug: change relative links to global links

### DIFF
--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-beta.9
+
+- docs: change relative links to global links.
+
 ## 2.0.0-beta.8
 
 - feat: change `path`, `branch`, `commit`, and `git-provider` arguments from mandatory to optional.

--- a/packages/widgetbook_cli/README.md
+++ b/packages/widgetbook_cli/README.md
@@ -3,8 +3,8 @@
 `widgetbook_cli` allows developers to upload their Widgetbook to Widgetbook Cloud.
 
 Currently the CLI supports two features:
-- uploading a [Widgetbook Build](/widgetbook-cloud/hosting)
-- uploading a [Widgetbook Review](/widgetbook-cloud/review)
+- uploading a [Widgetbook Build](https://docs.widgetbook.io/widgetbook-cloud/hosting)
+- uploading a [Widgetbook Review](https://docs.widgetbook.io/widgetbook-cloud/review)
 
 ## Repository
 
@@ -32,7 +32,7 @@ The CLI accepts the following arguments.
 | Argument         | Mandatory | Description |
 | ---------------- | --------- | ----------- |
 | `--path`         | ➖        | The path to your project. Defaults to `./`. |
-| `--api-key`      | ✅        | The project specific API key for Widgetbook Cloud. See [How to create an API key](/widgetbook-cloud/hosting#how-to-create-an-api-key).|
+| `--api-key`      | ✅        | The project specific API key for Widgetbook Cloud. See [How to create an API key](https://docs.widgetbook.io/widgetbook-cloud/hosting#how-to-create-an-api-key).|
 | `--branch`       | ➖        | The name of the branch for which the Widgetbook is uploaded. Defaults to the current git branch. |
 | `--commit`       | ➖        | The SHA hash of the commit for which the Widgetbook is uploaded. Defaults to the last commit of the current git branch. |
 | `--repository`   | ✅        | The name of the repository for which the Widgetbook is uploaded.|

--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widgetbook_cli
 description: A command-line application to upload Widgetbook builds to Widgetbook Cloud.
-version: 2.0.0-beta.8
+version: 2.0.0-beta.9
 homepage: https://www.widgetbook.io?utm_source=pub.dev&utm_medium=link&utm_campaign=widgetbook_models
 repository: https://github.com/widgetbook/widgetbook
 issue_tracker: https://github.com/widgetbook/widgetbook/issues


### PR DESCRIPTION
- change relative links from docs.page to global links. Links will now forward to [docs.widgetbook.io](https://docs.widgetbook.io).

### List of issues which are fixed by the PR
- closes #268 
