### PR TITLE
Update Go_Router from version '>=3.0.5' to version '>=5.2.0'

### DIFF
--- a/packages/widgetbook/lib/src/navigation/router.dart
+++ b/packages/widgetbook/lib/src/navigation/router.dart
@@ -78,7 +78,7 @@ GoRouter createRouter<CustomTheme>({
   required PreviewProvider previewProvider,
 }) {
   final router = GoRouter(
-    redirect: (routerState) {
+    redirect: (context, routerState) {
       final theme = routerState.queryParams['theme'];
       final locale = routerState.queryParams['locale'];
       final device = routerState.queryParams['device'];

--- a/packages/widgetbook/lib/src/rendering/builders/app_builder.dart
+++ b/packages/widgetbook/lib/src/rendering/builders/app_builder.dart
@@ -23,6 +23,7 @@ Widget _defaultAppBuilderMethod(BuildContext context, Widget child) {
       return childWidget ?? child;
     },
     debugShowCheckedModeBanner: false,
+    routeInformationProvider: _router.routeInformationProvider,
     routeInformationParser: _router.routeInformationParser,
     routerDelegate: _router.routerDelegate,
   );
@@ -33,6 +34,7 @@ AppBuilderFunction get materialAppBuilder =>
       final _router = getRouter(child);
       return MaterialApp.router(
         debugShowCheckedModeBanner: false,
+        routeInformationProvider: _router.routeInformationProvider,
         routerDelegate: _router.routerDelegate,
         routeInformationParser: _router.routeInformationParser,
       );

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -361,6 +361,7 @@ class _WidgetbookState<CustomTheme> extends State<Widgetbook<CustomTheme>> {
         ChangeNotifierProvider.value(value: appInfoProvider),
       ],
       child: MaterialApp.router(
+        routeInformationProvider: goRouter.routeInformationProvider,
         routeInformationParser: goRouter.routeInformationParser,
         routerDelegate: goRouter.routerDelegate,
         title: widget.appInfo.name,

--- a/packages/widgetbook/pubspec.lock
+++ b/packages/widgetbook/pubspec.lock
@@ -232,7 +232,7 @@ packages:
       name: go_router
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "6.0.1"
   graphs:
     dependency: transitive
     description:
@@ -562,4 +562,4 @@ packages:
     version: "3.1.1"
 sdks:
   dart: ">=2.17.0 <3.0.0"
-  flutter: ">=2.0.0"
+  flutter: ">=3.3.0"

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   freezed_annotation: ^2.0.3
-  go_router: ">=3.0.5"
+  go_router: ">=5.2.0"
   provider: ^6.0.2
   widgetbook_models: ^0.0.7
 


### PR DESCRIPTION
This PR updates the GoRouter from version '>=3.0.5' to version '>=5.2.0' on packages/widgetbook/pubspec.yaml
There is also a change on every use of 'MaterialApp.router()', where a new argument 'routeInformationProvider' is passed to the function, the value comes from the' GoRouter' instances

There is also a new parameter on the redirect callback of GoRouter, a BuildContext.

The changes are based on the GoRouter migration plans, you can find details about here:

(new BuildContext argument)
https://docs.google.com/document/d/10l22o4ml4Ss83UyzqUC8_xYOv_QjZEi80lJDNE4q7wM/edit?pli=1&resourcekey=0-U-BXBQzNfkk4v241Ow-vZg

(new routeInformationProvider argument)
https://docs.google.com/document/d/1T2LmzMj5HpD7hEexXL4Xz6vqoJD81bEGaa9NsV24faw/edit?resourcekey=0-PuQbtDVl7ZabpJ2B9AHWUg

This was made to solve the issue 342, listed below

### List of issues which are fixed by the PR
 https://github.com/widgetbook/widgetbook/issues/342

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
