### PR TITLE
ci: pin flutter version to 3.7.x

### DIFF
--- a/.github/workflows/_package.yml
+++ b/.github/workflows/_package.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          flutter-version: 3.7.x
 
       - name: Install Melos
         run: flutter pub global activate melos

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          flutter-version: 3.7.x
 
       - name: Enable melos
         run: dart pub global activate melos

--- a/.github/workflows/deploy-widgetbook-feat.yml
+++ b/.github/workflows/deploy-widgetbook-feat.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          flutter-version: 3.7.x
 
       - name: Enable melos
         run: flutter pub global activate melos

--- a/.github/workflows/deploy-widgetbook-main.yml
+++ b/.github/workflows/deploy-widgetbook-main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          flutter-version: 3.7.x
 
       - name: Enable melos
         run: flutter pub global activate melos


### PR DESCRIPTION
Currently Widgetbbok doesn't work with Flutter 3.10, so pinning the workflows to the previous version until we fix it.