### PR TITLE
refactor: remove configure addons functions

### DIFF
--- a/examples/screen_util_example/lib/widgetbook.dart
+++ b/examples/screen_util_example/lib/widgetbook.dart
@@ -18,34 +18,37 @@ class WidgetbookApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return Widgetbook.material(
       directories: directories,
-      addons: configureMaterialAddons(
-        themes: [
-          WidgetbookTheme(
-            name: 'Dark',
-            data: Themes.dark,
-          ),
-          WidgetbookTheme(
-            name: 'Dark',
-            data: Themes.dark,
-          ),
-        ],
-        textScales: [
-          1.0,
-          2.0,
-        ],
-        locales: [
-          Locale('en', 'US'),
-        ],
-        localizationsDelegates: [
-          DefaultWidgetsLocalizations.delegate,
-          DefaultMaterialLocalizations.delegate,
-        ],
-        devices: [
-          Devices.ios.iPhoneSE,
-          Devices.ios.iPhone12,
-          Devices.ios.iPhone13,
-        ],
-      ),
+      addons: [
+        MaterialThemeAddon(
+          themes: [
+            WidgetbookTheme(
+              name: 'Light',
+              data: Themes.light,
+            ),
+            WidgetbookTheme(
+              name: 'Dark',
+              data: Themes.dark,
+            ),
+          ],
+        ),
+        TextScaleAddon(
+          scales: [1.0, 2.0],
+        ),
+        LocalizationAddon(
+          locales: [Locale('en', 'US')],
+          localizationsDelegates: [
+            DefaultWidgetsLocalizations.delegate,
+            DefaultMaterialLocalizations.delegate,
+          ],
+        ),
+        DeviceAddon(
+          devices: [
+            Devices.ios.iPhoneSE,
+            Devices.ios.iPhone12,
+            Devices.ios.iPhone13,
+          ],
+        ),
+      ],
 
       /// Customize your appBuilder function so the [ScreenUtilInit] widget is
       /// injected into the [Widget] tree.

--- a/packages/widgetbook/lib/src/addons/addons.dart
+++ b/packages/widgetbook/lib/src/addons/addons.dart
@@ -1,57 +1,5 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
-import 'package:widgetbook/widgetbook.dart';
-
 export './common/common.dart';
 export './device_addon/addon.dart';
 export './localization_addon/addon.dart';
 export './text_scale_addon/addon.dart';
 export './theme_addon/addon.dart';
-
-List<WidgetbookAddOn> configureMaterialAddons({
-  required List<WidgetbookTheme<ThemeData>> themes,
-  required List<double> textScales,
-  required List<Locale> locales,
-  required List<LocalizationsDelegate> localizationsDelegates,
-  required List<DeviceInfo> devices,
-}) {
-  return [
-    MaterialThemeAddon(
-      themes: themes,
-    ),
-    TextScaleAddon(
-      scales: textScales,
-    ),
-    LocalizationAddon(
-      locales: locales,
-      localizationsDelegates: localizationsDelegates,
-    ),
-    DeviceAddon(
-      devices: devices,
-    ),
-  ];
-}
-
-List<WidgetbookAddOn> configureCupertinoAddons({
-  required List<WidgetbookTheme<CupertinoThemeData>> themes,
-  required List<double> textScales,
-  required List<Locale> locales,
-  required List<LocalizationsDelegate> localizationsDelegates,
-  required List<DeviceInfo> devices,
-}) {
-  return [
-    CupertinoThemeAddon(
-      themes: themes,
-    ),
-    TextScaleAddon(
-      scales: textScales,
-    ),
-    LocalizationAddon(
-      locales: locales,
-      localizationsDelegates: localizationsDelegates,
-    ),
-    DeviceAddon(
-      devices: devices,
-    ),
-  ];
-}

--- a/widgetbook_for_widgetbook/lib/widgetbook.dart
+++ b/widgetbook_for_widgetbook/lib/widgetbook.dart
@@ -17,34 +17,37 @@ class WidgetbookApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return Widgetbook.material(
       directories: directories,
-      addons: configureMaterialAddons(
-        themes: [
-          WidgetbookTheme(
-            name: 'Dark',
-            data: Themes.dark,
-          ),
-          WidgetbookTheme(
-            name: 'Dark',
-            data: Themes.dark,
-          ),
-        ],
-        textScales: [
-          1.0,
-          2.0,
-        ],
-        locales: [
-          Locale('en', 'US'),
-        ],
-        localizationsDelegates: [
-          DefaultWidgetsLocalizations.delegate,
-          DefaultMaterialLocalizations.delegate,
-        ],
-        devices: [
-          Devices.ios.iPhoneSE,
-          Devices.ios.iPhone12,
-          Devices.ios.iPhone13,
-        ],
-      ),
+      addons: [
+        MaterialThemeAddon(
+          themes: [
+            WidgetbookTheme(
+              name: 'Light',
+              data: Themes.light,
+            ),
+            WidgetbookTheme(
+              name: 'Dark',
+              data: Themes.dark,
+            ),
+          ],
+        ),
+        TextScaleAddon(
+          scales: [1.0, 2.0],
+        ),
+        LocalizationAddon(
+          locales: [Locale('en', 'US')],
+          localizationsDelegates: [
+            DefaultWidgetsLocalizations.delegate,
+            DefaultMaterialLocalizations.delegate,
+          ],
+        ),
+        DeviceAddon(
+          devices: [
+            Devices.ios.iPhoneSE,
+            Devices.ios.iPhone12,
+            Devices.ios.iPhone13,
+          ],
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
These functions wouldn't scale well with custom addons and any changes to the addons API. So, better have them removed by now.