### PR TITLE
fix: add `LabelBuilder` missing type param

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
  - **FIX**: Use related type checks when comparing device's frame state to its query parameter. ([#715](https://github.com/widgetbook/widgetbook/pull/715))
+ - **FIX**: Add missing type parameter to `LabelBuilder`, which affected the `list` knob. ([#718](https://github.com/widgetbook/widgetbook/pull/718))
 
 ## 3.0.0-rc.1
 

--- a/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
@@ -109,7 +109,7 @@ class KnobsBuilder {
     required String label,
     required List<T> options,
     String? description,
-    LabelBuilder? labelBuilder,
+    LabelBuilder<T>? labelBuilder,
   }) {
     assert(options.isNotEmpty, 'Must specify at least one option');
     return _onKnobAdded(

--- a/packages/widgetbook/lib/src/knobs/list_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/list_knob.dart
@@ -15,7 +15,7 @@ class ListKnob<T> extends Knob<T> {
   });
 
   final List<T> options;
-  final LabelBuilder? labelBuilder;
+  final LabelBuilder<T>? labelBuilder;
 
   @override
   List<Field> get fields {


### PR DESCRIPTION
If the app's analyer was so strict, the following error will arose due to the inability to infer the type parameter.

![image](https://github.com/widgetbook/widgetbook/assets/41103290/e5c2e89c-f147-409a-a972-2b197e212799)
