### PR TITLE
feat(widgetbook): add `disable-add-ons` query param

### DIFF
--- a/packages/widgetbook/lib/src/navigation/router.dart
+++ b/packages/widgetbook/lib/src/navigation/router.dart
@@ -88,9 +88,14 @@ GoRouter createRouter({
                 value: state.queryParams['disable-properties'],
               );
 
+              final disableAddOns = _parseBoolQueryParameter(
+                value: state.queryParams['disable-add-ons'],
+              );
+
               return NoTransitionPage<void>(
                 child: WidgetbookPage(
                   disableProperties: disableProperties,
+                  disableAddOns: disableAddOns,
                   routerData: state.queryParams,
                 ),
               );

--- a/packages/widgetbook/lib/src/settings_panel/settings_panel.dart
+++ b/packages/widgetbook/lib/src/settings_panel/settings_panel.dart
@@ -6,8 +6,11 @@ import 'package:widgetbook_core/widgetbook_core.dart' as core;
 
 class SettingsPanel extends StatelessWidget {
   const SettingsPanel({
+    required this.disableAddOns,
     super.key,
   });
+
+  final bool disableAddOns;
 
   @override
   Widget build(BuildContext context) {
@@ -20,10 +23,12 @@ class SettingsPanel extends StatelessWidget {
             child: SingleChildScrollView(
               child: core.SettingsPanel(
                 settings: [
-                  core.SettingsPanelData(
-                    name: 'Properties',
-                    settings: addons.map((e) => e.build(context)).toList(),
-                  ),
+                  if (!disableAddOns) ...{
+                    core.SettingsPanelData(
+                      name: 'Properties',
+                      settings: addons.map((e) => e.build(context)).toList(),
+                    ),
+                  },
                   core.SettingsPanelData(
                     name: 'Knobs',
                     settings: knobs.map((e) => e.build(context)).toList(),

--- a/packages/widgetbook/lib/src/widgetbook_page.dart
+++ b/packages/widgetbook/lib/src/widgetbook_page.dart
@@ -9,11 +9,13 @@ import 'package:widgetbook/src/workbench/workbench.dart';
 class WidgetbookPage extends StatelessWidget {
   const WidgetbookPage({
     required this.disableProperties,
+    required this.disableAddOns,
     required this.routerData,
     super.key,
   });
 
   final bool disableProperties;
+  final bool disableAddOns;
   final Map<String, String> routerData;
 
   @override
@@ -35,9 +37,11 @@ class WidgetbookPage extends StatelessWidget {
                   ),
                 ),
                 if (!disableProperties)
-                  const SizedBox(
+                  SizedBox(
                     width: 400,
-                    child: SettingsPanel(),
+                    child: SettingsPanel(
+                      disableAddOns: disableAddOns,
+                    ),
                   ),
               ],
             ),


### PR DESCRIPTION
The `disable-add-ons` query parameter that hides the Add-ons section of Settings side panel. It is considered an alternative for `disable-properties` query parameter which hides the whole panel.

This parameter will be used within Widgetbook Cloud to enable Knobs on the Cloud.

### List of issues which are fixed by the PR

- #605 

### Screenshots
| ![false](https://user-images.githubusercontent.com/41103290/230608578-7047dc56-f191-469a-834a-13b410f61eb1.png) | ![true](https://user-images.githubusercontent.com/41103290/230607623-47de28f4-60e0-42e4-b075-c2d053ee9d57.png) |
| :---: | :---: |
| `?disable-add-ons=false` | `?disable-add-ons=true` |

### Checklist

- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
