### PR TITLE
chore(deps): analyzer from 4.0.0 to 5.10.0 in /packages/widgetbook_generator

### DIFF
--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
-  analyzer: ^4.0.0
+  analyzer: ^5.10.0
   build: ^2.1.0
   collection: ^1.15.0
   freezed_annotation: ^2.2.0
@@ -21,7 +21,7 @@ dependencies:
   widgetbook_annotation: ^3.0.0-beta.6
   widgetbook_models: ^3.0.0-beta.3
 dev_dependencies:
-  build_runner: ^2.4.1
+  build_runner: ^2.3.3
   freezed: ^2.3.2
   json_serializable: ^6.6.1
   test: ^1.24.1

--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -13,15 +13,15 @@ dependencies:
   analyzer: ^4.0.0
   build: ^2.1.0
   collection: ^1.15.0
-  freezed_annotation: ^2.0.3
+  freezed_annotation: ^2.2.0
   glob: ^2.0.2
-  json_annotation: ^4.4.0
+  json_annotation: ^4.8.0
   meta: ^1.7.0
   source_gen: ^1.1.0
   widgetbook_annotation: ^3.0.0-beta.6
   widgetbook_models: ^3.0.0-beta.3
 dev_dependencies:
-  build_runner: ^2.1.2
-  freezed: ^2.0.3
-  json_serializable: ^6.1.4
+  build_runner: ^2.4.1
+  freezed: ^2.3.2
+  json_serializable: ^6.6.1
   test: ^1.24.1


### PR DESCRIPTION
- bumps `json_annotation` dependency from 4.4.0 to 4.8.0
- bumps `analyzer` dependency from 4.0.0 to 5.10.0