### PR TITLE
refactor: use local packages in `widgetbook_for_widgetbook`

### DIFF
--- a/widgetbook_for_widgetbook/pubspec.lock
+++ b/widgetbook_for_widgetbook/pubspec.lock
@@ -268,10 +268,10 @@ packages:
     dependency: transitive
     description:
       name: go_router
-      sha256: b4bb06205ec607278b6fc23db238278417bca84a3905779cc68d1eb7afae37e2
+      sha256: feab99a20fd248c658c923ba98f4449ca6e575c3dee9fdf07146f4f33482c6bc
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.5.5"
   graphs:
     dependency: transitive
     description:
@@ -525,14 +525,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  very_good_analysis:
-    dependency: "direct dev"
-    description:
-      name: very_good_analysis
-      sha256: "4815adc7ded57657038d2bb2a7f332c50e3c8152f7d3c6acf8f6b7c0cc81e5e2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.0"
   watcher:
     dependency: transitive
     description:
@@ -555,7 +547,7 @@ packages:
       path: "../packages/widgetbook"
       relative: true
     source: path
-    version: "3.0.0-beta.11"
+    version: "3.0.0-beta.13"
   widgetbook_annotation:
     dependency: "direct main"
     description:
@@ -569,7 +561,7 @@ packages:
       path: "../packages/widgetbook_core"
       relative: true
     source: path
-    version: "3.0.0-beta.6"
+    version: "3.0.0-beta.7"
   widgetbook_generator:
     dependency: "direct dev"
     description:
@@ -578,11 +570,12 @@ packages:
     source: path
     version: "3.0.0-beta.10"
   widgetbook_models:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../packages/widgetbook_models"
-      relative: true
-    source: path
+      name: widgetbook_models
+      sha256: f3e146fe403c1620532deca01ece616fbdaa6a5ee623efd6196b761ba59b4ac9
+      url: "https://pub.dev"
+    source: hosted
     version: "3.0.0-beta.3"
   yaml:
     dependency: transitive

--- a/widgetbook_for_widgetbook/pubspec.yaml
+++ b/widgetbook_for_widgetbook/pubspec.yaml
@@ -13,8 +13,10 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.1
-  widgetbook: ^3.0.0-beta.13
-  widgetbook_annotation: ^3.0.0-beta.6
+  widgetbook: 
+    path: ../packages/widgetbook
+  widgetbook_annotation:
+    path: ../packages/widgetbook_annotation
   widgetbook_core:
     path: ../packages/widgetbook_core
 
@@ -22,6 +24,18 @@ dev_dependencies:
   build_runner: ^2.3.2
   flutter_test:
     sdk: flutter
-  widgetbook_generator: ^3.0.0-beta.10
+  widgetbook_generator:
+    path: ../packages/widgetbook_generator
+
+dependency_overrides:
+  widgetbook: 
+    path: ../packages/widgetbook
+  widgetbook_annotation:
+    path: ../packages/widgetbook_annotation
+  widgetbook_core:
+    path: ../packages/widgetbook_core
+  widgetbook_generator:
+    path: ../packages/widgetbook_generator
+
 flutter:
   uses-material-design: true


### PR DESCRIPTION
`widgetbook_for_widgetbook` had a combination of `path` and `hosted` dependencies, and since it's used for local development, all of the `hosted` dependencies should be converted to `path` ones. To resolve the dependencies conflict, we use [`dependency_overrides`](https://dart.dev/tools/pub/dependencies#dependency-overrides), to make sure all transitive dependcies are still using `path`.

### List of issues which are fixed by the PR
*You must list at least one issue.*

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
