### PR TITLE
fix(cli): :bug: identifying merge commits with incorrect keywords

### DIFF
--- a/packages/widgetbook_cli/bin/commands/publish.dart
+++ b/packages/widgetbook_cli/bin/commands/publish.dart
@@ -216,7 +216,7 @@ class PublishCommand extends WidgetbookCommand {
     final commits = await gitDir.commits();
     if (_ciWrapper.isGithub()) {
       final commitEntry = commits.entries.first;
-      if (commitEntry.value.message.startsWith('Merge: ')) {
+      if (commitEntry.value.message.startsWith('Merge ')) {
         return commits.entries.toList()[1].key;
       }
 

--- a/packages/widgetbook_cli/test/commands/publish_test.dart
+++ b/packages/widgetbook_cli/test/commands/publish_test.dart
@@ -417,7 +417,7 @@ gpgsig -----BEGIN PGP SIGNATURE-----
  =dlq9
  -----END PGP SIGNATURE-----
 
-    Merge: 8c2d7c9020ffdf6e47211c280e33d022acdd0aa into aa79e1775885528bbf37e784a4a3828b89e27c0
+    Merge 8c2d7c9020ffdf6e47211c280e33d022acdd0aa into aa79e1775885528bbf37e784a4a3828b89e27c0
 
 commit 38b0f7a07a6167d8ea3784bfbe3daed621d3d06a
 tree da1e88aa7b662db17d7516da4fd8680c88202f53


### PR DESCRIPTION
fix identifying merge commits with incorrect keywords

### List of issues which are fixed by the PR
- closes #500 
