### PR TITLE
fix(annotation): :bug: remove obsolete `name` property

### DIFF
--- a/examples/addon_example/lib/app.dart
+++ b/examples/addon_example/lib/app.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart';
+
+@WidgetbookApp.material(
+  devices: [
+    Apple.iPhone12,
+    Apple.iPhone13,
+    Apple.iPadMini,
+    Desktop.desktop1080p,
+  ],
+)
+late int notUsed;
+
+@WidgetbookTheme(name: 'Light', isDefault: true)
+ThemeData getLightTheme() => ThemeData.light();
+
+/// Retrieves Dark Theme
+@WidgetbookTheme(name: 'Dark', isDefault: true)
+ThemeData getDarkTheme() => ThemeData.dark();

--- a/packages/widgetbook_annotation/lib/src/widgetbook_app.dart
+++ b/packages/widgetbook_annotation/lib/src/widgetbook_app.dart
@@ -4,12 +4,11 @@ import 'package:widgetbook_models/widgetbook_models.dart';
 /// Annotates a code element to create the widgetbook main file in the same
 /// folder in which the annotated element is defined.
 class WidgetbookApp {
-  /// Creates a new annotation with [name] and optional [devices].
+  /// Creates a new annotation optional [devices] and [textScaleFactors].
   /// If devices is not set or set to an empty list, no code for the
   /// Widgetbook.devices property will be generated.
   /// Therefore, the default of Widgetbook will be used.
   const WidgetbookApp({
-    required this.name,
     required Type this.themeType,
     this.devices = const <Device>[],
     this.textScaleFactors = const <double>[],
@@ -21,7 +20,6 @@ class WidgetbookApp {
   /// Annotates a code element to creat a Material-themed widgetbook main file
   /// in the same folder in which the annotated element is defined.
   const WidgetbookApp.material({
-    required this.name,
     this.devices = const <Device>[],
     this.textScaleFactors = const <double>[],
     this.foldersExpanded = false,
@@ -32,7 +30,6 @@ class WidgetbookApp {
   /// Annotates a code element to creat a Cupertino-themed widgetbook main
   /// file in the same folder in which the annotated element is defined.
   const WidgetbookApp.cupertino({
-    required this.name,
     this.devices = const <Device>[],
     this.textScaleFactors = const <double>[],
     this.foldersExpanded = false,
@@ -52,10 +49,6 @@ class WidgetbookApp {
 
   /// A list of text scale factors
   final List<double> textScaleFactors;
-
-  /// The name of the widgetbook.
-  /// This information will be displayed at the top left corner in the UI.
-  final String name;
 
   /// Determines folders are expanded by default
   final bool foldersExpanded;

--- a/packages/widgetbook_annotation/test/src/widgetbook_app_test.dart
+++ b/packages/widgetbook_annotation/test/src/widgetbook_app_test.dart
@@ -7,7 +7,7 @@ void main() {
     '$WidgetbookApp',
     () {
       test('defaults to empty list', () {
-        const instance = WidgetbookApp.material(name: 'Test');
+        const instance = WidgetbookApp.material();
 
         expect(
           instance.devices,

--- a/widgetbook_for_widgetbook/lib/app.dart
+++ b/widgetbook_for_widgetbook/lib/app.dart
@@ -4,7 +4,6 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as anno;
 import 'package:widgetbook_core/widgetbook_core.dart';
 
 @anno.WidgetbookApp.material(
-  name: 'Widgetbook',
   devices: [
     Apple.iPhone11,
     Apple.iPhone12,


### PR DESCRIPTION
- removes `name` property from `@WidgetbookApp` annotation

### List of issues which are fixed by the PR
- closes #519
