### PR TITLE
ci: fix melos filters

### DIFF
--- a/.github/workflows/_package.yml
+++ b/.github/workflows/_package.yml
@@ -41,16 +41,16 @@ jobs:
           flutter pub get
           melos --version # Needed to build melos executable
 
-      - name: Filter Melos Packages
+      - name: Create `MELOS_FILTERS`
         run: |
           PACKAGE_NAME=$(head -1 pubspec.yaml | cut -c7-)
-          PACKAGES_LIST=$(melos list --scope="$PACKAGE_NAME" --include-dependencies | paste -s -d, -)
+          FILTERS="--scope=$PACKAGE_NAME --include-dependencies"
 
-          # Melos commands will only work on these packages
-          echo "MELOS_PACKAGES=$PACKAGES_LIST" >> $GITHUB_ENV
+          # This variable is used to apply filters to melos scripts
+          echo "MELOS_FILTERS=$FILTERS" >> $GITHUB_ENV
 
       - name: Install Dependencies
-        run: melos bootstrap
+        run: melos bootstrap $MELOS_FILTERS
 
       - name: Generate Files
         run: melos generate

--- a/melos.yaml
+++ b/melos.yaml
@@ -19,7 +19,7 @@ scripts:
     description: Build all generated files.
     run: |
       rm packages/widgetbook_generator/build.yaml # Causes build runner to fail inside widgetbook_generator
-      melos exec -c 1 --depends-on="build_runner" -- "dart pub run build_runner build --delete-conflicting-outputs"
+      melos exec $MELOS_FILTERS -c 1 --depends-on="build_runner" -- "dart pub run build_runner build --delete-conflicting-outputs"
       git checkout packages/widgetbook_generator/build.yaml # Revert the file back
 
   pana:


### PR DESCRIPTION
Setting [`MELOS_PACKAGES`](https://melos.invertase.dev/environment-variables#melos_packages) overrides all melos filters, thus the `--depends-on="build_runner"` filter was not working.