### PR TITLE
refactor(cli): use `DioException` instead of `DioError`

### DIFF
--- a/packages/widgetbook_cli/bin/api/widgetbook_http_client.dart
+++ b/packages/widgetbook_cli/bin/api/widgetbook_http_client.dart
@@ -67,7 +67,7 @@ class WidgetbookHttpClient {
             ),
           ) as Map<String, dynamic>,
         );
-      } on DioError catch (e) {
+      } on DioException catch (e) {
         final response = e.response;
         if (response != null) {
           final errorResponse = _decodeResponse(response.data);
@@ -109,7 +109,7 @@ class WidgetbookHttpClient {
         ),
       );
       return response.data;
-    } on DioError catch (e) {
+    } on DioException catch (e) {
       final response = e.response;
       if (response != null) {
         final errorResponse = _decodeResponse(response.data);


### PR DESCRIPTION
dio deprecated `DioError` in favor of `DioException`
> `DioError` is deprecated and shouldn't be used. Use `DioException` instead. This will be removed in 6.0.0.