### PR TITLE
fix: use addons/knobs initial values

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -6,6 +6,7 @@
  - **REFACTOR**: Export `WidgetbookState`. ([#724](https://github.com/widgetbook/widgetbook/pull/724))
  - **REFACTOR**: Export fields to be used for custom addons/knobs. ([#728](https://github.com/widgetbook/widgetbook/pull/728))
  - **REFACTOR**: Make `KnobsBuilder.onKnobAdded` public. ([#727](https://github.com/widgetbook/widgetbook/pull/727))
+ - **FIX**: Use addons/knobs initial values. ([#746](https://github.com/widgetbook/widgetbook/pull/746))
  - **FIX**: Use related type checks when comparing device's frame state to its query parameter. ([#715](https://github.com/widgetbook/widgetbook/pull/715))
  - **FIX**: Add missing type parameter to `LabelBuilder`, which affected the `list` knob. ([#718](https://github.com/widgetbook/widgetbook/pull/718))
  - **FIX**: Use `labelBuilder`-based string comparison in `list` knob. ([#729](https://github.com/widgetbook/widgetbook/pull/729))

--- a/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
@@ -62,13 +62,17 @@ class DeviceFrameAddon extends WidgetbookAddon<DeviceFrameSetting> {
   @override
   DeviceFrameSetting settingFromQueryGroup(Map<String, String> group) {
     return DeviceFrameSetting(
-      device: devices.firstWhereOrNull(
-        (device) => device?.name == group['name'],
-      ),
+      device: !group.containsKey('name')
+          ? initialSetting.device
+          : devices.firstWhereOrNull(
+              (device) => device?.name == group['name'],
+            ),
       orientation: Orientation.values.byName(
         group['orientation']?.toLowerCase() ?? Orientation.portrait.name,
       ),
-      hasFrame: group['frame'] == 'true',
+      hasFrame: !group.containsKey('frame')
+          ? initialSetting.hasFrame
+          : group['frame'] == 'Device Frame',
     );
   }
 

--- a/packages/widgetbook/lib/src/fields/boolean_field.dart
+++ b/packages/widgetbook/lib/src/fields/boolean_field.dart
@@ -15,7 +15,7 @@ class BooleanField extends Field<bool> {
           type: FieldType.boolean,
           codec: FieldCodec(
             toParam: (value) => value.toString(),
-            toValue: (param) => param == 'true',
+            toValue: (param) => param == null ? null : param == 'true',
           ),
         );
 

--- a/packages/widgetbook/lib/src/fields/color_field.dart
+++ b/packages/widgetbook/lib/src/fields/color_field.dart
@@ -15,12 +15,14 @@ class ColorField extends Field<Color> {
           type: FieldType.color,
           codec: FieldCodec(
             toParam: (color) => color.value.toRadixString(16),
-            toValue: (param) => Color(
-              int.parse(
-                param ?? '0',
-                radix: 16,
-              ),
-            ),
+            toValue: (param) => param == null
+                ? null
+                : Color(
+                    int.parse(
+                      param,
+                      radix: 16,
+                    ),
+                  ),
           ),
         );
 

--- a/packages/widgetbook/lib/src/fields/field.dart
+++ b/packages/widgetbook/lib/src/fields/field.dart
@@ -56,7 +56,7 @@ abstract class Field<T> {
   Widget build(BuildContext context) {
     final state = WidgetbookState.of(context);
     final groupMap = FieldCodec.decodeQueryGroup(state.queryParams[group]);
-    final value = codec.toValue(groupMap[name]);
+    final value = codec.toValue(groupMap[name]) ?? initialValue;
 
     return toWidget(context, value);
   }


### PR DESCRIPTION
All Addons & Some Knobs (`boolean`, `color`) initial values did not work properly.
The `initialValue` is now used as a fallback value.