### PR TITLE
refactor(annotation): remove `Widgetbook` prefix

### DIFF
--- a/examples/screen_util_example/lib/image_page.dart
+++ b/examples/screen_util_example/lib/image_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:widgetbook_annotation/widgetbook_annotation.dart' as anno;
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' hide Theme;
 
-@anno.WidgetbookUseCase(name: 'Example', type: ImagePage)
+@UseCase(name: 'Example', type: ImagePage)
 Widget testUseCase(BuildContext context) {
   return const ImagePage(
     title: 'Image example',

--- a/examples/screen_util_example/lib/main.dart
+++ b/examples/screen_util_example/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:widgetbook/widgetbook.dart';
-import 'package:widgetbook_annotation/widgetbook_annotation.dart' as anno;
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
 /// An example [Widget] that uses [ScreenUtil].
 class ScreenUtilExample extends StatelessWidget {
@@ -30,7 +30,7 @@ class ScreenUtilExample extends StatelessWidget {
   }
 }
 
-@anno.WidgetbookUseCase(
+@widgetbook.UseCase(
   name: 'show screen height and width',
   type: ScreenUtilExample,
 )
@@ -43,7 +43,7 @@ Widget exampleBuilder(BuildContext context) {
 ///
 /// For more context on how to create the app builder see [materialAppBuilder]
 /// or have a look at the documentation.
-@anno.WidgetbookAppBuilder()
+@widgetbook.AppBuilder()
 Widget appBuilder(BuildContext context, Widget child) {
   return ScreenUtilInit(
     designSize: const Size(375, 812),
@@ -73,7 +73,7 @@ void main() {
 ///
 /// Note: The [WidgetbookApp] annotation can used on ANY code element.
 /// For more information, see the documentation
-@anno.WidgetbookApp.material(
+@widgetbook.App.material(
   // Adding devices is mandatory as it enables the [DeviceAddon] that is
   // required to properly set [MediaQuery] parameters
   devices: [

--- a/packages/widgetbook_annotation/lib/src/app.dart
+++ b/packages/widgetbook_annotation/lib/src/app.dart
@@ -1,40 +1,41 @@
-import 'package:widgetbook_annotation/src/widgetbook_constructor.dart';
 import 'package:widgetbook_models/widgetbook_models.dart';
+
+import 'constructor.dart';
 
 /// Annotates a code element to create the widgetbook main file in the same
 /// folder in which the annotated element is defined.
-class WidgetbookApp {
+class App {
   /// Creates a new annotation optional [devices] and [textScaleFactors].
   /// If devices is not set or set to an empty list, no code for the
   /// Widgetbook.devices property will be generated.
   /// Therefore, the default of Widgetbook will be used.
-  const WidgetbookApp({
+  const App({
     required Type this.themeType,
     this.devices = const <Device>[],
     this.textScaleFactors = const <double>[],
     this.foldersExpanded = false,
     this.widgetsExpanded = false,
-    this.constructor = WidgetbookConstructor.custom,
+    this.constructor = Constructor.custom,
   });
 
   /// Annotates a code element to creat a Material-themed widgetbook main file
   /// in the same folder in which the annotated element is defined.
-  const WidgetbookApp.material({
+  const App.material({
     this.devices = const <Device>[],
     this.textScaleFactors = const <double>[],
     this.foldersExpanded = false,
     this.widgetsExpanded = false,
-    this.constructor = WidgetbookConstructor.material,
+    this.constructor = Constructor.material,
   }) : themeType = null;
 
   /// Annotates a code element to creat a Cupertino-themed widgetbook main
   /// file in the same folder in which the annotated element is defined.
-  const WidgetbookApp.cupertino({
+  const App.cupertino({
     this.devices = const <Device>[],
     this.textScaleFactors = const <double>[],
     this.foldersExpanded = false,
     this.widgetsExpanded = false,
-    this.constructor = WidgetbookConstructor.cupertino,
+    this.constructor = Constructor.cupertino,
   }) : themeType = null;
 
   /// The type of the ThemeData.
@@ -42,7 +43,7 @@ class WidgetbookApp {
 
   /// Indicates which type of theme is used for the generic Widgetbook
   /// implementation.
-  final WidgetbookConstructor constructor;
+  final Constructor constructor;
 
   /// The devices shown in the Widgetbook
   final List<Device> devices;

--- a/packages/widgetbook_annotation/lib/src/app_builder.dart
+++ b/packages/widgetbook_annotation/lib/src/app_builder.dart
@@ -1,0 +1,5 @@
+/// Annotates a app builder function
+class AppBuilder {
+  /// Creates a new [AppBuilder].
+  const AppBuilder();
+}

--- a/packages/widgetbook_annotation/lib/src/constructor.dart
+++ b/packages/widgetbook_annotation/lib/src/constructor.dart
@@ -1,5 +1,5 @@
 /// Specifies the type of constructor used to create the widgetbook
-enum WidgetbookConstructor {
+enum Constructor {
   /// Generates a Widgetbook.material(...)
   material,
 
@@ -11,15 +11,15 @@ enum WidgetbookConstructor {
 }
 
 /// Extension to create a named constructor from the enum
-extension WidgetbookConstructorExtension on WidgetbookConstructor {
+extension ConstructorExtension on Constructor {
   /// transforms the enum into text
   String? get toCode {
     switch (this) {
-      case WidgetbookConstructor.material:
+      case Constructor.material:
         return 'material';
-      case WidgetbookConstructor.cupertino:
+      case Constructor.cupertino:
         return 'cupertino';
-      case WidgetbookConstructor.custom:
+      case Constructor.custom:
         return null;
     }
   }

--- a/packages/widgetbook_annotation/lib/src/locales.dart
+++ b/packages/widgetbook_annotation/lib/src/locales.dart
@@ -1,0 +1,6 @@
+/// Annotates a list of `Locale`s to support the app's localization in
+/// Widgetbook
+class Locales {
+  /// Creates a new instance of [Locales].
+  const Locales();
+}

--- a/packages/widgetbook_annotation/lib/src/localization_delegates.dart
+++ b/packages/widgetbook_annotation/lib/src/localization_delegates.dart
@@ -1,0 +1,6 @@
+/// Annotates a list of `LocalizationDelegate`s to support the app's
+/// localization in Widgetbook
+class LocalizationDelegates {
+  /// Creates a new instance of [LocalizationDelegates].
+  const LocalizationDelegates();
+}

--- a/packages/widgetbook_annotation/lib/src/theme.dart
+++ b/packages/widgetbook_annotation/lib/src/theme.dart
@@ -1,7 +1,7 @@
 /// Annotates a function returning a Theme.
-class WidgetbookTheme {
-  /// Creates a new instance of [WidgetbookTheme].
-  const WidgetbookTheme({
+class Theme {
+  /// Creates a new instance of [Theme].
+  const Theme({
     required this.name,
     this.isDefault = false,
   });

--- a/packages/widgetbook_annotation/lib/src/use_case.dart
+++ b/packages/widgetbook_annotation/lib/src/use_case.dart
@@ -1,14 +1,14 @@
 /// Annotates a builder function which is used to create the WidgetbookComponent
-/// and [WidgetbookUseCase] for the Widgetbook
-class WidgetbookUseCase {
+/// and [UseCase] for the Widgetbook
+class UseCase {
   /// Creates a new annotation with [name] and [type].
   ///
-  /// The [name] defines how the [WidgetbookUseCase] will show in the navigation
+  /// The [name] defines how the [UseCase] will show in the navigation
   /// area of the widgetbook.
   ///
   /// The [type] defines the Widget rendered with the UseCase. Therefore, it is
   /// used to create the WidgetElement of the Widgetbook
-  const WidgetbookUseCase({
+  const UseCase({
     required this.name,
     required this.type,
     this.designLink,

--- a/packages/widgetbook_annotation/lib/src/widgetbook_app_builder.dart
+++ b/packages/widgetbook_annotation/lib/src/widgetbook_app_builder.dart
@@ -1,5 +1,0 @@
-/// Annotates a app builder function
-class WidgetbookAppBuilder {
-  /// Creates a new [WidgetbookAppBuilder].
-  const WidgetbookAppBuilder();
-}

--- a/packages/widgetbook_annotation/lib/src/widgetbook_locales.dart
+++ b/packages/widgetbook_annotation/lib/src/widgetbook_locales.dart
@@ -1,6 +1,0 @@
-/// Annotates a list of `Locale`s to support the app's localization in
-/// Widgetbook
-class WidgetbookLocales {
-  /// Creates a new instance of [WidgetbookLocales].
-  const WidgetbookLocales();
-}

--- a/packages/widgetbook_annotation/lib/src/widgetbook_localization_delegates.dart
+++ b/packages/widgetbook_annotation/lib/src/widgetbook_localization_delegates.dart
@@ -1,6 +1,0 @@
-/// Annotates a list of `LocalizationDelegate`s to support the app's
-/// localization in Widgetbook
-class WidgetbookLocalizationDelegates {
-  /// Creates a new instance of [WidgetbookLocalizationDelegates].
-  const WidgetbookLocalizationDelegates();
-}

--- a/packages/widgetbook_annotation/lib/widgetbook_annotation.dart
+++ b/packages/widgetbook_annotation/lib/widgetbook_annotation.dart
@@ -1,9 +1,9 @@
 export 'package:widgetbook_models/widgetbook_models.dart';
 
-export './src/widgetbook_app.dart';
-export './src/widgetbook_app_builder.dart';
-export './src/widgetbook_constructor.dart';
-export './src/widgetbook_locales.dart';
-export './src/widgetbook_localization_delegates.dart';
-export './src/widgetbook_theme.dart';
-export './src/widgetbook_use_case.dart';
+export 'src/app.dart';
+export 'src/app_builder.dart';
+export 'src/constructor.dart';
+export 'src/locales.dart';
+export 'src/localization_delegates.dart';
+export 'src/theme.dart';
+export 'src/use_case.dart';

--- a/packages/widgetbook_annotation/test/src/app_test.dart
+++ b/packages/widgetbook_annotation/test/src/app_test.dart
@@ -4,10 +4,10 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 
 void main() {
   group(
-    '$WidgetbookApp',
+    '$App',
     () {
       test('defaults to empty list', () {
-        const instance = WidgetbookApp.material();
+        const instance = App.material();
 
         expect(
           instance.devices,

--- a/packages/widgetbook_annotation/test/src/use_case_test.dart
+++ b/packages/widgetbook_annotation/test/src/use_case_test.dart
@@ -1,11 +1,11 @@
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
-import 'package:widgetbook_annotation/src/widgetbook_use_case.dart';
+import 'package:widgetbook_annotation/src/use_case.dart';
 
 void main() {
-  group('$WidgetbookUseCase', () {
+  group('$UseCase', () {
     test('creates instance', () {
-      const instance = WidgetbookUseCase(name: 'Test', type: int);
+      const instance = UseCase(name: 'Test', type: int);
 
       expect(
         instance.name,

--- a/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_instance.dart
+++ b/packages/widgetbook_generator/lib/code_generators/instances/widgetbook_instance.dart
@@ -9,7 +9,7 @@ import 'package:widgetbook_generator/code_generators/properties/property.dart';
 class WidgetbookInstance extends Instance {
   /// Creates a new instance of [WidgetbookInstance]
   WidgetbookInstance({
-    required WidgetbookConstructor constructor,
+    required Constructor constructor,
     required List<Instance> directories,
     required List<AddOnInstance> addons,
     String? type,

--- a/packages/widgetbook_generator/lib/generators/app_generator.dart
+++ b/packages/widgetbook_generator/lib/generators/app_generator.dart
@@ -15,7 +15,7 @@ import 'package:widgetbook_generator/services/tree_service.dart';
 
 /// Generates the code of the Widgetbook
 String generateWidgetbook({
-  required WidgetbookConstructor constructor,
+  required Constructor constructor,
   required List<WidgetbookUseCaseData> useCases,
   required List<Device> devices,
   required List<double> textScaleFactors,
@@ -34,14 +34,14 @@ String generateWidgetbook({
   final addons = <AddOnInstance>[];
   if (themes.isNotEmpty) {
     switch (constructor) {
-      case WidgetbookConstructor.material:
+      case Constructor.material:
         addons.add(
           MaterialThemeAddonInstance(
             themes: themes,
           ),
         );
         break;
-      case WidgetbookConstructor.cupertino:
+      case Constructor.cupertino:
         addons.add(
           CustomThemeAddonInstance(
             themes: themes,
@@ -49,7 +49,7 @@ String generateWidgetbook({
           ),
         );
         break;
-      case WidgetbookConstructor.custom:
+      case Constructor.custom:
         if (widgetbookThemeData != null) {
           addons.add(
             CustomThemeAddonInstance(

--- a/packages/widgetbook_generator/lib/generators/widgetbook_generator.dart
+++ b/packages/widgetbook_generator/lib/generators/widgetbook_generator.dart
@@ -20,9 +20,9 @@ import 'package:widgetbook_generator/readers/device_reader.dart';
 
 /// Generates the code for Widgetbook
 ///
-/// The code is located at the same location in which the [WidgetbookApp]
+/// The code is located at the same location in which the [App]
 /// annotation is used.
-class WidgetbookGenerator extends GeneratorForAnnotation<WidgetbookApp> {
+class WidgetbookGenerator extends GeneratorForAnnotation<App> {
   @override
   Future<String> generateForAnnotatedElement(
     Element element,
@@ -158,9 +158,9 @@ List<double> _getTextScaleFactors(ConstantReader annotation) {
   return factors;
 }
 
-WidgetbookConstructor _getConstructor(ConstantReader annotation) {
+Constructor _getConstructor(ConstantReader annotation) {
   final index = annotation.read('constructor').read('index').intValue;
-  return WidgetbookConstructor.values[index];
+  return Constructor.values[index];
 }
 
 WidgetbookThemeTypeData? _getThemeType(ConstantReader annotation) {

--- a/packages/widgetbook_generator/lib/resolvers/app_builder_resolver.dart
+++ b/packages/widgetbook_generator/lib/resolvers/app_builder_resolver.dart
@@ -2,7 +2,7 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_generator/models/widgetbook_app_builder_data.dart';
 import 'package:widgetbook_generator/resolvers/builder_function_resolver.dart';
 
-class AppBuilderResolver extends BuilderFunctionResolver<WidgetbookAppBuilder> {
+class AppBuilderResolver extends BuilderFunctionResolver<AppBuilder> {
   AppBuilderResolver()
       : super(
           createData: (

--- a/packages/widgetbook_generator/lib/resolvers/device_resolver.dart
+++ b/packages/widgetbook_generator/lib/resolvers/device_resolver.dart
@@ -5,7 +5,7 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_generator/json_formatter.dart';
 import 'package:widgetbook_generator/models/widgetbook_device_data.dart';
 
-class DeviceResolver extends GeneratorForAnnotation<WidgetbookApp> {
+class DeviceResolver extends GeneratorForAnnotation<App> {
   @override
   dynamic generateForAnnotatedElement(
     Element element,

--- a/packages/widgetbook_generator/lib/resolvers/locales_resolver.dart
+++ b/packages/widgetbook_generator/lib/resolvers/locales_resolver.dart
@@ -8,7 +8,7 @@ import 'package:widgetbook_generator/extensions/element_extensions.dart';
 import 'package:widgetbook_generator/json_formatter.dart';
 import 'package:widgetbook_generator/models/widgetbook_locales_data.dart';
 
-class LocalesResolver extends GeneratorForAnnotation<WidgetbookLocales> {
+class LocalesResolver extends GeneratorForAnnotation<Locales> {
   @override
   Future<String> generateForAnnotatedElement(
     Element element,

--- a/packages/widgetbook_generator/lib/resolvers/localization_delegates_resolver.dart
+++ b/packages/widgetbook_generator/lib/resolvers/localization_delegates_resolver.dart
@@ -7,7 +7,7 @@ import 'package:widgetbook_generator/json_formatter.dart';
 import 'package:widgetbook_generator/models/widgetbook_localization_builder_data.dart';
 
 class LocalizationDelegatesResolver
-    extends GeneratorForAnnotation<WidgetbookLocalizationDelegates> {
+    extends GeneratorForAnnotation<LocalizationDelegates> {
   @override
   String generateForAnnotatedElement(
     Element element,

--- a/packages/widgetbook_generator/lib/resolvers/text_scale_factor_resolver.dart
+++ b/packages/widgetbook_generator/lib/resolvers/text_scale_factor_resolver.dart
@@ -5,7 +5,7 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_generator/json_formatter.dart';
 import 'package:widgetbook_generator/models/widgetbook_text_scale_factor_data.dart';
 
-class TextScaleFactorResolver extends GeneratorForAnnotation<WidgetbookApp> {
+class TextScaleFactorResolver extends GeneratorForAnnotation<App> {
   @override
   dynamic generateForAnnotatedElement(
     Element element,

--- a/packages/widgetbook_generator/lib/resolvers/theme_resolver.dart
+++ b/packages/widgetbook_generator/lib/resolvers/theme_resolver.dart
@@ -6,7 +6,7 @@ import 'package:widgetbook_generator/extensions/element_extensions.dart';
 import 'package:widgetbook_generator/json_formatter.dart';
 import 'package:widgetbook_generator/models/widgetbook_theme_data.dart';
 
-class ThemeResolver extends GeneratorForAnnotation<WidgetbookTheme> {
+class ThemeResolver extends GeneratorForAnnotation<Theme> {
   @override
   String generateForAnnotatedElement(
     Element element,
@@ -23,7 +23,7 @@ class ThemeResolver extends GeneratorForAnnotation<WidgetbookTheme> {
     if (element.kind != ElementKind.FUNCTION ||
         !(element as FunctionElement).isStatic) {
       throw InvalidGenerationSourceError(
-        'The $WidgetbookTheme annotation cannot be applied to static '
+        'The $Theme annotation cannot be applied to static '
         'functions.',
         element: element,
       );

--- a/packages/widgetbook_generator/lib/resolvers/use_case_resolver.dart
+++ b/packages/widgetbook_generator/lib/resolvers/use_case_resolver.dart
@@ -6,7 +6,7 @@ import 'package:widgetbook_generator/extensions/element_extensions.dart';
 import 'package:widgetbook_generator/json_formatter.dart';
 import 'package:widgetbook_generator/models/widgetbook_use_case_data.dart';
 
-class UseCaseResolver extends GeneratorForAnnotation<WidgetbookUseCase> {
+class UseCaseResolver extends GeneratorForAnnotation<UseCase> {
   @override
   String generateForAnnotatedElement(
     Element element,

--- a/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code_generators/instances/widgetbook_instance_test.dart
@@ -15,7 +15,7 @@ void main() {
       'Widgetbook',
       instance: WidgetbookInstance(
         addons: const [],
-        constructor: WidgetbookConstructor.material,
+        constructor: Constructor.material,
         directories: const [],
       ),
     );
@@ -40,7 +40,7 @@ void main() {
       () {
         final instance = WidgetbookInstance(
           addons: const [],
-          constructor: WidgetbookConstructor.material,
+          constructor: Constructor.material,
           directories: const [],
         );
 
@@ -59,7 +59,7 @@ void main() {
       () {
         final instance = WidgetbookInstance(
           addons: const [],
-          constructor: WidgetbookConstructor.material,
+          constructor: Constructor.material,
           directories: const [],
         );
 
@@ -79,7 +79,7 @@ void main() {
       () {
         final instance = WidgetbookInstance(
           addons: const [],
-          constructor: WidgetbookConstructor.material,
+          constructor: Constructor.material,
           directories: const [],
         );
 
@@ -99,7 +99,7 @@ void main() {
       () {
         final instance = WidgetbookInstance(
           addons: const [],
-          constructor: WidgetbookConstructor.material,
+          constructor: Constructor.material,
           directories: const [],
         );
 

--- a/widgetbook_for_widgetbook/lib/app.dart
+++ b/widgetbook_for_widgetbook/lib/app.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:widgetbook/widgetbook.dart';
-import 'package:widgetbook_annotation/widgetbook_annotation.dart' as anno;
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 import 'package:widgetbook_core/widgetbook_core.dart';
 
-@anno.WidgetbookApp.material(
+@widgetbook.App.material(
   devices: [
     Apple.iPhone11,
     Apple.iPhone12,
@@ -16,10 +16,8 @@ import 'package:widgetbook_core/widgetbook_core.dart';
 )
 const int notUsed = 0;
 
-@anno.WidgetbookTheme(name: 'Dark', isDefault: true)
+@widgetbook.Theme(name: 'Dark', isDefault: true)
 ThemeData themeDark() => Themes.dark;
 
-@anno.WidgetbookTheme(
-  name: 'Light',
-)
+@widgetbook.Theme(name: 'Light')
 ThemeData themeLight() => Themes.light;

--- a/widgetbook_for_widgetbook/lib/navigation/expander_button.dart
+++ b/widgetbook_for_widgetbook/lib/navigation/expander_button.dart
@@ -3,7 +3,7 @@ import 'package:widgetbook/widgetbook.dart' show Knobs;
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
-@WidgetbookUseCase(name: 'Default', type: ExpanderIcon)
+@UseCase(name: 'Default', type: ExpanderIcon)
 Widget expanderButton(BuildContext context) {
   return ExpanderIcon(
     isExpanded: context.knobs.boolean(label: 'Is expanded'),

--- a/widgetbook_for_widgetbook/lib/navigation/navigation_panel.dart
+++ b/widgetbook_for_widgetbook/lib/navigation/navigation_panel.dart
@@ -4,7 +4,7 @@ import 'package:widgetbook_core/widgetbook_core.dart';
 import 'package:widgetbook_for_widgetbook/navigation/navigation_bloc_provider.dart';
 import 'package:widgetbook_for_widgetbook/navigation/navigation_test_data.dart';
 
-@WidgetbookUseCase(name: 'Default', type: NavigationPanel)
+@UseCase(name: 'Default', type: NavigationPanel)
 Widget navigationPanelDefaultUseCase(BuildContext context) {
   return const NavigationBlocProvider(
     directories: directories,

--- a/widgetbook_for_widgetbook/lib/navigation/navigation_tree.dart
+++ b/widgetbook_for_widgetbook/lib/navigation/navigation_tree.dart
@@ -4,7 +4,7 @@ import 'package:widgetbook_core/widgetbook_core.dart';
 import 'package:widgetbook_for_widgetbook/navigation/navigation_bloc_provider.dart';
 import 'package:widgetbook_for_widgetbook/navigation/navigation_test_data.dart';
 
-@WidgetbookUseCase(name: 'Default', type: NavigationTree)
+@UseCase(name: 'Default', type: NavigationTree)
 Widget navigationTreeDefaultUseCase(BuildContext context) {
   return const NavigationBlocProvider(
     directories: directories,

--- a/widgetbook_for_widgetbook/lib/navigation/navigation_tree_item.dart
+++ b/widgetbook_for_widgetbook/lib/navigation/navigation_tree_item.dart
@@ -3,7 +3,7 @@ import 'package:widgetbook/widgetbook.dart' show Knobs;
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
-@WidgetbookUseCase(name: 'Default', type: NavigationTreeItem)
+@UseCase(name: 'Default', type: NavigationTreeItem)
 Widget navigationTreeItemWithout(BuildContext context) {
   final nodeType = context.knobs.options<NavigationNodeType>(
     label: 'Node Type',

--- a/widgetbook_for_widgetbook/lib/navigation/navigation_tree_node.dart
+++ b/widgetbook_for_widgetbook/lib/navigation/navigation_tree_node.dart
@@ -3,7 +3,7 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 import 'package:widgetbook_for_widgetbook/navigation/navigation_test_data.dart';
 
-@WidgetbookUseCase(name: 'Default', type: NavigationTreeNode)
+@UseCase(name: 'Default', type: NavigationTreeNode)
 Widget navigationTreeNodeDefaultUseCase(BuildContext context) {
   return const NavigationTreeNode(
     data: testNode5,

--- a/widgetbook_for_widgetbook/lib/search/search.dart
+++ b/widgetbook_for_widgetbook/lib/search/search.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
-@WidgetbookUseCase(name: 'Default', type: SearchField)
+@UseCase(name: 'Default', type: SearchField)
 Widget searchFieldDefaultUseCase(BuildContext context) {
   return const SearchField();
 }

--- a/widgetbook_for_widgetbook/lib/settings/features/knobs/bool_knob.widgetbook.dart
+++ b/widgetbook_for_widgetbook/lib/settings/features/knobs/bool_knob.widgetbook.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
-@WidgetbookUseCase(name: 'Default', type: BoolKnob)
+@UseCase(name: 'Default', type: BoolKnob)
 Widget boolKnob(BuildContext context) {
   return const BoolKnob(
     name: 'Is enabled',
@@ -11,7 +11,7 @@ Widget boolKnob(BuildContext context) {
   );
 }
 
-@WidgetbookUseCase(name: 'Default', type: NullableBoolKnob)
+@UseCase(name: 'Default', type: NullableBoolKnob)
 Widget nullableBoolKnob(BuildContext context) {
   return const NullableBoolKnob(
     name: 'Is enabled',

--- a/widgetbook_for_widgetbook/lib/settings/features/knobs/color_knob.widgetbook.dart
+++ b/widgetbook_for_widgetbook/lib/settings/features/knobs/color_knob.widgetbook.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
-@WidgetbookUseCase(name: 'Default', type: ColorKnob)
+@UseCase(name: 'Default', type: ColorKnob)
 Widget colorKnob(BuildContext context) {
   return const ColorKnob(
     name: 'Color',

--- a/widgetbook_for_widgetbook/lib/settings/features/knobs/number_knob.widgetbook.dart
+++ b/widgetbook_for_widgetbook/lib/settings/features/knobs/number_knob.widgetbook.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
-@WidgetbookUseCase(name: 'Default', type: NumberKnob)
+@UseCase(name: 'Default', type: NumberKnob)
 Widget numberKnob(BuildContext context) {
   return const NumberKnob(
     name: 'Is enabled',
@@ -11,7 +11,7 @@ Widget numberKnob(BuildContext context) {
   );
 }
 
-@WidgetbookUseCase(name: 'Default', type: NullableNumberKnob)
+@UseCase(name: 'Default', type: NullableNumberKnob)
 Widget nullableNumberKniob(BuildContext context) {
   return const NullableNumberKnob(
     name: 'Is enabled',

--- a/widgetbook_for_widgetbook/lib/settings/features/knobs/option_knob.widgetbook.dart
+++ b/widgetbook_for_widgetbook/lib/settings/features/knobs/option_knob.widgetbook.dart
@@ -12,7 +12,7 @@ class Person {
   final int age;
 }
 
-@WidgetbookUseCase(name: 'Default', type: OptionKnob)
+@UseCase(name: 'Default', type: OptionKnob)
 Widget optionKnob(BuildContext context) {
   const john = Person(name: 'John Doe', age: 24);
   const jane = Person(name: 'Jane Doe', age: 20);

--- a/widgetbook_for_widgetbook/lib/settings/features/knobs/slider_knob.widgetbook.dart
+++ b/widgetbook_for_widgetbook/lib/settings/features/knobs/slider_knob.widgetbook.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
-@WidgetbookUseCase(name: 'Default', type: SliderKnob)
+@UseCase(name: 'Default', type: SliderKnob)
 Widget sliderKnob(BuildContext context) {
   return const SliderKnob(
     name: 'Is enabled',
@@ -13,7 +13,7 @@ Widget sliderKnob(BuildContext context) {
   );
 }
 
-@WidgetbookUseCase(name: 'Default', type: NullableSliderKnob)
+@UseCase(name: 'Default', type: NullableSliderKnob)
 Widget nullableSliderKnob(BuildContext context) {
   return const NullableSliderKnob(
     name: 'Is enabled',

--- a/widgetbook_for_widgetbook/lib/settings/features/knobs/text_knob.widgetbook.dart
+++ b/widgetbook_for_widgetbook/lib/settings/features/knobs/text_knob.widgetbook.dart
@@ -3,7 +3,7 @@ import 'package:widgetbook/widgetbook.dart' show Knobs;
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
-@WidgetbookUseCase(name: 'Default', type: TextKnob)
+@UseCase(name: 'Default', type: TextKnob)
 Widget textKnob(BuildContext context) {
   return TextKnob(
     name: 'Is enabled',
@@ -15,7 +15,7 @@ Widget textKnob(BuildContext context) {
   );
 }
 
-@WidgetbookUseCase(name: 'Default', type: NullableTextKnob)
+@UseCase(name: 'Default', type: NullableTextKnob)
 Widget nullableTextKnob(BuildContext context) {
   return NullableTextKnob(
     name: 'Is enabled',

--- a/widgetbook_for_widgetbook/lib/settings/features/widgets/complex_setting.widgetbook.dart
+++ b/widgetbook_for_widgetbook/lib/settings/features/widgets/complex_setting.widgetbook.dart
@@ -3,7 +3,7 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 import 'package:widgetbook_for_widgetbook/settings/features/widgets/helper.dart';
 
-@WidgetbookUseCase(name: 'Default', type: ComplexSetting)
+@UseCase(name: 'Default', type: ComplexSetting)
 Widget complexSettingUseCase(BuildContext context) {
   return complexSetting(context);
 }

--- a/widgetbook_for_widgetbook/lib/settings/features/widgets/dropdown_setting.widgetbook.dart
+++ b/widgetbook_for_widgetbook/lib/settings/features/widgets/dropdown_setting.widgetbook.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:widgetbook/widgetbook.dart';
-import 'package:widgetbook_annotation/widgetbook_annotation.dart' as anno;
+import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
-@anno.WidgetbookUseCase(name: 'Test', type: DropdownSetting)
+@UseCase(name: 'Test', type: DropdownSetting)
 Widget test(BuildContext context) {
   return DropdownSetting(
     onSelected: (p0) {},

--- a/widgetbook_for_widgetbook/lib/settings/features/widgets/setting_group.widgetbook.dart
+++ b/widgetbook_for_widgetbook/lib/settings/features/widgets/setting_group.widgetbook.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:widgetbook_annotation/widgetbook_annotation.dart' as anno;
+import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 import 'package:widgetbook_for_widgetbook/settings/features/widgets/helper.dart';
 
-@anno.WidgetbookUseCase(
+@UseCase(
   name: 'default',
   type: SettingGroup,
 )

--- a/widgetbook_for_widgetbook/lib/settings/features/widgets/setting_header.widgetbook.dart
+++ b/widgetbook_for_widgetbook/lib/settings/features/widgets/setting_header.widgetbook.dart
@@ -3,14 +3,14 @@ import 'package:widgetbook/widgetbook.dart' show Knobs;
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
-@WidgetbookUseCase(name: 'Text only', type: SettingHeader)
+@UseCase(name: 'Text only', type: SettingHeader)
 Widget textOnly(BuildContext context) {
   return SettingHeader(
     content: context.knobs.text(label: 'Content', initialValue: 'Frames'),
   );
 }
 
-@WidgetbookUseCase(name: 'with Trailing', type: SettingHeader)
+@UseCase(name: 'with Trailing', type: SettingHeader)
 Widget trailing(BuildContext context) {
   return SettingHeader(
     content: context.knobs.text(label: 'Content', initialValue: 'Frames'),

--- a/widgetbook_for_widgetbook/lib/settings/features/widgets/setting_section.widgetbook.dart
+++ b/widgetbook_for_widgetbook/lib/settings/features/widgets/setting_section.widgetbook.dart
@@ -3,7 +3,7 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 import 'package:widgetbook_for_widgetbook/settings/features/widgets/helper.dart';
 
-@WidgetbookUseCase(name: 'Default', type: SettingSection)
+@UseCase(name: 'Default', type: SettingSection)
 Widget settingSection(BuildContext context) {
   return frameSettingSection(context);
 }

--- a/widgetbook_for_widgetbook/lib/settings/features/widgets/settings_panel.widgetbook.dart
+++ b/widgetbook_for_widgetbook/lib/settings/features/widgets/settings_panel.widgetbook.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:widgetbook_core/widgetbook_core.dart';
 
-@WidgetbookUseCase(name: 'Default', type: SettingsPanel)
+@UseCase(name: 'Default', type: SettingsPanel)
 Widget settingsPanel(BuildContext context) {
   return SettingsPanel(
     settings: [


### PR DESCRIPTION
Remove all `Widgetbook` prefix from annotations.
Some new names do not make sense or have naming conflicts with Flutter itself (e.g. `Theme`), but these annotations will be removed in the near future. 

The preferred way (until they get removed) to use the conflicting annotations is as follows:

```dart
import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;

@widgetbook.Theme(name: 'Dark', isDefault: true)
ThemeData themeDark() => Themes.dark;
```
