### PR TITLE
ci: add `validate-uncommitted-changes` job

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -5,3 +5,23 @@ on: pull_request
 jobs:
   semantic-pull-request:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1
+
+  validate-uncommitted-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Enable melos
+        run: dart pub global activate melos
+
+      - name: Get packages 
+        run: melos bootstrap
+
+      - name: Validate all changes are committed
+        run: git diff-index HEAD -p --exit-code

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -23,5 +23,8 @@ jobs:
       - name: Get packages 
         run: melos bootstrap
 
+      - name: Generate diff
+        run: git --no-pager diff
+
       - name: Validate all changes are committed
-        run: git diff-index HEAD -p --exit-code
+        run: git diff-index HEAD --exit-code -p

--- a/widgetbook_for_widgetbook/pubspec.lock
+++ b/widgetbook_for_widgetbook/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "4897882604d919befd350648c7f91926a9d5de99e67b455bf0917cc2362f4bb8"
+      sha256: a36ec4843dc30ea6bf652bf25e3448db6c5e8bcf4aa55f063a5d1dad216d8214
       url: "https://pub.dev"
     source: hosted
-    version: "47.0.0"
+    version: "58.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "690e335554a8385bc9d787117d9eb52c0c03ee207a607e593de3c9d71b1cfe80"
+      sha256: cc4242565347e98424ce9945c819c192ec0838cb9d1f6aa4a97cc96becbc5b27
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "5.10.0"
   args:
     dependency: transitive
     description:
@@ -316,10 +316,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: "3520fa844009431b5d4491a5a778603520cdc399ab3406332dcc50f93547258c"
+      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "4.8.0"
   logging:
     dependency: transitive
     description:
@@ -547,35 +547,35 @@ packages:
       path: "../packages/widgetbook"
       relative: true
     source: path
-    version: "3.0.0-beta.13"
+    version: "3.0.0-beta.14"
   widgetbook_annotation:
     dependency: "direct main"
     description:
       path: "../packages/widgetbook_annotation"
       relative: true
     source: path
-    version: "3.0.0-beta.6"
+    version: "3.0.0-beta.7"
   widgetbook_core:
     dependency: "direct main"
     description:
       path: "../packages/widgetbook_core"
       relative: true
     source: path
-    version: "3.0.0-beta.7"
+    version: "3.0.0-beta.8"
   widgetbook_generator:
     dependency: "direct dev"
     description:
       path: "../packages/widgetbook_generator"
       relative: true
     source: path
-    version: "3.0.0-beta.10"
+    version: "3.0.0-beta.11"
   widgetbook_models:
     dependency: "direct overridden"
     description:
       path: "../packages/widgetbook_models"
       relative: true
     source: path
-    version: "3.0.0-beta.3"
+    version: "3.0.0-beta.4"
   yaml:
     dependency: transitive
     description:
@@ -585,5 +585,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.5 <3.0.0"
+  dart: ">=2.19.0 <3.0.0"
   flutter: ">=3.3.0"


### PR DESCRIPTION
Usually when we update dependencies or packages' versions, we forget to run `melos bs` that updates all lock files with these changes. Causing the repo to have uncommitted changes after merging the proposed changes.

This CI job run a `git diff-index` command to make sure everything is up-to-date.
