### PR TITLE
fix(widgetbook): resolve `WidgetsBinding` null warnings

### DIFF
--- a/packages/widgetbook/lib/src/styled_widgets/styled_scaffold.dart
+++ b/packages/widgetbook/lib/src/styled_widgets/styled_scaffold.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../utils/ambiguate.dart';
+
 class StyledScaffold extends StatelessWidget {
   const StyledScaffold({
     super.key,
@@ -11,7 +13,10 @@ class StyledScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: WidgetsBinding.instance?.focusManager.primaryFocus?.unfocus,
+      onTap: ambiguate(WidgetsBinding.instance)!
+          .focusManager
+          .primaryFocus
+          ?.unfocus,
       child: Scaffold(
         body: body,
       ),

--- a/packages/widgetbook/lib/src/styled_widgets/styled_scaffold.dart
+++ b/packages/widgetbook/lib/src/styled_widgets/styled_scaffold.dart
@@ -11,7 +11,7 @@ class StyledScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: WidgetsBinding.instance.focusManager.primaryFocus?.unfocus,
+      onTap: WidgetsBinding.instance?.focusManager.primaryFocus?.unfocus,
       child: Scaffold(
         body: body,
       ),

--- a/packages/widgetbook/lib/src/utils/ambiguate.dart
+++ b/packages/widgetbook/lib/src/utils/ambiguate.dart
@@ -1,0 +1,13 @@
+/// This allows a value of type T or T?
+/// to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become
+/// non-nullable can still be used with `!` and `?`
+/// to support older versions of the API as well.
+///
+/// It's mainly used to support [SchedulerBinding] and
+/// [WidgetsBinding] on Flutter version 2 and 3.
+///
+/// For more info:
+/// https://docs.flutter.dev/release/release-notes/release-notes-3.0.0#your-code
+T? ambiguate<T>(T? value) => value;


### PR DESCRIPTION
It could not access to`FocusManager` because the instance of `WidgetsBinding` could be null.

Environment:
- widgetbook@2.4.1
- Flutter@2.10.5


### List of issues which are fixed by the PR

Error:
```
Property `focusManager` cannot be accessed on `WidgetBinding` because it is potentially null.
```

### Screenshots

<img width="1391" alt="image" src="https://user-images.githubusercontent.com/3519924/184089097-7dea9c77-8620-463e-9767-67883f7653a0.png">


### Checklist

- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing.

