### PR TITLE
refactor(generator): add meta comments to header

### DIFF
--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
  - **BREAKING**: Change generated extension from `.g.dart` to `.directories.g.dart` to avoid conflicting outputs with other generators. ([#737](https://github.com/widgetbook/widgetbook/pull/737))
  - **BREAKING**: Remove `@App` annotation's `foldersExpanded` and `widgetsExpanded` non-working parameters. ([#735](https://github.com/widgetbook/widgetbook/pull/735))
+ - **REFACTOR**: Add meta comments to header. ([#745](https://github.com/widgetbook/widgetbook/pull/745))
 
 ## 3.0.0-rc.1
 

--- a/packages/widgetbook_generator/lib/builder.dart
+++ b/packages/widgetbook_generator/lib/builder.dart
@@ -20,9 +20,23 @@ Builder useCaseBuilder(BuilderOptions options) {
 /// Creates exactly one .g.dart file next to the file containing
 /// the [App] annotation.
 Builder appBuilder(BuilderOptions options) {
+  const ignoredLintRules = {
+    'unused_import',
+    'prefer_relative_imports',
+    'directives_ordering',
+  };
+
+  final headerParts = [
+    '// coverage:ignore-file',
+    '// ignore_for_file: type=lint',
+    '// ignore_for_file: ${ignoredLintRules.join(", ")}',
+    '\n$defaultFileHeader',
+  ];
+
   return LibraryBuilder(
     AppGenerator(),
     generatedExtension: '.directories.g.dart',
+    header: headerParts.join('\n'),
   );
 }
 


### PR DESCRIPTION
The generated file header now includes some meta comments that disable coverage and some lint rules.
This is helpful for some users who haven't configured tools properly.