### PR TITLE
fix: sync none device frame

### DIFF
--- a/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
@@ -36,8 +36,6 @@ class DeviceFrameAddon extends WidgetbookAddOn<DeviceFrameSetting> {
         initialValue: setting.activeDevice,
         labelBuilder: (device) => device?.name ?? 'None',
         onChanged: (_, device) {
-          if (device == null) return;
-
           updateSetting(
             setting.copyWith(
               activeDevice: device,


### PR DESCRIPTION
When switching from any device back to "None" device, it wasn't working.
This teeny tiny fix makes it work again.