### PR TITLE
feat: add `initialOption` to `list` knob

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+ - **FEAT**: Add `initialOption` to `list` knob. ([#733](https://github.com/widgetbook/widgetbook/pull/733))
  - **REFACTOR**: Export `WidgetbookState`. ([#724](https://github.com/widgetbook/widgetbook/pull/724))
  - **REFACTOR**: Export fields to be used for custom addons/knobs. ([#728](https://github.com/widgetbook/widgetbook/pull/728))
  - **REFACTOR**: Make `KnobsBuilder.onKnobAdded` public. ([#727](https://github.com/widgetbook/widgetbook/pull/727))

--- a/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
@@ -107,6 +107,7 @@ class KnobsBuilder {
   T list<T>({
     required String label,
     required List<T> options,
+    T? initialOption,
     String? description,
     LabelBuilder<T>? labelBuilder,
   }) {
@@ -114,7 +115,7 @@ class KnobsBuilder {
     return onKnobAdded(
       ListKnob(
         label: label,
-        value: options.first,
+        value: initialOption ?? options.first,
         description: description,
         options: options,
         labelBuilder: labelBuilder,

--- a/packages/widgetbook/test/src/knobs/list_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/list_knob_test.dart
@@ -125,4 +125,34 @@ void main() {
       expect(find.text('${Icons.circle} icon'), findsWidgets);
     },
   );
+
+  testWidgets(
+    'Options knob respect initial selected option',
+    (WidgetTester tester) async {
+      await tester.pumpWithKnob(
+        (context) => Icon(
+          context.knobs.list<IconData>(
+            label: 'RemoveIcon',
+            options: [Icons.remove, Icons.crop_square_sharp, Icons.circle],
+            initialOption: Icons.circle,
+            labelBuilder: (value) => value.toString() + ' icon',
+          ),
+        ),
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) => widget is Icon && widget.icon == Icons.circle,
+        ),
+        findsOneWidget,
+      );
+
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(DropdownMenu<IconData>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('${Icons.remove} icon').first);
+      await tester.pumpAndSettle();
+      expect(find.text('${Icons.remove} icon'), findsWidgets);
+    },
+  );
 }


### PR DESCRIPTION
Adds support to select the initial list option from `list` knob

### Checklist

- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing. -> Some tests are breaking but not related with this change

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
