### PR TITLE
ci: create `_package` reusable workflow

### DIFF
--- a/.github/workflows/_package.yml
+++ b/.github/workflows/_package.yml
@@ -12,12 +12,12 @@ on:
         default: ""
 
 jobs:
-  build:
+  doctor:
+    runs-on: ubuntu-latest
+
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
-
-    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/_package.yml
+++ b/.github/workflows/_package.yml
@@ -6,6 +6,10 @@ on:
       working_directory:
         required: true
         type: string
+      post_checkout:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build:
@@ -18,6 +22,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Run Post Checkout Script
+        if: "${{ inputs.post_checkout != '' }}"
+        run: ${{ inputs.post_checkout }}
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/_package.yml
+++ b/.github/workflows/_package.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 jobs:
-  flutter:
+  build:
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -1,0 +1,43 @@
+name: Package Workflow
+
+on:
+  workflow_call:
+    inputs:
+      working_directory:
+        required: true
+        type: string
+
+jobs:
+  flutter:
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install Melos
+        run: flutter pub global activate melos
+
+      - name: Install Dependencies
+        run: melos bootstrap
+
+      - name: Generate Files
+        run: melos generate
+
+      - name: Check Formatting
+        run: dart format --set-exit-if-changed .
+
+      - name: Analyze
+        run: dart analyze .
+
+      - name: Run Tests
+        run: flutter test --coverage

--- a/.github/workflows/widgetbook-addon.yaml
+++ b/.github/workflows/widgetbook-addon.yaml
@@ -10,12 +10,7 @@ on:
       - main
 
 jobs:
-  build:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+  _:
+    uses: ./.github/workflows/_package.yml
     with:
-      flutter_channel: stable
       working_directory: packages/widgetbook_addon
-      min_coverage: 68
-      setup: |
-        dart pub global activate melos
-        melos bootstrap --scope='widgetbook_addon'

--- a/.github/workflows/widgetbook-annotation.yaml
+++ b/.github/workflows/widgetbook-annotation.yaml
@@ -10,13 +10,7 @@ on:
       - main
 
 jobs:
-  build:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+  _:
+    uses: ./.github/workflows/_package.yml
     with:
-      flutter_channel: stable
       working_directory: packages/widgetbook_annotation
-      min_coverage: 16
-      setup: |
-        dart pub global activate melos
-        melos bootstrap
-        melos run generate

--- a/.github/workflows/widgetbook-cli.yaml
+++ b/.github/workflows/widgetbook-cli.yaml
@@ -10,13 +10,7 @@ on:
       - main
 
 jobs:
-  build:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+  _:
+    uses: ./.github/workflows/_package.yml
     with:
-      flutter_channel: stable
       working_directory: packages/widgetbook_cli
-      analyze_directories: bin test
-      setup: |
-        dart pub global activate melos
-        melos bootstrap
-        melos run generate

--- a/.github/workflows/widgetbook-core.yaml
+++ b/.github/workflows/widgetbook-core.yaml
@@ -10,12 +10,7 @@ on:
       - main
 
 jobs:
-  build:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+  _:
+    uses: ./.github/workflows/_package.yml
     with:
-      flutter_channel: stable
       working_directory: packages/widgetbook_core
-      setup: |
-        dart pub global activate melos
-        melos bootstrap
-        melos run generate

--- a/.github/workflows/widgetbook-exception.yaml
+++ b/.github/workflows/widgetbook-exception.yaml
@@ -10,11 +10,7 @@ on:
       - main
 
 jobs:
-  build:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+  _:
+    uses: ./.github/workflows/_package.yml
     with:
-      flutter_channel: stable
       working_directory: packages/widgetbook_exception
-      setup: |
-        dart pub global activate melos
-        melos bootstrap --scope='widgetbook_exception'

--- a/.github/workflows/widgetbook-generator.yaml
+++ b/.github/workflows/widgetbook-generator.yaml
@@ -10,13 +10,7 @@ on:
       - main
 
 jobs:
-  build:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+  _:
+    uses: ./.github/workflows/_package.yml
     with:
-      flutter_channel: stable
       working_directory: packages/widgetbook_generator
-      min_coverage: 67
-      setup: |
-        dart pub global activate melos
-        melos bootstrap
-        melos run generate

--- a/.github/workflows/widgetbook-git.yaml
+++ b/.github/workflows/widgetbook-git.yaml
@@ -10,17 +10,11 @@ on:
       - main
 
 jobs:
-  build:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+  _:
+    uses: ./.github/workflows/_package.yml
     with:
-      flutter_channel: stable
       working_directory: packages/widgetbook_git
-      min_coverage: 75
-      setup: |
+      post_checkout: |
         # Setup dummy Git user
         git config --global user.email "you@example.com"
         git config --global user.name "Your Name"
-
-        # Melos Bootstrap
-        dart pub global activate melos
-        melos bootstrap --scope='widgetbook_git'

--- a/.github/workflows/widgetbook-models.yaml
+++ b/.github/workflows/widgetbook-models.yaml
@@ -10,12 +10,8 @@ on:
       - main
 
 jobs:
-  build:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+  _:
+    uses: ./.github/workflows/_package.yml
     with:
-      flutter_channel: stable
       working_directory: packages/widgetbook_models
-      setup: |
-        dart pub global activate melos
-        melos bootstrap
-        melos run generate
+

--- a/.github/workflows/widgetbook.yaml
+++ b/.github/workflows/widgetbook.yaml
@@ -10,7 +10,7 @@ on:
       - main
 
 jobs:
-  build:
-    uses: ./.github/workflows/base.yml
+  _:
+    uses: ./.github/workflows/_package.yml
     with:
       working_directory: packages/widgetbook

--- a/.github/workflows/widgetbook.yaml
+++ b/.github/workflows/widgetbook.yaml
@@ -11,13 +11,6 @@ on:
 
 jobs:
   build:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+    uses: ./.github/workflows/base.yml
     with:
-      flutter_channel: stable
       working_directory: packages/widgetbook
-      min_coverage: 77
-      test_optimization: false
-      setup: |
-        dart pub global activate melos
-        melos bootstrap
-        melos run generate


### PR DESCRIPTION
The new reusable workflow is an alternative for [`very_good_workflows`](https://github.com/VeryGoodOpenSource/very_good_workflows) which wasn't working properly with `melos` and local dependencies.

> ⚠️ **Caveat**
> This PR does NOT support **test coverage** yet, and it will be done later on when we stablize the coverage across packages.
