### PR TITLE
refactor(addon): group query params under name

### DIFF
--- a/packages/widgetbook/lib/src/addons/device_addon/device_addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_addon/device_addon.dart
@@ -17,6 +17,7 @@ class DeviceAddon extends WidgetbookAddOn<DeviceSetting> {
           'initialDevice must be in devices',
         ),
         super(
+          name: 'Device',
           initialSetting: DeviceSetting(
             // [null] represents a "none" device
             devices: [null, ...devices],
@@ -27,7 +28,7 @@ class DeviceAddon extends WidgetbookAddOn<DeviceSetting> {
   @override
   Widget buildSetting(BuildContext context) {
     return Setting(
-      name: 'Device',
+      name: name,
       child: Row(
         children: [
           DropdownSetting<Device?>(

--- a/packages/widgetbook/lib/src/addons/device_addon/device_setting.dart
+++ b/packages/widgetbook/lib/src/addons/device_addon/device_setting.dart
@@ -20,7 +20,7 @@ class DeviceSetting extends WidgetbookAddOnModel<DeviceSetting>
   @override
   Map<String, String> toMap() {
     return {
-      'device': activeDevice?.name ?? 'none',
+      'name': activeDevice?.name ?? 'none',
       'orientation': orientation.name,
       'frame': hasFrame.toString(),
     };
@@ -30,7 +30,7 @@ class DeviceSetting extends WidgetbookAddOnModel<DeviceSetting>
   DeviceSetting fromMap(Map<String, String> map) {
     return this.copyWith(
       activeDevice: devices.firstWhere(
-        (device) => device?.name == map['device'],
+        (device) => device?.name == map['name'],
         orElse: () => null,
       ),
       orientation: Orientation.values.byName(

--- a/packages/widgetbook/lib/src/addons/device_addon/device_setting.dart
+++ b/packages/widgetbook/lib/src/addons/device_addon/device_setting.dart
@@ -18,7 +18,7 @@ class DeviceSetting extends WidgetbookAddOnModel<DeviceSetting>
   DeviceSetting._();
 
   @override
-  Map<String, String> toQueryParameter() {
+  Map<String, String> toMap() {
     return {
       'device': activeDevice?.name ?? 'none',
       'orientation': orientation.name,
@@ -27,20 +27,16 @@ class DeviceSetting extends WidgetbookAddOnModel<DeviceSetting>
   }
 
   @override
-  DeviceSetting? fromQueryParameter(Map<String, String> queryParameters) {
-    return queryParameters.containsKey('device') &&
-            queryParameters.containsKey('orientation') &&
-            queryParameters.containsKey('frame')
-        ? this.copyWith(
-            activeDevice: devices.firstWhere(
-              (device) => device?.name == queryParameters['device']!,
-              orElse: () => null,
-            ),
-            orientation: Orientation.values.byName(
-              queryParameters['orientation']!,
-            ),
-            hasFrame: queryParameters['frame'] == 'true',
-          )
-        : null;
+  DeviceSetting fromMap(Map<String, String> map) {
+    return this.copyWith(
+      activeDevice: devices.firstWhere(
+        (device) => device?.name == map['device'],
+        orElse: () => null,
+      ),
+      orientation: Orientation.values.byName(
+        map['orientation'] ?? Orientation.portrait.name,
+      ),
+      hasFrame: map['frame'] == 'true',
+    );
   }
 }

--- a/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
+++ b/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
@@ -16,6 +16,7 @@ class LocalizationAddon extends WidgetbookAddOn<LocalizationSetting> {
           'initialLocale must be in locales',
         ),
         super(
+          name: 'Locale',
           initialSetting: LocalizationSetting(
             locales: locales,
             localizationsDelegates: localizationsDelegates,
@@ -26,7 +27,7 @@ class LocalizationAddon extends WidgetbookAddOn<LocalizationSetting> {
   @override
   Widget buildSetting(BuildContext context) {
     return Setting(
-      name: 'Locale',
+      name: name,
       child: DropdownSetting<Locale>(
         options: setting.locales,
         initialSelection: setting.activeLocale,

--- a/packages/widgetbook/lib/src/addons/localization_addon/localization_setting.dart
+++ b/packages/widgetbook/lib/src/addons/localization_addon/localization_setting.dart
@@ -16,20 +16,19 @@ class LocalizationSetting extends WidgetbookAddOnModel<LocalizationSetting>
   LocalizationSetting._();
 
   @override
-  Map<String, String> toQueryParameter() {
+  Map<String, String> toMap() {
     return {
       'locale': activeLocale.toLanguageTag(),
     };
   }
 
   @override
-  LocalizationSetting? fromQueryParameter(Map<String, String> queryParameters) {
-    return queryParameters.containsKey('locale')
-        ? this.copyWith(
-            activeLocale: locales.firstWhere(
-              (locale) => locale.toLanguageTag() == queryParameters['locale']!,
-            ),
-          )
-        : null;
+  LocalizationSetting fromMap(Map<String, String> map) {
+    return this.copyWith(
+      activeLocale: locales.firstWhere(
+        (locale) => locale.toLanguageTag() == map['locale'],
+        orElse: () => activeLocale,
+      ),
+    );
   }
 }

--- a/packages/widgetbook/lib/src/addons/localization_addon/localization_setting.dart
+++ b/packages/widgetbook/lib/src/addons/localization_addon/localization_setting.dart
@@ -18,7 +18,7 @@ class LocalizationSetting extends WidgetbookAddOnModel<LocalizationSetting>
   @override
   Map<String, String> toMap() {
     return {
-      'locale': activeLocale.toLanguageTag(),
+      'name': activeLocale.toLanguageTag(),
     };
   }
 
@@ -26,7 +26,7 @@ class LocalizationSetting extends WidgetbookAddOnModel<LocalizationSetting>
   LocalizationSetting fromMap(Map<String, String> map) {
     return this.copyWith(
       activeLocale: locales.firstWhere(
-        (locale) => locale.toLanguageTag() == map['locale'],
+        (locale) => locale.toLanguageTag() == map['name'],
         orElse: () => activeLocale,
       ),
     );

--- a/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
+++ b/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
@@ -16,6 +16,7 @@ class TextScaleAddon extends WidgetbookAddOn<TextScaleSetting> {
           'initialScale must be in scales',
         ),
         super(
+          name: 'Text scale',
           initialSetting: TextScaleSetting(
             textScales: scales,
             activeTextScale: initialScale ?? scales.first,
@@ -25,7 +26,7 @@ class TextScaleAddon extends WidgetbookAddOn<TextScaleSetting> {
   @override
   Widget buildSetting(BuildContext context) {
     return Setting(
-      name: 'Text scale',
+      name: name,
       child: DropdownSetting<double>(
         options: setting.textScales,
         initialSelection: setting.activeTextScale,

--- a/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_setting.dart
+++ b/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_setting.dart
@@ -14,21 +14,19 @@ class TextScaleSetting extends WidgetbookAddOnModel<TextScaleSetting>
   TextScaleSetting._();
 
   @override
-  Map<String, String> toQueryParameter() {
+  Map<String, String> toMap() {
     return {
       'text-scale': activeTextScale.toStringAsFixed(2),
     };
   }
 
   @override
-  TextScaleSetting? fromQueryParameter(Map<String, String> queryParameters) {
-    return queryParameters.containsKey('text-scale')
-        ? this.copyWith(
-            activeTextScale: textScales.firstWhere(
-              (scale) =>
-                  scale.toStringAsFixed(2) == queryParameters['text-scale']!,
-            ),
-          )
-        : null;
+  TextScaleSetting fromMap(Map<String, String> map) {
+    return this.copyWith(
+      activeTextScale: textScales.firstWhere(
+        (scale) => scale.toStringAsFixed(2) == map['text-scale'],
+        orElse: () => activeTextScale,
+      ),
+    );
   }
 }

--- a/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_setting.dart
+++ b/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_setting.dart
@@ -16,7 +16,7 @@ class TextScaleSetting extends WidgetbookAddOnModel<TextScaleSetting>
   @override
   Map<String, String> toMap() {
     return {
-      'text-scale': activeTextScale.toStringAsFixed(2),
+      'factor': activeTextScale.toStringAsFixed(2),
     };
   }
 
@@ -24,7 +24,7 @@ class TextScaleSetting extends WidgetbookAddOnModel<TextScaleSetting>
   TextScaleSetting fromMap(Map<String, String> map) {
     return this.copyWith(
       activeTextScale: textScales.firstWhere(
-        (scale) => scale.toStringAsFixed(2) == map['text-scale'],
+        (scale) => scale.toStringAsFixed(2) == map['factor'],
         orElse: () => activeTextScale,
       ),
     );

--- a/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
@@ -22,6 +22,7 @@ class ThemeAddon<T> extends WidgetbookAddOn<ThemeSetting<T>> {
           'initialTheme must be in themes',
         ),
         super(
+          name: 'Theme',
           initialSetting: ThemeSetting(
             themes: themes,
             activeTheme: initialTheme ?? themes.first,
@@ -33,7 +34,7 @@ class ThemeAddon<T> extends WidgetbookAddOn<ThemeSetting<T>> {
   @override
   Widget buildSetting(BuildContext context) {
     return Setting(
-      name: 'Theme',
+      name: name,
       child: DropdownSetting<WidgetbookTheme<T>>(
         options: setting.themes,
         initialSelection: setting.activeTheme,

--- a/packages/widgetbook/lib/src/addons/theme_addon/theme_setting.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/theme_setting.dart
@@ -26,7 +26,7 @@ class ThemeSetting<T> extends WidgetbookAddOnModel<ThemeSetting<T>> {
   @override
   Map<String, String> toMap() {
     return {
-      'theme': activeTheme.name,
+      'name': activeTheme.name,
     };
   }
 
@@ -34,7 +34,7 @@ class ThemeSetting<T> extends WidgetbookAddOnModel<ThemeSetting<T>> {
   ThemeSetting<T> fromMap(Map<String, String> map) {
     return this.copyWith(
       activeTheme: themes.firstWhere(
-        (theme) => theme.name == map['theme'],
+        (theme) => theme.name == map['name'],
         orElse: () => activeTheme,
       ),
     );

--- a/packages/widgetbook/lib/src/addons/theme_addon/theme_setting.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/theme_setting.dart
@@ -24,21 +24,20 @@ class ThemeSetting<T> extends WidgetbookAddOnModel<ThemeSetting<T>> {
   }
 
   @override
-  Map<String, String> toQueryParameter() {
+  Map<String, String> toMap() {
     return {
       'theme': activeTheme.name,
     };
   }
 
   @override
-  ThemeSetting<T>? fromQueryParameter(Map<String, String> queryParameters) {
-    return queryParameters.containsKey('theme')
-        ? this.copyWith(
-            activeTheme: themes.firstWhere(
-              (theme) => theme.name == queryParameters['theme']!,
-            ),
-          )
-        : null;
+  ThemeSetting<T> fromMap(Map<String, String> map) {
+    return this.copyWith(
+      activeTheme: themes.firstWhere(
+        (theme) => theme.name == map['theme'],
+        orElse: () => activeTheme,
+      ),
+    );
   }
 
   @override

--- a/packages/widgetbook/lib/src/navigation/widgets/navigation_panel_wrapper.dart
+++ b/packages/widgetbook/lib/src/navigation/widgets/navigation_panel_wrapper.dart
@@ -19,7 +19,7 @@ class NavigationPanelWrapper extends StatelessWidget {
       initialPath: initialPath,
       onNodeSelected: (path, _) {
         final router = GoRouter.of(context);
-        router.mergeQueryParams({'path': path});
+        router.updateQueryParam('path', path);
         context.read<UseCasesProvider>().selectUseCaseByPath(path);
       },
     );

--- a/packages/widgetbook/lib/src/routing/router.dart
+++ b/packages/widgetbook/lib/src/routing/router.dart
@@ -5,13 +5,15 @@ import 'package:widgetbook/src/widgetbook_shell.dart';
 import 'package:widgetbook/src/workbench/workbench.dart';
 
 extension GoRouterExtension on GoRouter {
-  void mergeQueryParams(Map<String, String> other) {
+  void updateQueryParam(String name, String value) {
     final uri = Uri.parse(location);
-    final queryParams = Map<String, String>.from(uri.queryParameters);
 
     goNamed(
       '/',
-      queryParams: queryParams..addAll(other),
+      queryParams: {
+        ...uri.queryParameters,
+        name: value,
+      },
     );
   }
 }

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -116,10 +114,9 @@ class _WidgetbookState<CustomTheme> extends State<Widgetbook<CustomTheme>> {
 
     widget.addons.forEach((addon) {
       addon.setListener(
-        (setting) => goRouter.mergeQueryParams(
-          {
-            addon.slugName: addon.setting.encoded,
-          },
+        (setting) => goRouter.updateQueryParam(
+          addon.slugName,
+          addon.setting.encoded,
         ),
       );
     });

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -118,7 +118,7 @@ class _WidgetbookState<CustomTheme> extends State<Widgetbook<CustomTheme>> {
       addon.setListener(
         (setting) => goRouter.mergeQueryParams(
           {
-            addon.name: jsonEncode(setting.toQueryParameter()),
+            addon.slugName: addon.setting.encoded,
           },
         ),
       );

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -115,7 +117,9 @@ class _WidgetbookState<CustomTheme> extends State<Widgetbook<CustomTheme>> {
     widget.addons.forEach((addon) {
       addon.setListener(
         (setting) => goRouter.mergeQueryParams(
-          setting.toQueryParameter(),
+          {
+            addon.name: jsonEncode(setting.toQueryParameter()),
+          },
         ),
       );
     });

--- a/packages/widgetbook/test/src/addons/device_addon/frames/device_frame_builder_test.dart
+++ b/packages/widgetbook/test/src/addons/device_addon/frames/device_frame_builder_test.dart
@@ -33,7 +33,7 @@ void main() {
             Builder(
               builder: (context) {
                 addon.updateFromQueryParameters({
-                  'device': phone.name,
+                  'device': '{name: ${phone.name}}',
                 });
 
                 return frame.build(

--- a/packages/widgetbook/test/src/addons/device_addon/frames/widgetbook_frame_builder_test.dart
+++ b/packages/widgetbook/test/src/addons/device_addon/frames/widgetbook_frame_builder_test.dart
@@ -32,7 +32,7 @@ void main() {
             Builder(
               builder: (context) {
                 addon.updateFromQueryParameters({
-                  'device': phone.name,
+                  'device': '{name: ${phone.name}}',
                 });
 
                 return frame.build(

--- a/packages/widgetbook_addon/example/main.dart
+++ b/packages/widgetbook_addon/example/main.dart
@@ -18,7 +18,7 @@ class CustomAddOnSetting extends WidgetbookAddOnModel<CustomAddOnSetting> {
   @override
   CustomAddOnSetting fromMap(Map<String, String> map) {
     return CustomAddOnSetting(
-      data: map['data']!,
+      data: map['data'] ?? 'Unknown',
     );
   }
 }

--- a/packages/widgetbook_addon/example/main.dart
+++ b/packages/widgetbook_addon/example/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:widgetbook_addon/widgetbook_addon.dart';
 
-class CustomAddOnSetting extends WidgetbookAddOnModel {
+class CustomAddOnSetting extends WidgetbookAddOnModel<CustomAddOnSetting> {
   const CustomAddOnSetting({
     required this.data,
   });
@@ -9,32 +9,29 @@ class CustomAddOnSetting extends WidgetbookAddOnModel {
   final String data;
 
   @override
-  Map<String, String> toQueryParameter() {
+  Map<String, String> toMap() {
     return {
       'data': data,
     };
   }
 
   @override
-  CustomAddOnSetting? fromQueryParameter(Map<String, String> queryParameters) {
-    return queryParameters.containsKey('data')
-        ? CustomAddOnSetting(data: queryParameters['data']!)
-        : null;
+  CustomAddOnSetting fromMap(Map<String, String> map) {
+    return CustomAddOnSetting(
+      data: map['data']!,
+    );
   }
 }
 
 class CustomAddOn extends WidgetbookAddOn<CustomAddOnSetting> {
   CustomAddOn({
     required super.initialSetting,
-  });
+  }) : super(
+          name: 'Custom',
+        );
 
   @override
-  Widget build(BuildContext context) {
-    return Text(setting.data);
+  Widget buildSetting(BuildContext context) {
+    return Placeholder();
   }
-}
-
-/// Allows accessing addons from [context]
-extension CustomAddOnExtension on BuildContext {
-  CustomAddOnSetting? get custom => getAddonValue<CustomAddOnSetting>();
 }

--- a/packages/widgetbook_addon/lib/src/widgetbook_addon.dart
+++ b/packages/widgetbook_addon/lib/src/widgetbook_addon.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'widgetbook_addon_model.dart';
@@ -16,9 +18,11 @@ import 'widgetbook_addon_model.dart';
 /// type
 abstract class WidgetbookAddOn<T extends WidgetbookAddOnModel<T>> {
   WidgetbookAddOn({
+    required this.name,
     required T initialSetting,
   }) : setting = initialSetting;
 
+  final String name;
   T setting;
   ValueChanged<T>? _listener;
 
@@ -36,7 +40,19 @@ abstract class WidgetbookAddOn<T extends WidgetbookAddOnModel<T>> {
   /// Used sync the [setting] with the current URI's [queryParams], in case
   /// it was changed from the URL bar and not from the settings panel.
   void updateFromQueryParameters(Map<String, String> queryParams) {
-    setting = setting.fromQueryParameter(queryParams) ?? setting;
+    final value = jsonDecode(queryParams[name] ?? '{}') as Map<String, dynamic>;
+
+    setting = setting.fromQueryParameter(
+          Map<String, String>.fromEntries(
+            value.entries.map(
+              (e) => MapEntry(
+                e.key,
+                e.value.toString(),
+              ),
+            ),
+          ),
+        ) ??
+        setting;
   }
 
   Widget buildSetting(BuildContext context);

--- a/packages/widgetbook_addon/lib/src/widgetbook_addon.dart
+++ b/packages/widgetbook_addon/lib/src/widgetbook_addon.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 
 import 'widgetbook_addon_model.dart';
@@ -26,6 +24,8 @@ abstract class WidgetbookAddOn<T extends WidgetbookAddOnModel<T>> {
   T setting;
   ValueChanged<T>? _listener;
 
+  String get slugName => name.trim().toLowerCase().replaceAll(RegExp(' '), '-');
+
   void setListener(ValueChanged<T> listener) {
     _listener = listener;
   }
@@ -40,19 +40,8 @@ abstract class WidgetbookAddOn<T extends WidgetbookAddOnModel<T>> {
   /// Used sync the [setting] with the current URI's [queryParams], in case
   /// it was changed from the URL bar and not from the settings panel.
   void updateFromQueryParameters(Map<String, String> queryParams) {
-    final value = jsonDecode(queryParams[name] ?? '{}') as Map<String, dynamic>;
-
-    setting = setting.fromQueryParameter(
-          Map<String, String>.fromEntries(
-            value.entries.map(
-              (e) => MapEntry(
-                e.key,
-                e.value.toString(),
-              ),
-            ),
-          ),
-        ) ??
-        setting;
+    final value = queryParams[slugName] ?? '';
+    setting = setting.fromEncoded(value) ?? setting;
   }
 
   Widget buildSetting(BuildContext context);

--- a/packages/widgetbook_addon/lib/src/widgetbook_addon.dart
+++ b/packages/widgetbook_addon/lib/src/widgetbook_addon.dart
@@ -40,8 +40,12 @@ abstract class WidgetbookAddOn<T extends WidgetbookAddOnModel<T>> {
   /// Used sync the [setting] with the current URI's [queryParams], in case
   /// it was changed from the URL bar and not from the settings panel.
   void updateFromQueryParameters(Map<String, String> queryParams) {
-    final value = queryParams[slugName] ?? '';
-    setting = setting.fromEncoded(value) ?? setting;
+    if (!queryParams.containsKey(slugName) || queryParams[slugName]!.isEmpty)
+      return;
+
+    setting = setting.fromEncoded(
+      queryParams[slugName]!,
+    );
   }
 
   Widget buildSetting(BuildContext context);

--- a/packages/widgetbook_addon/lib/src/widgetbook_addon_model.dart
+++ b/packages/widgetbook_addon/lib/src/widgetbook_addon_model.dart
@@ -1,41 +1,23 @@
 abstract class WidgetbookAddOnModel<T> {
   const WidgetbookAddOnModel();
 
-  /// Required to allow proper deep linking including AddOn property selection
-  ///
-  /// Defaults to an empty Map, which means no query parameters are set for the
-  /// route
-  Map<String, String> toQueryParameter() {
-    return {};
-  }
+  /// Converts this to a [Map] that's used in the deep-linking of the addon
+  /// via the query parameters of the router.
+  Map<String, String> toMap();
+
+  /// Converts a [map] to an instance to [T].
+  T fromMap(Map<String, String> map);
 
   /// Encodes this into a JSON-like format without double quotes.
   /// For example: `{foo:bar,baz:qux}`
   String get encoded {
-    final pairs = toQueryParameter()
-        .entries
-        .map((entry) => '${entry.key}:${entry.value}');
+    final pairs = toMap().entries.map((entry) => '${entry.key}:${entry.value}');
 
     return '{${pairs.join(',')}}';
   }
 
-  /// Allows for parsing of [queryParameters] by using information from the
-  /// router and from the initially provided [WidgetbookAddOnModel].
-  ///
-  /// If no [queryParameters] are available, return `null`.
-  /// If [queryParameters] are available return a property `Setting` object.
-  ///
-  /// If not overridden, returns `null`.
-  T? fromQueryParameter(
-    Map<String, String> queryParameters,
-  ) {
-    return null;
-  }
-
   /// Decodes an [encoded] value into an instance of [T].
-  T? fromEncoded(String value) {
-    if (value.isEmpty) return null;
-
+  T fromEncoded(String value) {
     final pairs = value.substring(1, value.length - 1).split(',');
 
     final map = Map<String, String>.fromEntries(
@@ -47,6 +29,6 @@ abstract class WidgetbookAddOnModel<T> {
       ),
     );
 
-    return fromQueryParameter(map);
+    return fromMap(map);
   }
 }

--- a/packages/widgetbook_addon/lib/src/widgetbook_addon_model.dart
+++ b/packages/widgetbook_addon/lib/src/widgetbook_addon_model.dart
@@ -9,6 +9,16 @@ abstract class WidgetbookAddOnModel<T> {
     return {};
   }
 
+  /// Encodes this into a JSON-like format without double quotes.
+  /// For example: `{foo:bar,baz:qux}`
+  String get encoded {
+    final pairs = toQueryParameter()
+        .entries
+        .map((entry) => '${entry.key}:${entry.value}');
+
+    return '{${pairs.join(',')}}';
+  }
+
   /// Allows for parsing of [queryParameters] by using information from the
   /// router and from the initially provided [WidgetbookAddOnModel].
   ///
@@ -20,5 +30,23 @@ abstract class WidgetbookAddOnModel<T> {
     Map<String, String> queryParameters,
   ) {
     return null;
+  }
+
+  /// Decodes an [encoded] value into an instance of [T].
+  T? fromEncoded(String value) {
+    if (value.isEmpty) return null;
+
+    final pairs = value.substring(1, value.length - 1).split(',');
+
+    final map = Map<String, String>.fromEntries(
+      pairs.map(
+        (pair) {
+          final parts = pair.split(':');
+          return MapEntry(parts[0], parts[1]);
+        },
+      ),
+    );
+
+    return fromQueryParameter(map);
   }
 }

--- a/packages/widgetbook_addon/test/helper/custom_addon.dart
+++ b/packages/widgetbook_addon/test/helper/custom_addon.dart
@@ -26,7 +26,9 @@ class CustomAddOnSetting extends WidgetbookAddOnModel<CustomAddOnSetting> {
 class CustomAddOn extends WidgetbookAddOn<CustomAddOnSetting> {
   CustomAddOn({
     required super.initialSetting,
-  });
+  }) : super(
+          name: 'Custom',
+        );
 
   @override
   Widget buildSetting(BuildContext context) {

--- a/packages/widgetbook_addon/test/helper/custom_addon.dart
+++ b/packages/widgetbook_addon/test/helper/custom_addon.dart
@@ -9,17 +9,17 @@ class CustomAddOnSetting extends WidgetbookAddOnModel<CustomAddOnSetting> {
   final String data;
 
   @override
-  Map<String, String> toQueryParameter() {
+  Map<String, String> toMap() {
     return {
       'data': data,
     };
   }
 
   @override
-  CustomAddOnSetting? fromQueryParameter(Map<String, String> queryParameters) {
-    return queryParameters.containsKey('data')
-        ? CustomAddOnSetting(data: queryParameters['data']!)
-        : null;
+  CustomAddOnSetting fromMap(Map<String, String> map) {
+    return CustomAddOnSetting(
+      data: map['data'] ?? 'Unknown',
+    );
   }
 }
 


### PR DESCRIPTION
Group each addon setting under a query parameter of its own name.

### Before

`/?device=iPhone13&orientation=landscape&frame=false`

### After

`/?device={name:iPhone13,orientation:landscape,frame:false}`