### PR TITLE
fix(core): call `onNodeSelected` for unique nodes

### DIFF
--- a/packages/widgetbook_core/CHANGELOG.md
+++ b/packages/widgetbook_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ - **Fix**: Prevent `onNodeSelected` from being called if the node is already selected. ([#725](https://github.com/widgetbook/widgetbook/pull/725))
+
 ## 3.0.0-rc.1
 
  - **FEAT**: Add Dart 3 and Flutter 3.10 support. ([#676](https://github.com/widgetbook/widgetbook/pull/676))

--- a/packages/widgetbook_core/lib/src/navigation_tree/widgets/navigation_tree.dart
+++ b/packages/widgetbook_core/lib/src/navigation_tree/widgets/navigation_tree.dart
@@ -59,6 +59,7 @@ class NavigationTreeState extends State<NavigationTree> {
         data: filteredNodes[index],
         selectedNode: selectedNode,
         onNodeSelected: (node) {
+          if (node.path == selectedNode?.path) return;
           setState(() => selectedNode = node);
           widget.onNodeSelected?.call(node.path, node.data);
         },


### PR DESCRIPTION
Prevent `onNodeSelected` from being called if the node is already selected.