### PR TITLE
chore: add core scope to conventional commits

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "mdx-preview.preview.useVscodeMarkdownStyles": false,
     "conventionalCommits.scopes": [
         "widgetbook",
-        "cli"
+        "cli",
+        "core"
     ]
 }


### PR DESCRIPTION
- adds the `core` scope to the conventional commits settngs