### PR TITLE
feat: send fields json via web messaging

### DIFF
--- a/packages/widgetbook/lib/src/addons/device_addon/device_addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_addon/device_addon.dart
@@ -32,6 +32,7 @@ class DeviceAddon extends WidgetbookAddOn<DeviceSetting> {
         group: slugName,
         name: 'name',
         values: setting.devices,
+        initialValue: setting.activeDevice,
         labelBuilder: (device) => device?.name ?? 'None',
         codec: FieldCodec(
           toParam: (device) => device?.name ?? 'None',
@@ -54,6 +55,7 @@ class DeviceAddon extends WidgetbookAddOn<DeviceSetting> {
         group: slugName,
         name: 'orientation',
         values: Orientation.values,
+        initialValue: setting.orientation,
         labelBuilder: (orientation) =>
             orientation.name.substring(0, 1).toUpperCase() +
             orientation.name.substring(1),
@@ -77,6 +79,7 @@ class DeviceAddon extends WidgetbookAddOn<DeviceSetting> {
         group: slugName,
         name: 'frame',
         values: [false, true],
+        initialValue: setting.hasFrame,
         labelBuilder: (hasFrame) => hasFrame ? 'Device Frame' : 'None',
         codec: FieldCodec(
           toParam: (hasFrame) => hasFrame.toString(),

--- a/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
+++ b/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
@@ -32,6 +32,7 @@ class LocalizationAddon extends WidgetbookAddOn<LocalizationSetting> {
         group: slugName,
         name: 'name',
         values: setting.locales,
+        initialValue: setting.activeLocale,
         labelBuilder: (locale) => locale.toLanguageTag(),
         codec: FieldCodec(
           toParam: (locale) => locale.toLanguageTag(),

--- a/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
+++ b/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
@@ -23,6 +23,7 @@ class TextScaleAddon extends WidgetbookAddOn<TextScaleSetting> {
           ),
         );
 
+  /// ?text-scale={factor:1.00}
   @override
   List<Field> get fields {
     return [
@@ -30,6 +31,7 @@ class TextScaleAddon extends WidgetbookAddOn<TextScaleSetting> {
         group: slugName,
         name: 'factor',
         values: setting.textScales,
+        initialValue: setting.activeTextScale,
         labelBuilder: (scale) => scale.toStringAsFixed(2),
         codec: FieldCodec(
           toParam: (scale) => scale.toStringAsFixed(2),

--- a/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
@@ -39,6 +39,7 @@ class ThemeAddon<T> extends WidgetbookAddOn<ThemeSetting<T>> {
         group: slugName,
         name: 'name',
         values: setting.themes,
+        initialValue: setting.activeTheme,
         labelBuilder: (theme) => theme.name,
         codec: FieldCodec(
           toParam: (theme) => theme.name,

--- a/packages/widgetbook/lib/src/fields/dropdown_field.dart
+++ b/packages/widgetbook/lib/src/fields/dropdown_field.dart
@@ -12,6 +12,7 @@ class DropdownField<T> extends Field<T> {
     required super.group,
     required super.name,
     required this.values,
+    required super.initialValue,
     required this.labelBuilder,
     required super.codec,
     required super.onChanged,
@@ -53,5 +54,12 @@ class DropdownField<T> extends Field<T> {
         );
       },
     );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'values': values.map((codec.toParam)).toList(),
+    };
   }
 }

--- a/packages/widgetbook/lib/src/fields/field.dart
+++ b/packages/widgetbook/lib/src/fields/field.dart
@@ -7,6 +7,7 @@ abstract class Field<T> {
     required this.group,
     required this.name,
     required this.type,
+    required this.initialValue,
     required this.codec,
     required this.onChanged,
   });
@@ -29,9 +30,22 @@ abstract class Field<T> {
   /// to help rendering proper widget by external listeners.
   final FieldType type;
 
+  final T initialValue;
+
   final FieldCodec<T> codec;
 
   final void Function(T? value) onChanged;
 
   Widget build(BuildContext context);
+
+  Map<String, dynamic> toFullJson() {
+    return {
+      'name': name,
+      'type': type.name,
+      'initialValue': codec.toParam(initialValue),
+      ...toJson(),
+    };
+  }
+
+  Map<String, dynamic> toJson();
 }

--- a/packages/widgetbook/lib/src/messaging/messaging.dart
+++ b/packages/widgetbook/lib/src/messaging/messaging.dart
@@ -1,0 +1,1 @@
+export 'no_messaging.dart' if (dart.library.html) 'web_messaging.dart';

--- a/packages/widgetbook/lib/src/messaging/no_messaging.dart
+++ b/packages/widgetbook/lib/src/messaging/no_messaging.dart
@@ -1,0 +1,1 @@
+void sendMessage(Map<String, dynamic> json) {}

--- a/packages/widgetbook/lib/src/messaging/web_messaging.dart
+++ b/packages/widgetbook/lib/src/messaging/web_messaging.dart
@@ -1,0 +1,8 @@
+import 'dart:html';
+
+import 'package:flutter/foundation.dart';
+
+void sendMessage(Map<String, dynamic> json) {
+  if (!kIsWeb) return;
+  window.parent?.postMessage(json, '*');
+}

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -111,21 +111,22 @@ class _WidgetbookState<CustomTheme> extends State<Widgetbook<CustomTheme>> {
     );
 
     // Sends a message with the json representation of Addon fields
-
-    sendMessage(widget.addons.fold(
-      {},
-      (json, addon) {
-        return json
-          ..putIfAbsent(
-            addon.slugName,
-            () => addon.fields
-                .map(
-                  (field) => field.toFullJson(),
-                )
-                .toList(),
-          );
-      },
-    ));
+    sendMessage(
+      widget.addons.fold(
+        {},
+        (json, addon) {
+          return json
+            ..putIfAbsent(
+              addon.slugName,
+              () => addon.fields
+                  .map(
+                    (field) => field.toFullJson(),
+                  )
+                  .toList(),
+            );
+        },
+      ),
+    );
 
     super.initState();
   }

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:widgetbook/src/builder/builder.dart';
+import 'package:widgetbook/src/messaging/messaging.dart';
 import 'package:widgetbook/src/routing/router.dart';
 import 'package:widgetbook/src/repositories/selected_use_case_repository.dart';
 import 'package:widgetbook/widgetbook.dart';
@@ -108,6 +109,23 @@ class _WidgetbookState<CustomTheme> extends State<Widgetbook<CustomTheme>> {
     goRouter = createRouter(
       useCasesProvider: useCasesProvider,
     );
+
+    // Sends a message with the json representation of Addon fields
+
+    sendMessage(widget.addons.fold(
+      {},
+      (json, addon) {
+        return json
+          ..putIfAbsent(
+            addon.slugName,
+            () => addon.fields
+                .map(
+                  (field) => field.toFullJson(),
+                )
+                .toList(),
+          );
+      },
+    ));
 
     super.initState();
   }

--- a/widgetbook_for_widgetbook/web/index.html
+++ b/widgetbook_for_widgetbook/web/index.html
@@ -53,6 +53,11 @@
         return appRunner.runApp();
       });
     });
+
+    /// Log dart's web messages
+    window.addEventListener('message', function(ev) {
+      console.log(ev.data);
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
To support fields on Widgetbook Cloud, all fields are converted to JSON, and then sent [through web messages](https://api.dart.dev/stable/2.19.6/dart-html/Window/postMessage.html).