### PR TITLE
changing generated file extension to be more unique

### DIFF
--- a/packages/widgetbook_generator/build.yaml
+++ b/packages/widgetbook_generator/build.yaml
@@ -10,6 +10,6 @@ builders:
   app_builder:
     import: "package:widgetbook_generator/builder.dart"
     builder_factories: ["appBuilder"]
-    build_extensions: { ".dart": [".g.dart"] }
+    build_extensions: { ".dart": [".directories.widgetbook.dart"] }
     auto_apply: dependents
     build_to: source

--- a/packages/widgetbook_generator/lib/builder.dart
+++ b/packages/widgetbook_generator/lib/builder.dart
@@ -22,7 +22,7 @@ Builder useCaseBuilder(BuilderOptions options) {
 Builder appBuilder(BuilderOptions options) {
   return LibraryBuilder(
     AppGenerator(),
-    generatedExtension: '.g.dart',
+    generatedExtension: '.directories.widgetbook.dart',
   );
 }
 


### PR DESCRIPTION
When there are multiple packages that are using build_runner, they can cause a collision when the outputs are possibly the same file. In the particular case that I ran in to, this was happening with widgetbook_generator and json_serializable, with the true culprit being from the package [source_gen](https://github.com/dart-lang/source_gen/blob/70e46c0079263192b7a914ac651f25eff4fa7680/source_gen/build.yaml#L6), which is a dependency of json_serializable. More details as to why it's necessary to have unique outputs can be found in the [build_runner repo](https://github.com/dart-lang/build/blob/master/docs/faq.md#why-do-builders-need-unique-outputs).

I hope this is an acceptable solution to the issue!

### List of issues which are fixed by the PR

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
