### PR TITLE
refactor: rename device addon

### DIFF
--- a/examples/custom_theme_example/widgetbook/main.widgetbook.dart
+++ b/examples/custom_theme_example/widgetbook/main.widgetbook.dart
@@ -37,7 +37,7 @@ class HotReload extends StatelessWidget {
 
     return Widgetbook(
       addons: [
-        DeviceAddon(
+        DeviceFrameAddon(
           devices: devices,
         ),
         ThemeAddon<AppThemeData>(

--- a/examples/knobs_example/lib/widgetbook.dart
+++ b/examples/knobs_example/lib/widgetbook.dart
@@ -14,7 +14,7 @@ class KnobsExample extends StatelessWidget {
   Widget build(BuildContext context) {
     return Widgetbook.material(
       addons: [
-        DeviceAddon(
+        DeviceFrameAddon(
           devices: [
             Devices.ios.iPhoneSE,
             Devices.ios.iPhone12,

--- a/examples/screen_util_example/lib/widgetbook.dart
+++ b/examples/screen_util_example/lib/widgetbook.dart
@@ -43,7 +43,7 @@ class WidgetbookApp extends StatelessWidget {
             DefaultMaterialLocalizations.delegate,
           ],
         ),
-        DeviceAddon(
+        DeviceFrameAddon(
           devices: [
             Devices.ios.iPhoneSE,
             Devices.ios.iPhone12,

--- a/packages/widgetbook/lib/src/addons/addons.dart
+++ b/packages/widgetbook/lib/src/addons/addons.dart
@@ -1,5 +1,5 @@
 export 'common/common.dart';
-export 'device_addon/addon.dart';
+export 'device_frame_addon/addon.dart';
 export 'localization_addon/addon.dart';
 export 'text_scale_addon/addon.dart';
 export 'theme_addon/addon.dart';

--- a/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
+++ b/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
@@ -11,7 +11,7 @@ import '../addons.dart';
 /// * [ThemeAddon], a generic implementation of a [WidgetbookAddOn].
 /// * [MaterialThemeAddon], an [WidgetbookAddOn] to change the active
 ///   [ThemeData] of the [WidgetbookUseCase].
-/// * [DeviceAddon], an [WidgetbookAddOn] to change the active [Device] that
+/// * [DeviceFrameAddon], an [WidgetbookAddOn] to change the active [Device] that
 ///   allows to view the [WidgetbookUseCase] on different screens.
 ///
 /// You must not have multiple [WidgetbookAddOn]s that are of the same generic

--- a/packages/widgetbook/lib/src/addons/device_addon/addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_addon/addon.dart
@@ -1,4 +1,0 @@
-export 'package:device_frame/device_frame.dart';
-
-export 'device_addon.dart';
-export 'device_setting.dart';

--- a/packages/widgetbook/lib/src/addons/device_frame_addon/addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/addon.dart
@@ -1,0 +1,4 @@
+export 'package:device_frame/device_frame.dart';
+
+export 'device_frame_addon.dart';
+export 'device_frame_setting.dart';

--- a/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
@@ -3,10 +3,10 @@ import 'package:flutter/material.dart';
 
 import '../../fields/fields.dart';
 import '../common/common.dart';
-import 'device_setting.dart';
+import 'device_frame_setting.dart';
 
-class DeviceAddon extends WidgetbookAddOn<DeviceSetting> {
-  DeviceAddon({
+class DeviceFrameAddon extends WidgetbookAddOn<DeviceFrameSetting> {
+  DeviceFrameAddon({
     required List<DeviceInfo> devices,
     DeviceInfo? initialDevice,
   })  : assert(
@@ -19,7 +19,7 @@ class DeviceAddon extends WidgetbookAddOn<DeviceSetting> {
         ),
         super(
           name: 'Device',
-          initialSetting: DeviceSetting(
+          initialSetting: DeviceFrameSetting(
             // [null] represents a "none" device
             devices: [null, ...devices],
             activeDevice: initialDevice,

--- a/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_setting.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_setting.dart
@@ -2,16 +2,16 @@ import 'package:device_frame/device_frame.dart';
 import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-part 'device_setting.freezed.dart';
+part 'device_frame_setting.freezed.dart';
 
 @freezed
-class DeviceSetting with _$DeviceSetting {
-  factory DeviceSetting({
+class DeviceFrameSetting with _$DeviceFrameSetting {
+  factory DeviceFrameSetting({
     required List<DeviceInfo?> devices,
     required DeviceInfo? activeDevice,
     @Default(Orientation.portrait) Orientation orientation,
     @Default(true) bool hasFrame,
-  }) = _DeviceSetting;
+  }) = _DeviceFrameSetting;
 
-  DeviceSetting._();
+  DeviceFrameSetting._();
 }

--- a/packages/widgetbook/test/src/addons/device_frame_addon/device_frame_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/device_frame_addon/device_frame_addon_test.dart
@@ -6,7 +6,7 @@ import '../utils/addon_test_helper.dart';
 
 void main() {
   group(
-    '$DeviceAddon',
+    '$DeviceFrameAddon',
     () {
       final devices = [
         Devices.ios.iPhone12,
@@ -14,7 +14,7 @@ void main() {
         Devices.ios.iPhone13Mini,
       ];
 
-      final addon = DeviceAddon(
+      final addon = DeviceFrameAddon(
         devices: devices,
         initialDevice: devices.first,
       );

--- a/packages/widgetbook/test/src/widgetbook_test.dart
+++ b/packages/widgetbook/test/src/widgetbook_test.dart
@@ -92,7 +92,7 @@ void main() {
                 () => Widgetbook(
                   appBuilder: _defaultAppBuilderMethod,
                   addons: [
-                    DeviceAddon(
+                    DeviceFrameAddon(
                       devices: [],
                     ),
                   ],

--- a/widgetbook_for_widgetbook/lib/widgetbook.dart
+++ b/widgetbook_for_widgetbook/lib/widgetbook.dart
@@ -42,7 +42,7 @@ class WidgetbookApp extends StatelessWidget {
             DefaultMaterialLocalizations.delegate,
           ],
         ),
-        DeviceAddon(
+        DeviceFrameAddon(
           devices: [
             Devices.ios.iPhoneSE,
             Devices.ios.iPhone12,


### PR DESCRIPTION
This change has two reasons:
1. Imply that we are using `device_frame` under the hood. As third party addons will have the following naming convention in the future: `widgetbook_{package_name}_addon`.
2. Reserve the name `device_addon` for future usage, when we decide to dump `device_frame` and use our new custom implementation. This will make deprecation and migration easier.