### PR TITLE
fixes #383: media query support

### DIFF
--- a/packages/widgetbook/lib/src/workbench/renderer.dart
+++ b/packages/widgetbook/lib/src/workbench/renderer.dart
@@ -64,44 +64,57 @@ class Renderer<CustomTheme> extends StatelessWidget {
                 context,
                 Builder(
                   builder: (context) {
-                    return renderingState.localizationBuilder(
+                    return renderingState.deviceFrameBuilder(
                       context,
-                      workbenchProvider.locales,
-                      localizationsDelegates?.toList(),
-                      locale,
+                      device,
+                      frame,
+                      orientation,
                       Builder(
                         builder: (context) {
-                          return renderingState.themeBuilder(
+                          return renderingState.localizationBuilder(
                             context,
-                            theme,
+                            workbenchProvider.locales,
+                            localizationsDelegates?.toList(),
+                            locale,
                             Builder(
                               builder: (context) {
-                                return Builder(
-                                  builder: (context) {
-                                    return renderingState.textScaleBuilder(
-                                      context,
-                                      textScaleFactor,
-                                      Builder(
+                                return renderingState.themeBuilder(
+                                  context,
+                                  theme,
+                                  Builder(
+                                    builder: (context) {
+                                      return Builder(
                                         builder: (context) {
-                                          return renderingState.scaffoldBuilder(
+                                          return renderingState
+                                              .textScaleBuilder(
                                             context,
-                                            frame,
+                                            textScaleFactor,
                                             Builder(
                                               builder: (context) {
                                                 return renderingState
-                                                    .useCaseBuilder(
+                                                    .scaffoldBuilder(
                                                   context,
+                                                  frame,
                                                   Builder(
-                                                    builder: useCaseBuilder,
+                                                    builder: (context) {
+                                                      return renderingState
+                                                          .useCaseBuilder(
+                                                        context,
+                                                        Builder(
+                                                          builder:
+                                                              useCaseBuilder,
+                                                        ),
+                                                      );
+                                                    },
                                                   ),
                                                 );
                                               },
                                             ),
                                           );
                                         },
-                                      ),
-                                    );
-                                  },
+                                      );
+                                    },
+                                  ),
                                 );
                               },
                             ),


### PR DESCRIPTION
PR description: fixes #383 There is support of media query data from `renderingState.deviceFrameBuilder` but it is getting override by `renderingState.appBuilder` as `renderingState.appBuilder` uses `MaterialApp.router` which has it's own MediaQuery data of web window.

### List of issues which are fixed by the PR
issue: #383

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
