### PR TITLE
chore: analyze `.widgetbook.dart` files

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,7 +4,7 @@ analyzer:
     - "bricks"
     - "**/*.g.dart"
     - "**/*.freezed.dart"
-    - "**/*.widgetbook.dart"
+    - "examples/screen_util_example/lib/main.widgetbook.dart" # The only generated .widgetbook.dart file
     - "**/example/*.dart"
     - "**/example/**/*.dart"
 


### PR DESCRIPTION
Excluding `.widgetbook.dart` files from analysis leads to disabling the intellisense in VSCode. And since these files are manually written and not generated, so we need to make sure that they are following our lint rules as well.

Currently the only generated file is `examples/screen_util_example/lib/main.widgetbook.dart` and it can be safely excluded from analysis.
