### PR TITLE
fix(cli): :bug: CLI fails on environments without terminal

### DIFF
--- a/packages/widgetbook_cli/bin/std/stdin_wrapper.dart
+++ b/packages/widgetbook_cli/bin/std/stdin_wrapper.dart
@@ -1,0 +1,5 @@
+import 'dart:io';
+
+class StdInWrapper {
+  bool get hasTerminal => stdin.hasTerminal;
+}

--- a/packages/widgetbook_cli/test/commands/publish_test.dart
+++ b/packages/widgetbook_cli/test/commands/publish_test.dart
@@ -17,6 +17,7 @@ import '../../bin/review/devices/device_parser.dart';
 import '../../bin/review/locales/locales_parser.dart';
 import '../../bin/review/text_scale_factors/text_scale_factor_parser.dart';
 import '../../bin/review/themes/theme_parser.dart';
+import '../../bin/std/stdin_wrapper.dart';
 import '../helpers/test_data.dart';
 import '../mocks/mocks.dart';
 
@@ -33,6 +34,7 @@ void main() {
     late Logger logger;
     late GitDir gitDir;
     late CiWrapper ciWrapper;
+    late StdInWrapper stdInWrapper;
     late ArgResults argResults;
     late PublishCommand publishCommand;
     late WidgetbookHttpClient widgetbookHttpClient;
@@ -53,6 +55,7 @@ void main() {
       gitDir = MockGitDir();
       argResults = MockArgResults();
       ciWrapper = MockCiWrapper();
+      stdInWrapper = MockStdInWrapper();
       widgetbookHttpClient = MockWidgetbookHttpClient();
       widgetbookZipEncoder = MockWidgetbookZipEncoder();
       localFileSystem = MockLocalFileSystem();
@@ -141,6 +144,7 @@ void main() {
       when(() => argResults['path'] as String).thenReturn(tempDir.path);
       when(() => gitDir.getActorName())
           .thenAnswer((_) => Future.value('John Doe'));
+      when(() => stdInWrapper.hasTerminal).thenReturn(true);
       when(
         () => logger.chooseOne(
           'Would you like to proceed anyways?',

--- a/packages/widgetbook_cli/test/mocks/command_mocks.dart
+++ b/packages/widgetbook_cli/test/mocks/command_mocks.dart
@@ -14,6 +14,7 @@ import '../../bin/review/devices/device_parser.dart';
 import '../../bin/review/locales/locales_parser.dart';
 import '../../bin/review/text_scale_factors/text_scale_factor_parser.dart';
 import '../../bin/review/themes/theme_parser.dart';
+import '../../bin/std/stdin_wrapper.dart';
 
 class MockLogger extends Mock implements Logger {}
 
@@ -38,6 +39,8 @@ class MockLocalFileSystem extends Mock implements LocalFileSystem {}
 class MockThemeParser extends Mock implements ThemeParser {}
 
 class MockCiWrapper extends Mock implements CiWrapper {}
+
+class MockStdInWrapper extends Mock implements StdInWrapper {}
 
 class MockLocaleParser extends Mock implements LocaleParser {}
 


### PR DESCRIPTION
- adds check if terminal (`stdin`) exists in the runtime environment which will cause the expected user input to fail
    - this might happen on CI/CD pipelines or when debugging the code since no input from the user can be obtained

### List of issues which are fixed by the PR
- closes #348 

### Screenshots
*If applicable, add screenshots to help explain the changes.*
