### PR TITLE
fix(widgetbook): :bug: addons property cannot be empty

### DIFF
--- a/packages/widgetbook/lib/src/addons/addon_injector_widget.dart
+++ b/packages/widgetbook/lib/src/addons/addon_injector_widget.dart
@@ -16,20 +16,22 @@ class AddonInjectorWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Nested(
-      key: ValueKey(routerData),
-      children: [
-        ...addons.map(
-          (e) => SingleChildBuilder(
-            builder: (context, child) => e.buildProvider(
-              context,
-              routerData,
-              child!,
-            ),
-          ),
-        ),
-      ],
-      child: child,
-    );
+    return addons.isEmpty
+        ? child
+        : Nested(
+            key: ValueKey(routerData),
+            children: [
+              ...addons.map(
+                (e) => SingleChildBuilder(
+                  builder: (context, child) => e.buildProvider(
+                    context,
+                    routerData,
+                    child!,
+                  ),
+                ),
+              ),
+            ],
+            child: child,
+          );
   }
 }


### PR DESCRIPTION
- allows users to not define `addons`

### List of issues which are fixed by the PR
- closes #522 