### PR TITLE
test(widgetbook): :white_check_mark: `DeviceFrameAddon` overrides `MediaQuery`

### DIFF
--- a/packages/widgetbook/test/src/addons/frame_addon/frames/device_frame/device_frame_test.dart
+++ b/packages/widgetbook/test/src/addons/frame_addon/frames/device_frame/device_frame_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:widgetbook/src/addons/frame_addon/addons/device_addon/device_provider.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import '../../../../../helper/widget_test_helper.dart';
+import '../../../utils/addons.dart';
+import '../../../utils/extensions/widget_tester_extension.dart';
+
+void main() {
+  group(
+    '$DefaultDeviceFrame',
+    () {
+      testWidgets(
+        'overrides $MediaQuery',
+        (tester) async {
+          const phone = Apple.iPhone13;
+          final devices = [phone];
+          final frame = DefaultDeviceFrame(
+            setting: DeviceSetting.firstAsSelected(
+              devices: devices,
+            ),
+          );
+          await tester.pumpWidgetWithMaterialApp(
+            ChangeNotifierProvider(
+              create: (c) => DeviceProvider(
+                DeviceSetting(devices: devices, activeDevice: phone),
+              ),
+              child: Builder(
+                builder: (context) {
+                  return frame.builder(
+                    context,
+                    const Text(
+                      'Text',
+                      key: textKey,
+                    ),
+                  );
+                },
+              ),
+            ),
+          );
+
+          final context = tester.findContextByKey(textKey);
+          final mediaQuery = MediaQuery.of(context);
+
+          expect(
+            mediaQuery.size.width,
+            equals(phone.resolution.logicalSize.width),
+          );
+
+          expect(
+            mediaQuery.size.height,
+            equals(phone.resolution.logicalSize.height),
+          );
+
+          expect(
+            mediaQuery.devicePixelRatio,
+            equals(phone.resolution.scaleFactor),
+          );
+        },
+      );
+    },
+  );
+}

--- a/packages/widgetbook/test/src/addons/frame_addon/frames/no_frame/no_frame_test.dart
+++ b/packages/widgetbook/test/src/addons/frame_addon/frames/no_frame/no_frame_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import '../../../../../helper/widget_test_helper.dart';
+import '../../../utils/addons.dart';
+import '../../../utils/extensions/widget_tester_extension.dart';
+
+void main() {
+  group(
+    '$NoFrame',
+    () {
+      testWidgets(
+        'overrides $MediaQuery',
+        (tester) async {
+          tester.binding.window.physicalSizeTestValue = const Size(800, 600);
+          final frame = NoFrame();
+          await tester.pumpWidgetWithMaterialApp(
+            Builder(
+              builder: (context) {
+                return frame.builder(
+                  context,
+                  const Text(
+                    'Text',
+                    key: textKey,
+                  ),
+                );
+              },
+            ),
+          );
+
+          final context = tester.findContextByKey(textKey);
+          final mediaQuery = MediaQuery.of(context);
+          final window = tester.binding.window;
+
+          expect(
+            mediaQuery.size.width,
+            equals(window.physicalSize.width / window.devicePixelRatio),
+          );
+
+          expect(
+            mediaQuery.size.height,
+            equals(window.physicalSize.height / window.devicePixelRatio),
+          );
+
+          expect(
+            mediaQuery.devicePixelRatio,
+            equals(window.devicePixelRatio),
+          );
+        },
+      );
+    },
+  );
+}

--- a/packages/widgetbook/test/src/addons/frame_addon/frames/widgetbook_frame/widgetbook_frame_test.dart
+++ b/packages/widgetbook/test/src/addons/frame_addon/frames/widgetbook_frame/widgetbook_frame_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:widgetbook/src/addons/frame_addon/addons/device_addon/device_provider.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import '../../../../../helper/widget_test_helper.dart';
+import '../../../utils/addons.dart';
+import '../../../utils/extensions/widget_tester_extension.dart';
+
+void main() {
+  group(
+    '$WidgetbookFrame',
+    () {
+      testWidgets(
+        'overrides $MediaQuery',
+        (tester) async {
+          const phone = Apple.iPhone13;
+          final devices = [phone];
+          final frame = WidgetbookFrame(
+            setting: DeviceSetting.firstAsSelected(
+              devices: devices,
+            ),
+          );
+          await tester.pumpWidgetWithMaterialApp(
+            ChangeNotifierProvider(
+              create: (c) => DeviceProvider(
+                DeviceSetting(devices: devices, activeDevice: phone),
+              ),
+              child: Builder(
+                builder: (context) {
+                  return frame.builder(
+                    context,
+                    const Text(
+                      'Text',
+                      key: textKey,
+                    ),
+                  );
+                },
+              ),
+            ),
+          );
+
+          final context = tester.findContextByKey(textKey);
+          final mediaQuery = MediaQuery.of(context);
+
+          expect(
+            mediaQuery.size.width,
+            equals(phone.resolution.logicalSize.width),
+          );
+
+          expect(
+            mediaQuery.size.height,
+            equals(phone.resolution.logicalSize.height),
+          );
+
+          expect(
+            mediaQuery.devicePixelRatio,
+            equals(phone.resolution.scaleFactor),
+          );
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
- add test to check if `MediaQuery` is correctly applied for `DefaultDeviceFrame` and `WidgetbookFrame`

### List of issues that are fixed by the PR
- closes #119 
- closes #383 
