### PR TITLE
fix: use related type checks

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -35,3 +35,6 @@ linter:
     prefer_single_quotes: true
     require_trailing_commas: true
     noop_primitive_operations: true
+  
+    # Types
+    unrelated_type_equality_checks: true

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ - **FIX**: Use related type checks when comparing device's frame state to its query parameter. ([#715](https://github.com/widgetbook/widgetbook/pull/715))
+
 ## 3.0.0-rc.1
 
  - Check out the [migration guide](https://docs.widgetbook.io/~docs%2Fwidgetbook-3/migration/3.0.0-beta-to-rc) for more details.

--- a/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
@@ -68,7 +68,7 @@ class DeviceFrameAddon extends WidgetbookAddon<DeviceFrameSetting> {
       orientation: Orientation.values.byName(
         group['orientation']?.toLowerCase() ?? Orientation.portrait.name,
       ),
-      hasFrame: group['frame'] == true,
+      hasFrame: group['frame'] == 'true',
     );
   }
 


### PR DESCRIPTION
When decoding the query parameters of the device addon, a string-on-bool comparison is made for the frame, which is pretty weird. 
A linter rule was added to prevent that in the future.