### PR TITLE
fix: preview app shows debug banner in other theme than material

### DIFF
--- a/packages/widgetbook/lib/src/rendering/builders/app_builder.dart
+++ b/packages/widgetbook/lib/src/rendering/builders/app_builder.dart
@@ -22,6 +22,7 @@ Widget _defaultAppBuilderMethod(BuildContext context, Widget child) {
     builder: (context, childWidget) {
       return childWidget ?? child;
     },
+    debugShowCheckedModeBanner: false,
     routeInformationParser: _router.routeInformationParser,
     routerDelegate: _router.routerDelegate,
   );
@@ -41,6 +42,7 @@ AppBuilderFunction get cupertinoAppBuilder =>
     (BuildContext context, Widget child) {
       final _router = getRouter(child);
       return CupertinoApp.router(
+        debugShowCheckedModeBanner: false,
         routerDelegate: _router.routerDelegate,
         routeInformationParser: _router.routeInformationParser,
       );


### PR DESCRIPTION
Set `debugShowCheckedModeBanner: false` for other app builder than only `MaterialApp`.

### List of issues which are fixed by the PR
Related to  #202, #212

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
