### PR TITLE
Fixes mason brick widgetbook_starter usage in the docs

### DIFF
--- a/docs/widgetbook/setup.mdx
+++ b/docs/widgetbook/setup.mdx
@@ -20,7 +20,7 @@ Checkout the [widgetbook_starter](https://brickhub.dev/bricks/widgetbook_starter
 dart pub global activate mason_cli
 mason init
 mason add widgetbook_starter
-mason make --name "Name of your widgetbook"
+mason make widgetbook_starter --name "Name of your widgetbook"
 ```
 
 ## Create a Widgetbook manually


### PR DESCRIPTION
This PR fixes the command to generate the initial code using widgetbook_starter brick.

### List of issues which are fixed by the PR
No issue

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
