### PR TITLE
refactor: build knobs once post build

### DIFF
--- a/packages/widgetbook/lib/src/app/use_case_builder.dart
+++ b/packages/widgetbook/lib/src/app/use_case_builder.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import '../models/models.dart';
+import '../state/state.dart';
+
+class UseCaseBuilder extends StatefulWidget {
+  const UseCaseBuilder({
+    super.key,
+    required this.useCase,
+  });
+
+  final WidgetbookUseCase useCase;
+
+  @override
+  State<UseCaseBuilder> createState() => _UseCaseBuilderState();
+}
+
+class _UseCaseBuilderState extends State<UseCaseBuilder> {
+  @override
+  void initState() {
+    super.initState();
+
+    // Notify that the use case finished building,
+    // to rebuild the use case with all registered knobs
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      WidgetbookState.of(context).notifyListeners();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.useCase.builder(context);
+  }
+}

--- a/packages/widgetbook/lib/src/app/workbench.dart
+++ b/packages/widgetbook/lib/src/app/workbench.dart
@@ -4,6 +4,7 @@ import '../addons/addons.dart';
 import '../fields/fields.dart';
 import '../state/state.dart';
 import 'safe_boundaries.dart';
+import 'use_case_builder.dart';
 
 class Workbench extends StatelessWidget {
   const Workbench({super.key});
@@ -36,7 +37,10 @@ class Workbench extends StatelessWidget {
             );
           },
           child: Scaffold(
-            body: state.useCase!.builder(context),
+            body: UseCaseBuilder(
+              key: ValueKey(state.uri),
+              useCase: state.useCase!,
+            ),
           ),
         ),
       ),

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -107,10 +107,7 @@ class WidgetbookState extends ChangeNotifier {
   T? registerKnob<T>(Knob<T> knob) {
     final cachedKnob = knobs.putIfAbsent(
       knob.label,
-      () {
-        Future.microtask(notifyListeners);
-        return knob;
-      },
+      () => knob,
     );
 
     // Return `null` even if the knob has value, but it was marked as null


### PR DESCRIPTION
Instead of rebuilding the use case with every knob getting registered, this PR aims at rebuilding the use case only once after the build method (i.e. all knobs have been registered but not built).