### PR TITLE
refactor: parse addon's setting from query param

### DIFF
--- a/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
+++ b/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
@@ -23,20 +23,18 @@ import '../addons.dart';
 abstract class WidgetbookAddOn<T> {
   WidgetbookAddOn({
     required this.name,
-    required T initialSetting,
-  }) : setting = initialSetting;
+    required this.initialSetting,
+  });
 
   final String name;
-  T setting;
+  final T initialSetting;
 
   String get slugName => name.trim().toLowerCase().replaceAll(RegExp(' '), '-');
 
-  /// Updates [setting] with the [newSetting] and calls the listeners.
-  void updateSetting(T newSetting) {
-    setting = newSetting;
-  }
-
   List<Field> get fields;
+
+  /// Converts a query group to a setting of type [T].
+  T settingFromQueryGroup(Map<String, String> group);
 
   /// Converts the [fields] into a [Widget] by calling their [Field.build] and
   /// grouping them inside a [Column].
@@ -50,8 +48,13 @@ abstract class WidgetbookAddOn<T> {
     );
   }
 
-  /// Wraps use cases with a custom widget depending on the addon [setting].
-  Widget buildUseCase(BuildContext context, Widget child) {
+  /// Wraps use cases with a custom widget depending on the addon [setting]
+  /// that is obtained from [settingFromQueryGroup].
+  Widget buildUseCase(
+    BuildContext context,
+    Widget child,
+    T setting,
+  ) {
     return child;
   }
 }

--- a/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:device_frame/device_frame.dart';
 import 'package:flutter/material.dart';
 
@@ -34,56 +35,49 @@ class DeviceFrameAddon extends WidgetbookAddOn<DeviceFrameSetting> {
       ListField<DeviceInfo?>(
         group: slugName,
         name: 'name',
-        values: setting.devices,
-        initialValue: setting.activeDevice,
+        values: initialSetting.devices,
+        initialValue: initialSetting.activeDevice,
         labelBuilder: (device) => device?.name ?? 'None',
-        onChanged: (_, device) {
-          updateSetting(
-            setting.copyWith(
-              activeDevice: device,
-            ),
-          );
-        },
       ),
       ListField<Orientation>(
         group: slugName,
         name: 'orientation',
         values: Orientation.values,
-        initialValue: setting.orientation,
+        initialValue: initialSetting.orientation,
         labelBuilder: (orientation) =>
             orientation.name.substring(0, 1).toUpperCase() +
             orientation.name.substring(1),
-        onChanged: (_, orientation) {
-          if (orientation == null) return;
-
-          updateSetting(
-            setting.copyWith(
-              orientation: orientation,
-            ),
-          );
-        },
       ),
       ListField<bool>(
         group: slugName,
         name: 'frame',
         values: [false, true],
-        initialValue: setting.hasFrame,
+        initialValue: initialSetting.hasFrame,
         labelBuilder: (hasFrame) => hasFrame ? 'Device Frame' : 'None',
-        onChanged: (_, hasFrame) {
-          if (hasFrame == null) return;
-
-          updateSetting(
-            setting.copyWith(
-              hasFrame: hasFrame,
-            ),
-          );
-        },
       ),
     ];
   }
 
   @override
-  Widget buildUseCase(BuildContext context, Widget child) {
+  DeviceFrameSetting settingFromQueryGroup(Map<String, String> group) {
+    return DeviceFrameSetting(
+      devices: initialSetting.devices,
+      activeDevice: initialSetting.devices.firstWhereOrNull(
+        (device) => device?.name == group['name'],
+      ),
+      orientation: Orientation.values.byName(
+        group['orientation']?.toLowerCase() ?? Orientation.portrait.name,
+      ),
+      hasFrame: group['frame'] == true,
+    );
+  }
+
+  @override
+  Widget buildUseCase(
+    BuildContext context,
+    Widget child,
+    DeviceFrameSetting setting,
+  ) {
     if (setting.activeDevice == null) {
       return child;
     }

--- a/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
+++ b/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
@@ -33,24 +33,31 @@ class LocalizationAddon extends WidgetbookAddOn<LocalizationSetting> {
       ListField<Locale>(
         group: slugName,
         name: 'name',
-        values: setting.locales,
-        initialValue: setting.activeLocale,
+        values: initialSetting.locales,
+        initialValue: initialSetting.activeLocale,
         labelBuilder: (locale) => locale.toLanguageTag(),
-        onChanged: (_, locale) {
-          if (locale == null) return;
-
-          updateSetting(
-            setting.copyWith(
-              activeLocale: locale,
-            ),
-          );
-        },
       ),
     ];
   }
 
   @override
-  Widget buildUseCase(BuildContext context, Widget child) {
+  LocalizationSetting settingFromQueryGroup(Map<String, String> group) {
+    return LocalizationSetting(
+      locales: initialSetting.locales,
+      localizationsDelegates: initialSetting.localizationsDelegates,
+      activeLocale: initialSetting.locales.firstWhere(
+        (locale) => locale.toLanguageTag() == group['name'],
+        orElse: () => initialSetting.activeLocale,
+      ),
+    );
+  }
+
+  @override
+  Widget buildUseCase(
+    BuildContext context,
+    Widget child,
+    LocalizationSetting setting,
+  ) {
     return Localizations(
       locale: setting.activeLocale,
       delegates: setting.localizationsDelegates,

--- a/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
+++ b/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
@@ -26,31 +26,35 @@ class TextScaleAddon extends WidgetbookAddOn<TextScaleSetting> {
           ),
         );
 
-  /// ?text-scale={factor:1.00}
   @override
   List<Field> get fields {
     return [
       ListField<double>(
         group: slugName,
         name: 'factor',
-        values: setting.textScales,
-        initialValue: setting.activeTextScale,
+        values: initialSetting.textScales,
+        initialValue: initialSetting.activeTextScale,
         labelBuilder: (scale) => scale.toStringAsFixed(2),
-        onChanged: (_, scale) {
-          if (scale == null) return;
-
-          updateSetting(
-            setting.copyWith(
-              activeTextScale: scale,
-            ),
-          );
-        },
       ),
     ];
   }
 
   @override
-  Widget buildUseCase(BuildContext context, Widget child) {
+  TextScaleSetting settingFromQueryGroup(Map<String, String> group) {
+    return TextScaleSetting(
+      textScales: initialSetting.textScales,
+      activeTextScale: double.parse(
+        group['factor'] ?? initialSetting.activeTextScale.toStringAsFixed(2),
+      ),
+    );
+  }
+
+  @override
+  Widget buildUseCase(
+    BuildContext context,
+    Widget child,
+    TextScaleSetting setting,
+  ) {
     return MediaQuery(
       data: MediaQuery.of(context).copyWith(
         textScaleFactor: setting.activeTextScale,

--- a/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
@@ -42,24 +42,30 @@ class ThemeAddon<T> extends WidgetbookAddOn<ThemeSetting<T>> {
       ListField<WidgetbookTheme<T>>(
         group: slugName,
         name: 'name',
-        values: setting.themes,
-        initialValue: setting.activeTheme,
+        values: initialSetting.themes,
+        initialValue: initialSetting.activeTheme,
         labelBuilder: (theme) => theme.name,
-        onChanged: (_, theme) {
-          if (theme == null) return;
-
-          updateSetting(
-            setting.copyWith(
-              activeTheme: theme,
-            ),
-          );
-        },
       ),
     ];
   }
 
   @override
-  Widget buildUseCase(BuildContext context, Widget child) {
+  ThemeSetting<T> settingFromQueryGroup(Map<String, String> group) {
+    return ThemeSetting<T>(
+      themes: initialSetting.themes,
+      activeTheme: initialSetting.themes.firstWhere(
+        (theme) => theme.name == group['name'],
+        orElse: () => initialSetting.activeTheme,
+      ),
+    );
+  }
+
+  @override
+  Widget buildUseCase(
+    BuildContext context,
+    Widget child,
+    ThemeSetting<T> setting,
+  ) {
     return themeBuilder(
       context,
       setting.activeTheme.data,

--- a/packages/widgetbook/lib/src/app/workbench.dart
+++ b/packages/widgetbook/lib/src/app/workbench.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../addons/addons.dart';
+import '../fields/fields.dart';
 import '../state/state.dart';
 import 'safe_boundaries.dart';
 
@@ -21,9 +22,17 @@ class Workbench extends StatelessWidget {
         MultiAddonBuilder(
           addons: state.addons,
           builder: (context, addon, child) {
+            final state = WidgetbookState.of(context);
+            final groupMap = FieldCodec.decodeQueryGroup(
+              state.queryParams[addon.slugName],
+            );
+
+            final newSetting = addon.settingFromQueryGroup(groupMap);
+
             return addon.buildUseCase(
               context,
               child,
+              newSetting,
             );
           },
           child: Scaffold(

--- a/packages/widgetbook/lib/src/fields/boolean_field.dart
+++ b/packages/widgetbook/lib/src/fields/boolean_field.dart
@@ -10,7 +10,7 @@ class BooleanField extends Field<bool> {
     required super.group,
     required super.name,
     super.initialValue = true,
-    required super.onChanged,
+    super.onChanged,
   }) : super(
           type: FieldType.boolean,
           codec: FieldCodec(

--- a/packages/widgetbook/lib/src/fields/color_field.dart
+++ b/packages/widgetbook/lib/src/fields/color_field.dart
@@ -10,7 +10,7 @@ class ColorField extends Field<Color> {
     required super.group,
     required super.name,
     super.initialValue = defaultColor,
-    required super.onChanged,
+    super.onChanged,
   }) : super(
           type: FieldType.color,
           codec: FieldCodec(

--- a/packages/widgetbook/lib/src/fields/double_input_field.dart
+++ b/packages/widgetbook/lib/src/fields/double_input_field.dart
@@ -10,7 +10,7 @@ class DoubleInputField extends Field<double> {
     required super.group,
     required super.name,
     super.initialValue = 0,
-    required super.onChanged,
+    super.onChanged,
   }) : super(
           type: FieldType.doubleSlider,
           codec: FieldCodec(

--- a/packages/widgetbook/lib/src/fields/double_slider_field.dart
+++ b/packages/widgetbook/lib/src/fields/double_slider_field.dart
@@ -13,7 +13,7 @@ class DoubleSliderField extends Field<double> {
     required this.min,
     required this.max,
     this.divisions,
-    required super.onChanged,
+    super.onChanged,
   }) : super(
           type: FieldType.doubleSlider,
           codec: FieldCodec(

--- a/packages/widgetbook/lib/src/fields/field.dart
+++ b/packages/widgetbook/lib/src/fields/field.dart
@@ -28,7 +28,7 @@ abstract class Field<T> {
     required this.type,
     required this.initialValue,
     required this.codec,
-    required this.onChanged,
+    this.onChanged,
   });
 
   /// A set of [Field]s can be grouped under the same query parameter
@@ -51,19 +51,12 @@ abstract class Field<T> {
   /// Callback for when [Field]'s value changed through:
   /// 1. [WidgetbookState.queryParams], used for deep linking.
   /// 2. [Field]'s widget from the side panel.
-  final void Function(BuildContext context, T? value) onChanged;
+  final void Function(BuildContext context, T? value)? onChanged;
 
   Widget build(BuildContext context) {
     final state = WidgetbookState.of(context);
     final groupMap = FieldCodec.decodeQueryGroup(state.queryParams[group]);
     final value = codec.toValue(groupMap[name]);
-
-    // TODO: remove this workaround
-    if (group != 'knobs') {
-      // Notify change when field is built from new query params,
-      // to keep query params and locale state (e.g. addon's setting) in sync.
-      onChanged(context, value);
-    }
 
     return toWidget(context, value);
   }
@@ -83,7 +76,7 @@ abstract class Field<T> {
         ifAbsent: () => codec.toParam(value),
       );
 
-    onChanged(context, value);
+    onChanged?.call(context, value);
 
     state.updateQueryParam(
       group,

--- a/packages/widgetbook/lib/src/fields/list_field.dart
+++ b/packages/widgetbook/lib/src/fields/list_field.dart
@@ -16,7 +16,7 @@ class ListField<T> extends Field<T> {
     required this.values,
     required super.initialValue,
     this.labelBuilder,
-    required super.onChanged,
+    super.onChanged,
   }) : super(
           type: FieldType.list,
           codec: FieldCodec(

--- a/packages/widgetbook/lib/src/fields/string_field.dart
+++ b/packages/widgetbook/lib/src/fields/string_field.dart
@@ -11,7 +11,7 @@ class StringField extends Field<String> {
     required super.name,
     super.initialValue = '',
     this.maxLines,
-    required super.onChanged,
+    super.onChanged,
   }) : super(
           type: FieldType.string,
           codec: FieldCodec(

--- a/packages/widgetbook/test/src/addons/common/custom_addon.dart
+++ b/packages/widgetbook/test/src/addons/common/custom_addon.dart
@@ -10,4 +10,7 @@ class CustomAddOn extends WidgetbookAddOn<String> {
 
   @override
   List<Field> get fields => [];
+
+  @override
+  String settingFromQueryGroup(Map<String, String> group) => initialSetting;
 }

--- a/packages/widgetbook/test/src/addons/device_frame_addon/device_frame_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/device_frame_addon/device_frame_addon_test.dart
@@ -19,162 +19,91 @@ void main() {
         initialDevice: devices.first,
       );
 
-      group('Device can be activated via', () {
-        testWidgets(
-          'updateSetting',
-          (WidgetTester tester) async {
-            final device = devices.first;
+      testWidgets(
+        'can activate device',
+        (WidgetTester tester) async {
+          final device = devices.last;
 
-            await testAddon(
-              tester: tester,
-              addon: addon,
-              act: () async => addon.updateSetting(
-                addon.setting.copyWith(
-                  activeDevice: device,
-                ),
-              ),
-              expect: (context) => expect(
-                addon.setting.activeDevice,
-                equals(device),
-              ),
-            );
-          },
-        );
-
-        testWidgets(
-          'widget',
-          (WidgetTester tester) async {
-            final device = devices.last;
-
-            await testAddon(
-              tester: tester,
-              addon: addon,
-              act: () async {
-                final dropdownFinder = find.byType(
-                  DropdownMenu<DeviceInfo?>,
-                );
-
-                await tester.tap(dropdownFinder);
-                await tester.pumpAndSettle();
-
-                final textFinder = find.byWidgetPredicate(
-                  (widget) => widget is Text && widget.data == device.name,
-                );
-
-                await tester.tap(textFinder.last);
-                await tester.pumpAndSettle();
-              },
-              expect: (context) => expect(
-                addon.setting.activeDevice,
-                equals(device),
-              ),
-            );
-          },
-        );
-      });
-
-      group(
-        '$Orientation can be activated via',
-        () {
-          testWidgets(
-            'updateSetting',
-            (WidgetTester tester) async {
-              await testAddon(
-                tester: tester,
-                addon: addon,
-                act: () async => addon.updateSetting(
-                  addon.setting.copyWith(
-                    orientation: Orientation.landscape,
-                  ),
-                ),
-                expect: (context) => expect(
-                  addon.setting.orientation,
-                  equals(Orientation.landscape),
-                ),
+          await testAddon<DeviceFrameSetting>(
+            tester: tester,
+            addon: addon,
+            act: () async {
+              final dropdownFinder = find.byType(
+                DropdownMenu<DeviceInfo?>,
               );
-            },
-          );
 
-          testWidgets(
-            'widget',
-            (WidgetTester tester) async {
-              await testAddon(
-                tester: tester,
-                addon: addon,
-                act: () async {
-                  final dropdownFinder = find.byType(
-                    DropdownMenu<Orientation>,
-                  );
+              await tester.tap(dropdownFinder);
+              await tester.pumpAndSettle();
 
-                  await tester.tap(dropdownFinder);
-                  await tester.pumpAndSettle();
-
-                  final textFinder = find.byWidgetPredicate(
-                    (widget) => widget is Text && widget.data == 'Landscape',
-                  );
-
-                  await tester.tap(textFinder.last);
-                  await tester.pumpAndSettle();
-                },
-                expect: (context) => expect(
-                  addon.setting.orientation,
-                  equals(Orientation.landscape),
-                ),
+              final textFinder = find.byWidgetPredicate(
+                (widget) => widget is Text && widget.data == device.name,
               );
+
+              await tester.tap(textFinder.last);
+              await tester.pumpAndSettle();
             },
+            expect: (setting) => expect(
+              setting.activeDevice,
+              equals(device),
+            ),
           );
         },
       );
 
-      group(
-        'Frame can be activated via',
-        () {
-          testWidgets(
-            'updateSetting',
-            (WidgetTester tester) async {
-              await testAddon(
-                tester: tester,
-                addon: addon,
-                act: () async => addon.updateSetting(
-                  addon.setting.copyWith(
-                    hasFrame: true,
-                  ),
-                ),
-                expect: (context) => expect(
-                  addon.setting.hasFrame,
-                  equals(true),
-                ),
+      testWidgets(
+        'can activate device $Orientation',
+        (WidgetTester tester) async {
+          await testAddon<DeviceFrameSetting>(
+            tester: tester,
+            addon: addon,
+            act: () async {
+              final dropdownFinder = find.byType(
+                DropdownMenu<Orientation>,
               );
+
+              await tester.tap(dropdownFinder);
+              await tester.pumpAndSettle();
+
+              final textFinder = find.byWidgetPredicate(
+                (widget) => widget is Text && widget.data == 'Landscape',
+              );
+
+              await tester.tap(textFinder.last);
+              await tester.pumpAndSettle();
             },
+            expect: (setting) => expect(
+              setting.orientation,
+              equals(Orientation.landscape),
+            ),
           );
+        },
+      );
 
-          testWidgets(
-            'widget',
-            (WidgetTester tester) async {
-              await testAddon(
-                tester: tester,
-                addon: addon,
-                act: () async {
-                  final dropdownFinder = find.byType(
-                    DropdownMenu<bool>,
-                  );
-
-                  await tester.tap(dropdownFinder);
-                  await tester.pumpAndSettle();
-
-                  final textFinder = find.byWidgetPredicate(
-                    (widget) => widget is Text && widget.data == 'None',
-                  );
-
-                  await tester.tap(textFinder.last);
-                  await tester.pumpAndSettle();
-                },
-                expect: (context) => expect(
-                  addon.setting.hasFrame,
-                  equals(false),
-                ),
+      testWidgets(
+        'can activate frame',
+        (WidgetTester tester) async {
+          await testAddon<DeviceFrameSetting>(
+            tester: tester,
+            addon: addon,
+            act: () async {
+              final dropdownFinder = find.byType(
+                DropdownMenu<bool>,
               );
+
+              await tester.tap(dropdownFinder);
+              await tester.pumpAndSettle();
+
+              final textFinder = find.byWidgetPredicate(
+                (widget) => widget is Text && widget.data == 'None',
+              );
+
+              await tester.tap(textFinder.last);
+              await tester.pumpAndSettle();
             },
+            expect: (setting) => expect(
+              setting.hasFrame,
+              equals(false),
+            ),
           );
         },
       );

--- a/packages/widgetbook/test/src/addons/locale_addon/locale_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/locale_addon/locale_addon_test.dart
@@ -13,28 +13,9 @@ void main() {
 
   group('$LocalizationAddon', () {
     testWidgets(
-      'can activate a locale',
+      'can activate locale',
       (WidgetTester tester) async {
-        await testAddon(
-          tester: tester,
-          addon: addon,
-          act: () async => addon.updateSetting(
-            addon.setting.copyWith(
-              activeLocale: frenchLocale,
-            ),
-          ),
-          expect: (context) => expect(
-            addon.setting.activeLocale,
-            equals(frenchLocale),
-          ),
-        );
-      },
-    );
-
-    testWidgets(
-      'can activate locale via Widget',
-      (WidgetTester tester) async {
-        await testAddon(
+        await testAddon<LocalizationSetting>(
           tester: tester,
           addon: addon,
           act: () async {
@@ -48,31 +29,10 @@ void main() {
             await tester.tap(textFinder.last);
             await tester.pumpAndSettle();
           },
-          expect: (context) => expect(
-            addon.setting.activeLocale,
+          expect: (setting) => expect(
+            setting.activeLocale,
             equals(germanLocale),
           ),
-        );
-      },
-    );
-
-    testWidgets(
-      'supports locales with same language code',
-      (tester) async {
-        await testAddon(
-          tester: tester,
-          addon: addon,
-          act: () async => addon.updateSetting(
-            addon.setting.copyWith(
-              activeLocale: engLocaleGb,
-            ),
-          ),
-          expect: (context) {
-            expect(
-              addon.setting.activeLocale,
-              equals(engLocaleGb),
-            );
-          },
         );
       },
     );

--- a/packages/widgetbook/test/src/addons/test_scale_factor/text_scale_factor_test.dart
+++ b/packages/widgetbook/test/src/addons/test_scale_factor/text_scale_factor_test.dart
@@ -13,28 +13,9 @@ void main() {
       );
 
       testWidgets(
-        'can activate a text scale factor',
+        'can activate text scale factor',
         (WidgetTester tester) async {
-          await testAddon(
-            tester: tester,
-            addon: addon,
-            act: () async => addon.updateSetting(
-              addon.setting.copyWith(
-                activeTextScale: 2,
-              ),
-            ),
-            expect: (context) => expect(
-              addon.setting.activeTextScale,
-              equals(2),
-            ),
-          );
-        },
-      );
-
-      testWidgets(
-        'can activate text scale factor via Widget',
-        (WidgetTester tester) async {
-          await testAddon(
+          await testAddon<TextScaleSetting>(
             tester: tester,
             addon: addon,
             act: () async {
@@ -48,8 +29,8 @@ void main() {
               await tester.tap(textFinder.last);
               await tester.pumpAndSettle();
             },
-            expect: (context) => expect(
-              addon.setting.activeTextScale,
+            expect: (setting) => expect(
+              setting.activeTextScale,
               equals(2),
             ),
           );

--- a/packages/widgetbook/test/src/addons/theme_addon/cupertino_theme_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/theme_addon/cupertino_theme_addon_test.dart
@@ -10,7 +10,7 @@ void main() {
   group(
     '$CupertinoThemeAddon',
     () {
-      const bluetheme = CupertinoThemeData(
+      const blueTheme = CupertinoThemeData(
         primaryColor: colorBlue,
       );
 
@@ -20,7 +20,7 @@ void main() {
 
       const blueWidgetbookTheme = WidgetbookTheme<CupertinoThemeData>(
         name: 'Blue',
-        data: bluetheme,
+        data: blueTheme,
       );
 
       const yellowWidgetbookTheme = WidgetbookTheme(
@@ -36,28 +36,9 @@ void main() {
       );
 
       testWidgets(
-        'can activate a theme',
+        'can activate theme',
         (WidgetTester tester) async {
-          await testAddon(
-            tester: tester,
-            addon: addon,
-            act: () async => addon.updateSetting(
-              addon.setting.copyWith(
-                activeTheme: yellowWidgetbookTheme,
-              ),
-            ),
-            expect: (context) => expect(
-              addon.setting.activeTheme.data,
-              equals(yellowWidgetbookTheme.data),
-            ),
-          );
-        },
-      );
-
-      testWidgets(
-        'can activate theme via Widget',
-        (WidgetTester tester) async {
-          await testAddon(
+          await testAddon<ThemeSetting<CupertinoThemeData>>(
             tester: tester,
             addon: addon,
             act: () async {
@@ -73,8 +54,8 @@ void main() {
               await tester.tap(textFinder.last);
               await tester.pumpAndSettle();
             },
-            expect: (context) => expect(
-              addon.setting.activeTheme.data,
+            expect: (setting) => expect(
+              setting.activeTheme.data,
               equals(yellowWidgetbookTheme.data),
             ),
           );

--- a/packages/widgetbook/test/src/addons/theme_addon/material_theme_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/theme_addon/material_theme_addon_test.dart
@@ -32,28 +32,9 @@ void main() {
       );
 
       testWidgets(
-        'can activate a theme',
+        'can activate theme',
         (WidgetTester tester) async {
-          await testAddon(
-            tester: tester,
-            addon: addon,
-            act: () async => addon.updateSetting(
-              addon.setting.copyWith(
-                activeTheme: yellowWidgetbookTheme,
-              ),
-            ),
-            expect: (context) => expect(
-              addon.setting.activeTheme.data,
-              equals(yellowWidgetbookTheme.data),
-            ),
-          );
-        },
-      );
-
-      testWidgets(
-        'can activate theme via Widget',
-        (WidgetTester tester) async {
-          await testAddon(
+          await testAddon<ThemeSetting<ThemeData>>(
             tester: tester,
             addon: addon,
             act: () async {
@@ -69,8 +50,8 @@ void main() {
               await tester.tap(textFinder.last);
               await tester.pumpAndSettle();
             },
-            expect: (context) => expect(
-              addon.setting.activeTheme.data,
+            expect: (setting) => expect(
+              setting.activeTheme.data,
               equals(yellowWidgetbookTheme.data),
             ),
           );

--- a/packages/widgetbook/test/src/addons/theme_addon/theme_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/theme_addon/theme_addon_test.dart
@@ -55,28 +55,9 @@ void main() {
       );
 
       testWidgets(
-        'can activate a theme',
-        (WidgetTester tester) async {
-          await testAddon(
-            tester: tester,
-            addon: addon,
-            act: () async => addon.updateSetting(
-              addon.setting.copyWith(
-                activeTheme: yellowCustomWidgetbookTheme,
-              ),
-            ),
-            expect: (context) => expect(
-              addon.setting.activeTheme.data,
-              equals(yellowCustomWidgetbookTheme.data),
-            ),
-          );
-        },
-      );
-
-      testWidgets(
         'can activate theme via Widget',
         (WidgetTester tester) async {
-          await testAddon(
+          await testAddon<ThemeSetting<AppThemeData>>(
             tester: tester,
             addon: addon,
             act: () async {
@@ -92,8 +73,8 @@ void main() {
               await tester.tap(textFinder.last);
               await tester.pumpAndSettle();
             },
-            expect: (context) => expect(
-              addon.setting.activeTheme.data,
+            expect: (setting) => expect(
+              setting.activeTheme.data,
               equals(yellowCustomWidgetbookTheme.data),
             ),
           );

--- a/packages/widgetbook/test/src/addons/utils/addon_test_helper.dart
+++ b/packages/widgetbook/test/src/addons/utils/addon_test_helper.dart
@@ -1,30 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widgetbook/src/addons/addons.dart';
+import 'package:widgetbook/src/fields/fields.dart';
 import 'package:widgetbook/src/state/state.dart';
 
-import 'extensions/widget_tester_extension.dart';
-
-Future<void> testAddon({
+Future<void> testAddon<T>({
   required WidgetTester tester,
-  required WidgetbookAddOn addon,
-  required void Function(BuildContext context) expect,
+  required WidgetbookAddOn<T> addon,
+  required void Function(T setting) expect,
   Future<void> Function()? act,
 }) async {
-  const key = ValueKey('RandomKey');
+  final state = WidgetbookState(
+    queryParams: {},
+    addons: [addon],
+    appBuilder: materialAppBuilder,
+    catalog: WidgetbookCatalog.fromDirectories([]),
+  );
 
   await tester.pumpWidget(
     MaterialApp(
       home: WidgetbookScope(
-        state: WidgetbookState(
-          queryParams: {},
-          addons: [addon],
-          appBuilder: materialAppBuilder,
-          catalog: WidgetbookCatalog.fromDirectories([]),
-        ),
+        state: state,
         child: Scaffold(
           body: Builder(
-            key: key,
             builder: addon.buildSetting,
           ),
         ),
@@ -35,6 +33,11 @@ Future<void> testAddon({
   await act?.call();
   await tester.pumpAndSettle();
 
-  final context = tester.findContextByKey(key);
-  expect(context);
+  final groupMap = FieldCodec.decodeQueryGroup(
+    state.queryParams[addon.slugName],
+  );
+
+  final setting = addon.settingFromQueryGroup(groupMap);
+
+  expect(setting);
 }


### PR DESCRIPTION
Instead of having a local `setting` variable and updating it with each field change, a method called `settingFromQueryGroup` is added to parse query parameters into an addon's setting.

This change was made to avoid [calling `onChange` inside `Field`'s `build` method](https://github.com/widgetbook/widgetbook/blob/07fd5c19db24db3de00ca947ef2848cd4831cd4b/packages/widgetbook/lib/src/fields/field.dart#L61-L66); which was causing some undesired rebuilds.

The only caveat of this change, that the fields' names are considered magic strings that are shared between `fields` and `settingFromQueryGroup`.