### PR TITLE
feat: add `listOrNull` knob

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+ - **FEAT**: Add `listOrNull` knob. ([#741](https://github.com/widgetbook/widgetbook/pull/741))
  - **FEAT**: Add `initialOption` to `list` knob. ([#733](https://github.com/widgetbook/widgetbook/pull/733))
  - **REFACTOR**: Export `WidgetbookState`. ([#724](https://github.com/widgetbook/widgetbook/pull/724))
  - **REFACTOR**: Export fields to be used for custom addons/knobs. ([#728](https://github.com/widgetbook/widgetbook/pull/728))

--- a/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
@@ -102,8 +102,7 @@ class KnobsBuilder {
   }
 
   /// Allow the users to select from a list of options in a drop down box.
-  /// The initial value is the first item in the list of options
-  /// Must contain at least one value
+  /// Must contain at least one value.
   T list<T>({
     required String label,
     required List<T> options,
@@ -113,7 +112,7 @@ class KnobsBuilder {
   }) {
     assert(options.isNotEmpty, 'Must specify at least one option');
     return onKnobAdded(
-      ListKnob(
+      ListKnob<T>(
         label: label,
         value: initialOption ?? options.first,
         description: description,
@@ -121,5 +120,26 @@ class KnobsBuilder {
         labelBuilder: labelBuilder,
       ),
     )!;
+  }
+
+  /// Allow the users to select from a list of options in a drop down box that
+  /// might contain a null value.
+  T? listOrNull<T>({
+    required String label,
+    required List<T?> options,
+    T? initialOption,
+    String? description,
+    LabelBuilder<T?>? labelBuilder,
+  }) {
+    assert(options.isNotEmpty, 'Must specify at least one option');
+    return onKnobAdded<T?>(
+      ListOrNullKnob<T>(
+        label: label,
+        value: initialOption ?? options.first,
+        description: description,
+        options: options,
+        labelBuilder: labelBuilder,
+      ),
+    );
   }
 }

--- a/packages/widgetbook/lib/src/knobs/list_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/list_knob.dart
@@ -17,6 +17,10 @@ class ListKnob<T> extends Knob<T> {
   final List<T> options;
   final LabelBuilder<T>? labelBuilder;
 
+  // Force non-nullable behavior
+  @override
+  bool get isNullable => false;
+
   @override
   List<Field> get fields {
     return [
@@ -36,6 +40,48 @@ class ListKnob<T> extends Knob<T> {
 
   @override
   T valueFromQueryGroup(Map<String, String> group) {
+    return options.firstWhere(
+      (option) {
+        final optionLabel = labelBuilder?.call(option);
+        return (optionLabel ?? option.toString()) == group[label];
+      },
+      orElse: () => value,
+    );
+  }
+}
+
+@internal
+class ListOrNullKnob<T> extends Knob<T?> {
+  ListOrNullKnob({
+    required super.label,
+    required super.value,
+    required this.options,
+    super.description,
+    this.labelBuilder,
+  });
+
+  final List<T?> options;
+  final LabelBuilder<T?>? labelBuilder;
+
+  @override
+  List<Field> get fields {
+    return [
+      ListField<T?>(
+        group: 'knobs',
+        name: label,
+        values: options,
+        initialValue: value,
+        labelBuilder: labelBuilder,
+        onChanged: (context, value) {
+          if (value == null) return;
+          WidgetbookState.of(context).updateKnobValue<T>(label, value);
+        },
+      ),
+    ];
+  }
+
+  @override
+  T? valueFromQueryGroup(Map<String, String> group) {
     return options.firstWhere(
       (option) {
         final optionLabel = labelBuilder?.call(option);

--- a/packages/widgetbook/lib/widgetbook.dart
+++ b/packages/widgetbook/lib/widgetbook.dart
@@ -15,6 +15,7 @@ export 'src/knobs/knobs.dart'
         DoubleOrNullSliderKnob,
         DoubleSliderKnob,
         ListKnob,
+        ListOrNullKnob,
         StringKnob,
         StringOrNullKnob;
 export 'src/models/models.dart';


### PR DESCRIPTION
The new `listOrNull` knob is the nullable alternative of the `list` knob. This should be used if the options have a nullable value.