### PR TITLE
refactor(annotation): remove `@App`'s non-working params

### DIFF
--- a/packages/widgetbook_annotation/CHANGELOG.md
+++ b/packages/widgetbook_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ - **BREAKING**: Remove `@App` annotation's `foldersExpanded` and `widgetsExpanded` non-working parameters. ([#735](https://github.com/widgetbook/widgetbook/pull/735))
+
 ## 3.0.0-rc.1
 
  - Check out the [migration guide](https://docs.widgetbook.io/~docs%2Fwidgetbook-3/migration/3.0.0-beta-to-rc) for more details.

--- a/packages/widgetbook_annotation/lib/src/app.dart
+++ b/packages/widgetbook_annotation/lib/src/app.dart
@@ -1,14 +1,5 @@
 /// Annotates a code element to create the widgetbook main file in the same
 /// folder in which the annotated element is defined.
 class App {
-  const App({
-    this.foldersExpanded = false,
-    this.widgetsExpanded = false,
-  });
-
-  /// Determines folders are expanded by default
-  final bool foldersExpanded;
-
-  /// Determines widgets are expanded by default
-  final bool widgetsExpanded;
+  const App();
 }

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ - **BREAKING**: Remove `@App` annotation's `foldersExpanded` and `widgetsExpanded` non-working parameters. ([#735](https://github.com/widgetbook/widgetbook/pull/735))
+
 ## 3.0.0-rc.1
 
  - Check out the [migration guide](https://docs.widgetbook.io/~docs%2Fwidgetbook-3/migration/3.0.0-beta-to-rc) for more details.

--- a/packages/widgetbook_generator/lib/generators/app_generator.dart
+++ b/packages/widgetbook_generator/lib/generators/app_generator.dart
@@ -32,16 +32,8 @@ class AppGenerator extends GeneratorForAnnotation<App> {
     );
 
     final buffer = StringBuffer()
-      ..writeln(
-        generateImports(useCases),
-      )
-      ..writeln(
-        generateDirectories(
-          useCases: useCases,
-          foldersExpanded: annotation.read('foldersExpanded').boolValue,
-          widgetsExpanded: annotation.read('widgetsExpanded').boolValue,
-        ),
-      );
+      ..writeln(generateImports(useCases))
+      ..writeln(generateDirectories(useCases));
 
     return buffer.toString();
   }
@@ -69,16 +61,10 @@ class AppGenerator extends GeneratorForAnnotation<App> {
   }
 
   /// Generates the directories of Widgetbook
-  String generateDirectories({
-    required List<WidgetbookUseCaseData> useCases,
-    required bool foldersExpanded,
-    required bool widgetsExpanded,
-  }) {
-    final directories = _generateDirectoriesInstances(
-      useCases,
-      foldersExpanded,
-      widgetsExpanded,
-    );
+  String generateDirectories(
+    List<WidgetbookUseCaseData> useCases,
+  ) {
+    final directories = _generateDirectoriesInstances(useCases);
 
     final instance = ListInstance(
       instances: directories,
@@ -119,13 +105,8 @@ class AppGenerator extends GeneratorForAnnotation<App> {
 
   List<Instance> _generateDirectoriesInstances(
     List<WidgetbookUseCaseData> useCases,
-    bool foldersExpanded,
-    bool widgetsExpanded,
   ) {
-    final service = TreeService(
-      foldersExpanded: foldersExpanded,
-      widgetsExpanded: widgetsExpanded,
-    );
+    final service = TreeService();
 
     for (final useCase in useCases) {
       final folder =

--- a/packages/widgetbook_generator/lib/generators/tree_service.dart
+++ b/packages/widgetbook_generator/lib/generators/tree_service.dart
@@ -5,25 +5,18 @@ import 'package:meta/meta.dart';
 import '../models/widgetbook_use_case_data.dart';
 
 class Widget {
-  Widget(
-    this.name, {
-    this.isExpanded = false,
-  });
+  Widget(this.name);
 
   final String name;
-  final bool isExpanded;
+
   List<WidgetbookUseCaseData> stories = <WidgetbookUseCaseData>[];
 }
 
 @immutable
 class Folder {
-  Folder({
-    required this.name,
-    this.isExpanded = false,
-  });
+  Folder(this.name);
 
   final String name;
-  final bool isExpanded;
   final Map<String, Folder> subFolders = HashMap();
   final Map<String, Widget> widgets = HashMap();
 
@@ -39,13 +32,7 @@ class Folder {
 }
 
 class TreeService {
-  TreeService({
-    this.foldersExpanded = false,
-    this.widgetsExpanded = false,
-  }) : rootFolder = Folder(name: 'root', isExpanded: foldersExpanded);
-
-  final bool foldersExpanded;
-  final bool widgetsExpanded;
+  TreeService() : rootFolder = Folder('root');
 
   Map<String, Folder> folders = HashMap();
   // TODO This is a bit weird but (likely) works
@@ -79,7 +66,7 @@ class TreeService {
     if (!widgets.containsKey(widgetName)) {
       widgets.putIfAbsent(
         widgetName,
-        () => Widget(widgetName, isExpanded: widgetsExpanded),
+        () => Widget(widgetName),
       );
     }
 
@@ -100,10 +87,7 @@ class TreeService {
       if (!folders.containsKey(folderName)) {
         folders.putIfAbsent(
           folderName,
-          () => Folder(
-            name: folderName,
-            isExpanded: foldersExpanded,
-          ),
+          () => Folder(folderName),
         );
       }
 
@@ -117,10 +101,7 @@ class TreeService {
       if (!folder.subFolders.containsKey(folderName)) {
         folder.subFolders.putIfAbsent(
           folderName,
-          () => Folder(
-            name: folderName,
-            isExpanded: foldersExpanded,
-          ),
+          () => Folder(folderName),
         );
       }
 

--- a/packages/widgetbook_generator/lib/instances/widgetbook_category_instance.dart
+++ b/packages/widgetbook_generator/lib/instances/widgetbook_category_instance.dart
@@ -27,7 +27,6 @@ class WidgetbookCategoryInstance extends Instance {
                     (widget) => WidgetbookComponentInstance(
                       name: widget.name,
                       stories: widget.stories,
-                      isExpanded: widget.isExpanded,
                     ),
                   ),
                 ],

--- a/packages/widgetbook_generator/lib/instances/widgetbook_folder_instance.dart
+++ b/packages/widgetbook_generator/lib/instances/widgetbook_folder_instance.dart
@@ -21,7 +21,6 @@ class WidgetbookFolderInstance extends Instance {
                     (widget) => WidgetbookComponentInstance(
                       name: widget.name,
                       stories: widget.stories,
-                      isExpanded: widget.isExpanded,
                     ),
                   ),
                   ...folder.subFolders.values.map(
@@ -30,11 +29,6 @@ class WidgetbookFolderInstance extends Instance {
                 ],
               ),
             ),
-            if (folder.isExpanded)
-              Property.bool(
-                key: 'isInitiallyExpanded',
-                value: true,
-              ),
           ],
         );
 }

--- a/packages/widgetbook_generator/lib/instances/widgetbook_widget_instance.dart
+++ b/packages/widgetbook_generator/lib/instances/widgetbook_widget_instance.dart
@@ -28,11 +28,6 @@ class WidgetbookComponentInstance extends Instance {
                     .toList(),
               ),
             ),
-            if (isExpanded)
-              Property.bool(
-                key: 'isInitiallyExpanded',
-                value: true,
-              ),
           ],
         );
 }

--- a/packages/widgetbook_generator/test/src/instances/widgetbook_category_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/instances/widgetbook_category_instance_test.dart
@@ -12,13 +12,9 @@ void main() {
   group(
     '$WidgetbookCategoryInstance',
     () {
-      final folder = Folder(name: 'Folder');
-      final folder1 = Folder(
-        name: 'Folder1',
-      );
-      final folder2 = Folder(
-        name: 'Folder2',
-      );
+      final folder = Folder('Folder');
+      final folder1 = Folder('Folder1');
+      final folder2 = Folder('Folder2');
       final folders = [
         folder1,
         folder2,

--- a/packages/widgetbook_generator/test/src/instances/widgetbook_folder_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/instances/widgetbook_folder_instance_test.dart
@@ -11,19 +11,11 @@ void main() {
   group(
     '$WidgetbookFolderInstance',
     () {
-      final folder = Folder(name: 'Folder');
-      final folder1 = Folder(
-        name: 'Folder1',
-      );
-      final folder2 = Folder(
-        name: 'Folder2',
-        isExpanded: true,
-      );
+      final folder = Folder('Folder');
+      final folder1 = Folder('Folder1');
+      final folder2 = Folder('Folder2');
       final widget1 = Widget('Widget1');
-      final widget2 = Widget(
-        'Widget2',
-        isExpanded: true,
-      );
+      final widget2 = Widget('Widget2');
       folder.subFolders
         ..putIfAbsent(
           folder1.name,


### PR DESCRIPTION
The `foldersExpanded` and `widgetsExpanded` params were not working for the following reasons:

1. All `MultiChildNavigationNodeData` has `isInitiallyExpanded` defaulting to `true`.
2. `WidgetbookFolderInstance` and `WidgetbookComponentInstance` would only set `isInitiallyExpanded` if and only if the `isExpanded` param is `true`, so setting any of the above params would have no effect.