### PR TITLE
chore: bump go_router version

### DIFF
--- a/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
@@ -32,7 +32,7 @@ String _getQueryParameter<T>(BuildContext context) {
   final selectedItems =
       context.read<ThemeSettingProvider<T>>().value.activeThemes;
 
-  return selectedItems.map((e) => e).join(',');
+  return selectedItems.map((e) => e.name).join(',');
 }
 
 int _selectionCount<T>(BuildContext context) {

--- a/packages/widgetbook/lib/src/navigation/router.dart
+++ b/packages/widgetbook/lib/src/navigation/router.dart
@@ -37,7 +37,7 @@ GoRouter createRouter({
   required PreviewProvider previewProvider,
 }) {
   final router = GoRouter(
-    redirect: (routerState) {
+    redirect: (context, routerState) {
       final path = routerState.queryParams['path'];
 
       previewProvider.selectUseCaseByPath(path);

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   freezed_annotation: ^2.1.0
-  go_router: ^4.2.8
+  go_router: ^5.2.1
   nested: ^1.0.0
   provider: ^6.0.2
   widgetbook_models: ^0.0.7


### PR DESCRIPTION
- bumps `go_router` version to `5.x.x`
- fixes how theme is displayed in the route  