### PR TITLE
refactor(addon): simplify api

### DIFF
--- a/packages/widgetbook/lib/src/addons/frame_addon/addons/device/device_addon.dart
+++ b/packages/widgetbook/lib/src/addons/frame_addon/addons/device/device_addon.dart
@@ -13,11 +13,6 @@ class DeviceAddon extends WidgetbookAddOn<DeviceSetting> {
         );
 
   @override
-  void updateQueryParameters(BuildContext context, DeviceSetting value) {
-    context.goTo(queryParams: value.toQueryParameter());
-  }
-
-  @override
   DeviceSetting settingFromQueryParameters({
     required Map<String, String> queryParameters,
     required DeviceSetting setting,

--- a/packages/widgetbook/lib/src/addons/frame_addon/addons/device/device_addon.dart
+++ b/packages/widgetbook/lib/src/addons/frame_addon/addons/device/device_addon.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:widgetbook/src/routing/router.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
@@ -11,33 +10,6 @@ class DeviceAddon extends WidgetbookAddOn<DeviceSetting> {
   }) : super(
           name: 'Device',
         );
-
-  @override
-  DeviceSetting settingFromQueryParameters({
-    required Map<String, String> queryParameters,
-    required DeviceSetting setting,
-  }) {
-    final activeDevice = parseQueryParameters(
-          name: 'device',
-          queryParameters: queryParameters,
-          mappedData: {for (var e in setting.devices) e.name: e},
-        ) ??
-        setting.activeDevice;
-    final activeOrientation = parseQueryParameters(
-          name: 'orientation',
-          queryParameters: queryParameters,
-          mappedData: {
-            Orientation.portrait.name: Orientation.portrait,
-            Orientation.landscape.name: Orientation.landscape,
-          },
-        ) ??
-        setting.orientation;
-
-    return setting.copyWith(
-      activeDevice: activeDevice,
-      orientation: activeOrientation,
-    );
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/packages/widgetbook/lib/src/addons/frame_addon/addons/device/device_setting.dart
+++ b/packages/widgetbook/lib/src/addons/frame_addon/addons/device/device_setting.dart
@@ -39,14 +39,16 @@ class DeviceSetting extends WidgetbookAddOnModel<DeviceSetting>
 
   @override
   DeviceSetting? fromQueryParameter(Map<String, String> queryParameters) {
-    return this.copyWith(
-      orientation: Orientation.values.byName(
-        queryParameters['orientation'] ?? orientation.name,
-      ),
-      activeDevice: devices.firstWhere(
-        (device) => device.name == queryParameters['device'],
-        orElse: () => activeDevice,
-      ),
-    );
+    return queryParameters.containsKey('orientation') &&
+            queryParameters.containsKey('device')
+        ? this.copyWith(
+            orientation: Orientation.values.byName(
+              queryParameters['orientation']!,
+            ),
+            activeDevice: devices.firstWhere(
+              (device) => device.name == queryParameters['device']!,
+            ),
+          )
+        : null;
   }
 }

--- a/packages/widgetbook/lib/src/addons/frame_addon/addons/device/device_setting.dart
+++ b/packages/widgetbook/lib/src/addons/frame_addon/addons/device/device_setting.dart
@@ -6,7 +6,8 @@ import 'package:widgetbook_addon/widgetbook_addon.dart';
 part 'device_setting.freezed.dart';
 
 @freezed
-class DeviceSetting extends WidgetbookAddOnModel with _$DeviceSetting {
+class DeviceSetting extends WidgetbookAddOnModel<DeviceSetting>
+    with _$DeviceSetting {
   factory DeviceSetting({
     required List<Device> devices,
     required Device activeDevice,
@@ -34,5 +35,18 @@ class DeviceSetting extends WidgetbookAddOnModel with _$DeviceSetting {
       'orientation': orientation.name,
       'device': activeDevice.name,
     };
+  }
+
+  @override
+  DeviceSetting? fromQueryParameter(Map<String, String> queryParameters) {
+    return this.copyWith(
+      orientation: Orientation.values.byName(
+        queryParameters['orientation'] ?? orientation.name,
+      ),
+      activeDevice: devices.firstWhere(
+        (device) => device.name == queryParameters['device'],
+        orElse: () => activeDevice,
+      ),
+    );
   }
 }

--- a/packages/widgetbook/lib/src/addons/frame_addon/addons/no_frame/no_frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/frame_addon/addons/no_frame/no_frame_addon.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:widgetbook_addon/widgetbook_addon.dart';
 import 'package:widgetbook/src/addons/frame_addon/addons/no_frame/no_frame_setting.dart';
-import 'package:widgetbook/src/routing/router.dart';
 
 class NoFrameAddon extends WidgetbookAddOn<NoFrameSetting> {
   NoFrameAddon()
@@ -9,11 +8,6 @@ class NoFrameAddon extends WidgetbookAddOn<NoFrameSetting> {
           name: 'No Frame',
           setting: NoFrameSetting(),
         );
-
-  @override
-  void updateQueryParameters(BuildContext context, NoFrameSetting value) {
-    context.goTo(queryParams: value.toQueryParameter());
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/packages/widgetbook/lib/src/addons/frame_addon/frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/frame_addon/frame_addon.dart
@@ -56,11 +56,6 @@ class FrameAddon extends WidgetbookAddOn<FrameSetting> {
   }
 
   @override
-  void updateQueryParameters(BuildContext context, FrameSetting value) {
-    context.goTo(queryParams: value.toQueryParameter());
-  }
-
-  @override
   FrameSetting settingFromQueryParameters({
     required Map<String, String> queryParameters,
     required FrameSetting setting,

--- a/packages/widgetbook/lib/src/addons/frame_addon/frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/frame_addon/frame_addon.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_addon/widgetbook_addon.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
 class FrameAddon extends WidgetbookAddOn<FrameSetting> {
@@ -8,6 +9,17 @@ class FrameAddon extends WidgetbookAddOn<FrameSetting> {
   }) : super(
           name: 'Frame',
         );
+
+  @override
+  void addListener(ValueChanged<FrameSetting> listener) {
+    super.addListener(listener);
+
+    value.frames.forEach((frame) {
+      frame.addon.addListener(
+        listener as ValueChanged<WidgetbookAddOnModel>,
+      );
+    });
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/packages/widgetbook/lib/src/addons/frame_addon/frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/frame_addon/frame_addon.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:widgetbook/src/routing/router.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
@@ -43,31 +42,17 @@ class FrameAddon extends WidgetbookAddOn<FrameSetting> {
     Map<String, String> queryParameters,
     Widget child,
   ) {
-    final initialData = settingFromQueryParameters(
-      queryParameters: queryParameters,
-      setting: setting,
-    );
+    final newSetting = setting.fromQueryParameter(queryParameters) ?? setting;
+
     return super.buildProvider(
       context,
       queryParameters,
-      initialData.activeFrame.addon
-          .buildProvider(context, queryParameters, child),
+      newSetting.activeFrame.addon.buildProvider(
+        context,
+        queryParameters,
+        child,
+      ),
     );
-  }
-
-  @override
-  FrameSetting settingFromQueryParameters({
-    required Map<String, String> queryParameters,
-    required FrameSetting setting,
-  }) {
-    final activeFrame = parseQueryParameters(
-          name: 'frame',
-          queryParameters: queryParameters,
-          mappedData: {for (var e in setting.frames) e.name: e},
-        ) ??
-        setting.activeFrame;
-
-    return setting.copyWith(activeFrame: activeFrame);
   }
 }
 

--- a/packages/widgetbook/lib/src/addons/frame_addon/frame_setting.dart
+++ b/packages/widgetbook/lib/src/addons/frame_addon/frame_setting.dart
@@ -5,7 +5,8 @@ import 'package:widgetbook_addon/widgetbook_addon.dart';
 part 'frame_setting.freezed.dart';
 
 @freezed
-class FrameSetting extends WidgetbookAddOnModel with _$FrameSetting {
+class FrameSetting extends WidgetbookAddOnModel<FrameSetting>
+    with _$FrameSetting {
   @Assert('frames.isNotEmpty', 'frames cannot be empty')
   factory FrameSetting({
     required List<Frame> frames,
@@ -36,5 +37,15 @@ class FrameSetting extends WidgetbookAddOnModel with _$FrameSetting {
     }..addAll(
         activeFrame.addon.value.toQueryParameter(),
       );
+  }
+
+  @override
+  FrameSetting? fromQueryParameter(Map<String, String> queryParameters) {
+    return this.copyWith(
+      activeFrame: frames.firstWhere(
+        (frame) => frame.name == queryParameters['frame'],
+        orElse: () => activeFrame,
+      ),
+    );
   }
 }

--- a/packages/widgetbook/lib/src/addons/frame_addon/frame_setting.dart
+++ b/packages/widgetbook/lib/src/addons/frame_addon/frame_setting.dart
@@ -41,11 +41,12 @@ class FrameSetting extends WidgetbookAddOnModel<FrameSetting>
 
   @override
   FrameSetting? fromQueryParameter(Map<String, String> queryParameters) {
-    return this.copyWith(
-      activeFrame: frames.firstWhere(
-        (frame) => frame.name == queryParameters['frame'],
-        orElse: () => activeFrame,
-      ),
-    );
+    return queryParameters.containsKey('frame')
+        ? this.copyWith(
+            activeFrame: frames.firstWhere(
+              (frame) => frame.name == queryParameters['frame']!,
+            ),
+          )
+        : null;
   }
 }

--- a/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
+++ b/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
@@ -29,11 +29,6 @@ class LocalizationAddon extends WidgetbookAddOn<LocalizationSetting> {
   }
 
   @override
-  void updateQueryParameters(BuildContext context, LocalizationSetting value) {
-    context.goTo(queryParams: value.toQueryParameter());
-  }
-
-  @override
   LocalizationSetting settingFromQueryParameters({
     required Map<String, String> queryParameters,
     required LocalizationSetting setting,

--- a/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
+++ b/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:widgetbook/src/routing/router.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
@@ -26,21 +25,6 @@ class LocalizationAddon extends WidgetbookAddOn<LocalizationSetting> {
         },
       ),
     );
-  }
-
-  @override
-  LocalizationSetting settingFromQueryParameters({
-    required Map<String, String> queryParameters,
-    required LocalizationSetting setting,
-  }) {
-    final activeLocale = parseQueryParameters(
-          name: 'locale',
-          queryParameters: queryParameters,
-          mappedData: {for (var e in setting.locales) e.toString(): e},
-        ) ??
-        setting.activeLocale;
-
-    return setting.copyWith(activeLocale: activeLocale);
   }
 }
 

--- a/packages/widgetbook/lib/src/addons/localization_addon/localization_setting.dart
+++ b/packages/widgetbook/lib/src/addons/localization_addon/localization_setting.dart
@@ -40,4 +40,14 @@ class LocalizationSetting extends WidgetbookAddOnModel
       'locale': activeLocale.toString(),
     };
   }
+
+  @override
+  fromQueryParameter(Map<String, String> queryParameters) {
+    return this.copyWith(
+      activeLocale: locales.firstWhere(
+        (locale) => locale == queryParameters['locale'].toString(),
+        orElse: () => activeLocale,
+      ),
+    );
+  }
 }

--- a/packages/widgetbook/lib/src/addons/localization_addon/localization_setting.dart
+++ b/packages/widgetbook/lib/src/addons/localization_addon/localization_setting.dart
@@ -43,11 +43,12 @@ class LocalizationSetting extends WidgetbookAddOnModel
 
   @override
   fromQueryParameter(Map<String, String> queryParameters) {
-    return this.copyWith(
-      activeLocale: locales.firstWhere(
-        (locale) => locale == queryParameters['locale'].toString(),
-        orElse: () => activeLocale,
-      ),
-    );
+    return queryParameters.containsKey('locale')
+        ? this.copyWith(
+            activeLocale: locales.firstWhere(
+              (locale) => locale == queryParameters['locale']!,
+            ),
+          )
+        : null;
   }
 }

--- a/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
+++ b/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:widgetbook_addon/widgetbook_addon.dart';
 import 'package:widgetbook/src/addons/text_scale_addon/text_scale_setting.dart';
-import 'package:widgetbook/src/routing/router.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
 class TextScaleAddon extends WidgetbookAddOn<TextScaleSetting> {
@@ -30,23 +29,6 @@ class TextScaleAddon extends WidgetbookAddOn<TextScaleSetting> {
         },
       ),
     );
-  }
-
-  @override
-  TextScaleSetting settingFromQueryParameters({
-    required Map<String, String> queryParameters,
-    required TextScaleSetting setting,
-  }) {
-    final activeTextScale = parseQueryParameters(
-          name: 'text-scale',
-          queryParameters: queryParameters,
-          mappedData: {
-            for (var e in setting.textScales) e.toStringAsFixed(2): e
-          },
-        ) ??
-        setting.activeTextScale;
-
-    return setting.copyWith(activeTextScale: activeTextScale);
   }
 }
 

--- a/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
+++ b/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
@@ -33,11 +33,6 @@ class TextScaleAddon extends WidgetbookAddOn<TextScaleSetting> {
   }
 
   @override
-  void updateQueryParameters(BuildContext context, TextScaleSetting value) {
-    context.goTo(queryParams: value.toQueryParameter());
-  }
-
-  @override
   TextScaleSetting settingFromQueryParameters({
     required Map<String, String> queryParameters,
     required TextScaleSetting setting,

--- a/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_setting.dart
+++ b/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_setting.dart
@@ -4,7 +4,8 @@ import 'package:widgetbook_addon/widgetbook_addon.dart';
 part 'text_scale_setting.freezed.dart';
 
 @freezed
-class TextScaleSetting extends WidgetbookAddOnModel with _$TextScaleSetting {
+class TextScaleSetting extends WidgetbookAddOnModel<TextScaleSetting>
+    with _$TextScaleSetting {
   @Assert('textScales.isNotEmpty', 'textScales cannot be empty')
   factory TextScaleSetting({
     required double activeTextScale,
@@ -33,5 +34,15 @@ class TextScaleSetting extends WidgetbookAddOnModel with _$TextScaleSetting {
     return {
       'text-scale': activeTextScale.toStringAsFixed(2),
     };
+  }
+
+  @override
+  TextScaleSetting? fromQueryParameter(Map<String, String> queryParameters) {
+    return this.copyWith(
+      activeTextScale: textScales.firstWhere(
+        (scale) => scale.toStringAsFixed(2) == queryParameters['text-scale'],
+        orElse: () => activeTextScale,
+      ),
+    );
   }
 }

--- a/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_setting.dart
+++ b/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_setting.dart
@@ -38,11 +38,13 @@ class TextScaleSetting extends WidgetbookAddOnModel<TextScaleSetting>
 
   @override
   TextScaleSetting? fromQueryParameter(Map<String, String> queryParameters) {
-    return this.copyWith(
-      activeTextScale: textScales.firstWhere(
-        (scale) => scale.toStringAsFixed(2) == queryParameters['text-scale'],
-        orElse: () => activeTextScale,
-      ),
-    );
+    return queryParameters.containsKey('text-scale')
+        ? this.copyWith(
+            activeTextScale: textScales.firstWhere(
+              (scale) =>
+                  scale.toStringAsFixed(2) == queryParameters['text-scale']!,
+            ),
+          )
+        : null;
   }
 }

--- a/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
@@ -32,11 +32,6 @@ abstract class ThemeAddon<T> extends WidgetbookAddOn<ThemeSetting<T>> {
   }
 
   @override
-  void updateQueryParameters(BuildContext context, ThemeSetting<T> value) {
-    context.goTo(queryParams: value.toQueryParameter());
-  }
-
-  @override
   ThemeSetting<T> settingFromQueryParameters({
     required Map<String, String> queryParameters,
     required ThemeSetting<T> setting,

--- a/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:widgetbook/src/routing/router.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
@@ -29,19 +28,5 @@ abstract class ThemeAddon<T> extends WidgetbookAddOn<ThemeSetting<T>> {
         },
       ),
     );
-  }
-
-  @override
-  ThemeSetting<T> settingFromQueryParameters({
-    required Map<String, String> queryParameters,
-    required ThemeSetting<T> setting,
-  }) {
-    final WidgetbookTheme<T>? activeTheme = parseQueryParameters(
-      name: 'theme',
-      queryParameters: queryParameters,
-      mappedData: {for (var e in setting.themes) e.name: e},
-    );
-
-    return setting.copyWith(activeTheme: activeTheme);
   }
 }

--- a/packages/widgetbook/lib/src/addons/theme_addon/theme_setting.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/theme_setting.dart
@@ -46,12 +46,13 @@ class ThemeSetting<T> extends WidgetbookAddOnModel<ThemeSetting<T>> {
 
   @override
   ThemeSetting<T>? fromQueryParameter(Map<String, String> queryParameters) {
-    return this.copyWith(
-      activeTheme: themes.firstWhere(
-        (theme) => theme.name == queryParameters['theme'],
-        orElse: () => activeTheme,
-      ),
-    );
+    return queryParameters.containsKey('theme')
+        ? this.copyWith(
+            activeTheme: themes.firstWhere(
+              (theme) => theme.name == queryParameters['theme']!,
+            ),
+          )
+        : null;
   }
 
   @override

--- a/packages/widgetbook/lib/src/addons/theme_addon/theme_setting.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/theme_setting.dart
@@ -4,7 +4,7 @@ import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_addon/widgetbook_addon.dart';
 
 @immutable
-class ThemeSetting<T> extends WidgetbookAddOnModel {
+class ThemeSetting<T> extends WidgetbookAddOnModel<ThemeSetting<T>> {
   ThemeSetting({
     required this.themes,
     required this.activeTheme,
@@ -42,6 +42,16 @@ class ThemeSetting<T> extends WidgetbookAddOnModel {
     return {
       'theme': activeTheme.name,
     };
+  }
+
+  @override
+  ThemeSetting<T>? fromQueryParameter(Map<String, String> queryParameters) {
+    return this.copyWith(
+      activeTheme: themes.firstWhere(
+        (theme) => theme.name == queryParameters['theme'],
+        orElse: () => activeTheme,
+      ),
+    );
   }
 
   @override

--- a/packages/widgetbook/lib/src/routing/router.dart
+++ b/packages/widgetbook/lib/src/routing/router.dart
@@ -4,22 +4,6 @@ import 'package:widgetbook/src/navigation/navigation.dart';
 import 'package:widgetbook/src/routing/widgetbook_panel.dart';
 import 'package:widgetbook/src/widgetbook_page.dart';
 
-T? parseQueryParameters<T>({
-  required String name,
-  required Map<String, dynamic> queryParameters,
-  required Map<String, T> mappedData,
-}) {
-  final value = queryParameters[name] as String?;
-  T? selectedValue;
-
-  if (value != null) {
-    if (mappedData.containsKey(value)) {
-      selectedValue = mappedData[value];
-    }
-  }
-  return selectedValue;
-}
-
 extension GoRouterExtension on BuildContext {
   void goTo({
     required Map<String, String> queryParams,

--- a/packages/widgetbook/lib/src/widgetbook_page.dart
+++ b/packages/widgetbook/lib/src/widgetbook_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:widgetbook/src/routing/router.dart';
 import 'package:widgetbook_addon/widgetbook_addon.dart';
 import 'package:widgetbook/src/routing/widgetbook_panel.dart';
 import 'package:widgetbook/src/settings_panel/settings_panel.dart';
@@ -32,6 +33,9 @@ class WidgetbookPage extends StatelessWidget {
           return AddonInjectorWidget(
             addons: addons,
             routerData: routerData,
+            onChanged: (setting) => context.goTo(
+              queryParams: setting.toQueryParameter(),
+            ),
             child: Row(
               children: [
                 const Expanded(

--- a/packages/widgetbook_addon/example/main.dart
+++ b/packages/widgetbook_addon/example/main.dart
@@ -14,6 +14,13 @@ class CustomAddOnSetting extends WidgetbookAddOnModel {
       'data': data,
     };
   }
+
+  @override
+  CustomAddOnSetting? fromQueryParameter(Map<String, String> queryParameters) {
+    return queryParameters.containsKey('data')
+        ? CustomAddOnSetting(data: queryParameters['data']!)
+        : null;
+  }
 }
 
 class CustomAddOn extends WidgetbookAddOn<CustomAddOnSetting> {
@@ -26,16 +33,6 @@ class CustomAddOn extends WidgetbookAddOn<CustomAddOnSetting> {
   @override
   Widget build(BuildContext context) {
     return Text(value.data);
-  }
-
-  @override
-  CustomAddOnSetting settingFromQueryParameters({
-    required Map<String, String> queryParameters,
-    required CustomAddOnSetting setting,
-  }) {
-    return CustomAddOnSetting(
-      data: queryParameters['data'] ?? 'Unknown',
-    );
   }
 }
 

--- a/packages/widgetbook_addon/example/main.dart
+++ b/packages/widgetbook_addon/example/main.dart
@@ -29,13 +29,6 @@ class CustomAddOn extends WidgetbookAddOn<CustomAddOnSetting> {
   }
 
   @override
-  void updateQueryParameters(BuildContext context, CustomAddOnSetting value) {
-    context.goTo(
-      queryParams: value.toQueryParameter(),
-    );
-  }
-
-  @override
   CustomAddOnSetting settingFromQueryParameters({
     required Map<String, String> queryParameters,
     required CustomAddOnSetting setting,

--- a/packages/widgetbook_addon/lib/src/addon_injector_widget.dart
+++ b/packages/widgetbook_addon/lib/src/addon_injector_widget.dart
@@ -2,18 +2,25 @@ import 'package:flutter/material.dart';
 import 'package:nested/nested.dart';
 
 import 'widgetbook_addon.dart';
+import 'widgetbook_addon_model.dart';
 
 class AddonInjectorWidget extends StatelessWidget {
-  const AddonInjectorWidget({
+  AddonInjectorWidget({
     required this.addons,
     required this.routerData,
+    required this.onChanged,
     required this.child,
     super.key,
-  });
+  }) {
+    addons.forEach(
+      (addon) => addon.addListener(onChanged),
+    );
+  }
 
   final List<WidgetbookAddOn> addons;
-  final Widget child;
   final Map<String, String> routerData;
+  final ValueChanged<WidgetbookAddOnModel> onChanged;
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/widgetbook_addon/lib/src/widgetbook_addon.dart
+++ b/packages/widgetbook_addon/lib/src/widgetbook_addon.dart
@@ -25,20 +25,6 @@ abstract class WidgetbookAddOn<T extends WidgetbookAddOnModel> {
   final T setting;
   late ValueNotifier<T> provider;
 
-  /// Allows for parsing of [queryParameters] by using information from the
-  /// router and from the initially provided [setting].
-  ///
-  /// If no [queryParameters] are available, return [setting].
-  /// If [queryParameters] are avaialbe return a propert `Setting` object.
-  ///
-  /// If not overriden, returns the initially provided [setting].
-  T settingFromQueryParameters({
-    required Map<String, String> queryParameters,
-    required T setting,
-  }) {
-    return setting;
-  }
-
   T get value => provider.value;
 
   void addListener(ValueChanged<T> listener) {
@@ -56,13 +42,12 @@ abstract class WidgetbookAddOn<T extends WidgetbookAddOnModel> {
     Map<String, String> queryParameters,
     Widget child,
   ) {
-    provider.value = settingFromQueryParameters(
-      queryParameters: queryParameters,
-      setting: setting,
-    );
+    final newSetting = setting.fromQueryParameter(queryParameters) ?? setting;
+
+    provider.value = newSetting;
 
     return ChangeNotifierProvider.value(
-      key: ValueKey(provider.value),
+      key: ValueKey(newSetting),
       value: provider,
       child: child,
     );

--- a/packages/widgetbook_addon/lib/src/widgetbook_addon.dart
+++ b/packages/widgetbook_addon/lib/src/widgetbook_addon.dart
@@ -25,9 +25,6 @@ abstract class WidgetbookAddOn<T extends WidgetbookAddOnModel> {
   final T setting;
   late ValueNotifier<T> provider;
 
-  /// Updates the router's query parameters using the changed [value].
-  void updateQueryParameters(BuildContext context, T value);
-
   /// Allows for parsing of [queryParameters] by using information from the
   /// router and from the initially provided [setting].
   ///
@@ -44,9 +41,14 @@ abstract class WidgetbookAddOn<T extends WidgetbookAddOnModel> {
 
   T get value => provider.value;
 
+  void addListener(ValueChanged<T> listener) {
+    provider.addListener(
+      () => listener(provider.value),
+    );
+  }
+
   void onChanged(BuildContext context, T value) {
     provider.value = value;
-    updateQueryParameters(context, value);
   }
 
   Widget buildProvider(
@@ -54,14 +56,13 @@ abstract class WidgetbookAddOn<T extends WidgetbookAddOnModel> {
     Map<String, String> queryParameters,
     Widget child,
   ) {
-    final initialData = settingFromQueryParameters(
+    provider.value = settingFromQueryParameters(
       queryParameters: queryParameters,
       setting: setting,
     );
-    provider = ValueNotifier<T>(initialData);
 
     return ChangeNotifierProvider.value(
-      key: ValueKey(initialData),
+      key: ValueKey(provider.value),
       value: provider,
       child: child,
     );

--- a/packages/widgetbook_addon/lib/src/widgetbook_addon_model.dart
+++ b/packages/widgetbook_addon/lib/src/widgetbook_addon_model.dart
@@ -1,4 +1,4 @@
-abstract class WidgetbookAddOnModel {
+abstract class WidgetbookAddOnModel<T> {
   const WidgetbookAddOnModel();
 
   /// Required to allow proper deep linking including AddOn property selection
@@ -7,5 +7,18 @@ abstract class WidgetbookAddOnModel {
   /// route
   Map<String, String> toQueryParameter() {
     return {};
+  }
+
+  /// Allows for parsing of [queryParameters] by using information from the
+  /// router and from the initially provided [WidgetbookAddOnModel].
+  ///
+  /// If no [queryParameters] are available, return `null`.
+  /// If [queryParameters] are available return a property `Setting` object.
+  ///
+  /// If not overridden, returns `null`.
+  T? fromQueryParameter(
+    Map<String, String> queryParameters,
+  ) {
+    return null;
   }
 }

--- a/packages/widgetbook_addon/test/helper/custom_addon.dart
+++ b/packages/widgetbook_addon/test/helper/custom_addon.dart
@@ -24,9 +24,6 @@ class CustomAddOn extends WidgetbookAddOn<CustomAddOnSetting> {
         );
 
   @override
-  void updateQueryParameters(BuildContext context, CustomAddOnSetting value) {}
-
-  @override
   CustomAddOnSetting settingFromQueryParameters({
     required Map<String, String> queryParameters,
     required CustomAddOnSetting setting,

--- a/packages/widgetbook_addon/test/helper/custom_addon.dart
+++ b/packages/widgetbook_addon/test/helper/custom_addon.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:widgetbook_addon/widgetbook_addon.dart';
 
-class CustomAddOnSetting extends WidgetbookAddOnModel {
+class CustomAddOnSetting extends WidgetbookAddOnModel<CustomAddOnSetting> {
   const CustomAddOnSetting({
     required this.data,
   });
@@ -14,6 +14,13 @@ class CustomAddOnSetting extends WidgetbookAddOnModel {
       'data': data,
     };
   }
+
+  @override
+  CustomAddOnSetting? fromQueryParameter(Map<String, String> queryParameters) {
+    return queryParameters.containsKey('data')
+        ? CustomAddOnSetting(data: queryParameters['data']!)
+        : null;
+  }
 }
 
 class CustomAddOn extends WidgetbookAddOn<CustomAddOnSetting> {
@@ -22,16 +29,6 @@ class CustomAddOn extends WidgetbookAddOn<CustomAddOnSetting> {
   }) : super(
           name: 'Custom',
         );
-
-  @override
-  CustomAddOnSetting settingFromQueryParameters({
-    required Map<String, String> queryParameters,
-    required CustomAddOnSetting setting,
-  }) {
-    return CustomAddOnSetting(
-      data: queryParameters['data'] ?? 'Unknown',
-    );
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/packages/widgetbook_addon/test/src/addon_injector_widget_test.dart
+++ b/packages/widgetbook_addon/test/src/addon_injector_widget_test.dart
@@ -17,6 +17,7 @@ void main() {
             AddonInjectorWidget(
               routerData: {},
               addons: [],
+              onChanged: (_) {},
               child: Text('single child'),
             ),
           );
@@ -43,6 +44,7 @@ void main() {
                   ),
                 )
               ],
+              onChanged: (_) {},
               child: Text('single child'),
             ),
           );


### PR DESCRIPTION
Remove 2 abstract methods (`updateQueryParameters` & `settingFromQueryParameters`) from `WidgetbookAddOn` by providing the following alternatives respectively:

 1.  `WidgetbookAddOn.addListener`: Allows `AddonInjectorWidget` to add a listener on all addons that has the same logic of `updateQueryParameters` (i.e. syncing the `setting` with the query parameters).
 2. `WidgetbookAddOnModel.fromQueryParameter`: Move the responsibility of deserializing query parameters to the model instead of the addon itself (similar to `toJson` and `fromJson`).

### Screenshots

| Before  | After |
| :--- | :---- |
| ![before](https://user-images.githubusercontent.com/41103290/232298916-aeac7ee1-ff02-40ad-9524-d93b5a761000.png) | ![after](https://user-images.githubusercontent.com/41103290/232298402-3ecbbd3e-1afa-42ac-8288-af60078b7502.png) |



