### PR TITLE
refactor(generator): change generated extension

### DIFF
--- a/examples/screen_util_example/lib/widgetbook.dart
+++ b/examples/screen_util_example/lib/widgetbook.dart
@@ -3,7 +3,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
-import 'widgetbook.g.dart';
+import 'widgetbook.directories.g.dart';
 
 void main() {
   runApp(const WidgetbookApp());

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+ - **BREAKING**: Change generated extension from `.g.dart` to `.directories.g.dart` to avoid conflicting outputs with other generators. ([#737](https://github.com/widgetbook/widgetbook/pull/737))
  - **BREAKING**: Remove `@App` annotation's `foldersExpanded` and `widgetsExpanded` non-working parameters. ([#735](https://github.com/widgetbook/widgetbook/pull/735))
 
 ## 3.0.0-rc.1

--- a/packages/widgetbook_generator/build.yaml
+++ b/packages/widgetbook_generator/build.yaml
@@ -10,6 +10,6 @@ builders:
   app_builder:
     import: "package:widgetbook_generator/builder.dart"
     builder_factories: ["appBuilder"]
-    build_extensions: { ".dart": [".g.dart"] }
+    build_extensions: { ".dart": [".directories.g.dart"] }
     auto_apply: dependents
     build_to: source

--- a/packages/widgetbook_generator/example/main.dart
+++ b/packages/widgetbook_generator/example/main.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
-import 'widgetbook.g.dart';
+import 'main.directories.g.dart';
 
 void main() {
   runApp(const WidgetbookApp());

--- a/packages/widgetbook_generator/lib/builder.dart
+++ b/packages/widgetbook_generator/lib/builder.dart
@@ -22,7 +22,7 @@ Builder useCaseBuilder(BuilderOptions options) {
 Builder appBuilder(BuilderOptions options) {
   return LibraryBuilder(
     AppGenerator(),
-    generatedExtension: '.g.dart',
+    generatedExtension: '.directories.g.dart',
   );
 }
 

--- a/packages/widgetbook_generator/lib/generators/app_generator.dart
+++ b/packages/widgetbook_generator/lib/generators/app_generator.dart
@@ -73,7 +73,7 @@ class AppGenerator extends GeneratorForAnnotation<App> {
     return 'final directories = $instance;';
   }
 
-  /// generates the imports for all the types used in widgetbook.g.dart
+  /// generates the imports for all the types used
   ///
   /// the code returned likely contains unneccesary imports
   /// but this implementation is simple in comparison to a complex approach

--- a/widgetbook_for_widgetbook/lib/widgetbook.dart
+++ b/widgetbook_for_widgetbook/lib/widgetbook.dart
@@ -3,7 +3,7 @@ import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 import 'package:widgetbook_core/widgetbook_core.dart';
 
-import 'widgetbook.g.dart';
+import 'widgetbook.directories.g.dart';
 
 void main() {
   runApp(const WidgetbookApp());


### PR DESCRIPTION
Change extension from `.g.dart` to `.directories.g.dart` to avoid conflicts with other generators (e.g. `json_serializable`) that use the same extension.