### PR TITLE
refactor: add `FieldsComposable`

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -3,6 +3,7 @@
  - **FEAT**: Make side panels resizable. ([#738](https://github.com/widgetbook/widgetbook/pull/738))
  - **FEAT**: Add `listOrNull` knob. ([#741](https://github.com/widgetbook/widgetbook/pull/741))
  - **FEAT**: Add `initialOption` to `list` knob. ([#733](https://github.com/widgetbook/widgetbook/pull/733))
+ - **BREAKING**: Create `FieldsComposable` to unify addons/knobs APIs. ([#749](https://github.com/widgetbook/widgetbook/pull/749))
  - **REFACTOR**: Move `widgetbook_core` package to `widgetbook` package. ([#742](https://github.com/widgetbook/widgetbook/pull/742))
  - **REFACTOR**: Export `WidgetbookState`. ([#724](https://github.com/widgetbook/widgetbook/pull/724))
  - **REFACTOR**: Export fields to be used for custom addons/knobs. ([#728](https://github.com/widgetbook/widgetbook/pull/728))

--- a/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
+++ b/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
@@ -20,7 +20,7 @@ import '../addons.dart';
 /// * [LocalizationAddon], changes the active [Locale].
 /// * [DeviceFrameAddon], an [WidgetbookAddon] to change the active frame that
 ///   allows to view the [WidgetbookUseCase] on different screens.
-abstract class WidgetbookAddon<T> {
+abstract class WidgetbookAddon<T> extends FieldsComposable<T> {
   WidgetbookAddon({
     required this.name,
     required this.initialSetting,
@@ -31,14 +31,8 @@ abstract class WidgetbookAddon<T> {
 
   String get slugName => name.trim().toLowerCase().replaceAll(RegExp(' '), '-');
 
-  List<Field> get fields;
-
-  /// Converts a query group to a setting of type [T].
-  T settingFromQueryGroup(Map<String, String> group);
-
-  /// Converts the [fields] into a [Widget] by calling their [Field.build] and
-  /// grouping them inside a [Column].
-  Widget buildSetting(BuildContext context) {
+  @override
+  Widget buildFields(BuildContext context) {
     return Setting(
       name: name,
       child: Column(
@@ -49,7 +43,7 @@ abstract class WidgetbookAddon<T> {
   }
 
   /// Wraps use cases with a custom widget depending on the addon [setting]
-  /// that is obtained from [settingFromQueryGroup].
+  /// that is obtained from [valueFromQueryGroup].
   Widget buildUseCase(
     BuildContext context,
     Widget child,

--- a/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
@@ -60,7 +60,7 @@ class DeviceFrameAddon extends WidgetbookAddon<DeviceFrameSetting> {
   }
 
   @override
-  DeviceFrameSetting settingFromQueryGroup(Map<String, String> group) {
+  DeviceFrameSetting valueFromQueryGroup(Map<String, String> group) {
     return DeviceFrameSetting(
       device: !group.containsKey('name')
           ? initialSetting.device

--- a/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
+++ b/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
@@ -39,7 +39,7 @@ class LocalizationAddon extends WidgetbookAddon<Locale> {
   }
 
   @override
-  Locale settingFromQueryGroup(Map<String, String> group) {
+  Locale valueFromQueryGroup(Map<String, String> group) {
     return locales.firstWhere(
       (locale) => locale.toLanguageTag() == group['name'],
       orElse: () => initialSetting,

--- a/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
+++ b/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
@@ -38,7 +38,7 @@ class TextScaleAddon extends WidgetbookAddon<double> {
   }
 
   @override
-  double settingFromQueryGroup(Map<String, String> group) {
+  double valueFromQueryGroup(Map<String, String> group) {
     return double.parse(
       group['factor'] ?? initialSetting.toStringAsFixed(2),
     );

--- a/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
@@ -47,7 +47,7 @@ class ThemeAddon<T> extends WidgetbookAddon<WidgetbookTheme<T>> {
   }
 
   @override
-  WidgetbookTheme<T> settingFromQueryGroup(Map<String, String> group) {
+  WidgetbookTheme<T> valueFromQueryGroup(Map<String, String> group) {
     return themes.firstWhere(
       (theme) => theme.name == group['name'],
       orElse: () => initialSetting,

--- a/packages/widgetbook/lib/src/fields/fields.dart
+++ b/packages/widgetbook/lib/src/fields/fields.dart
@@ -5,5 +5,6 @@ export 'double_slider_field.dart';
 export 'field.dart';
 export 'field_codec.dart';
 export 'field_type.dart';
+export 'fields_composable.dart';
 export 'list_field.dart';
 export 'string_field.dart';

--- a/packages/widgetbook/lib/src/fields/fields_composable.dart
+++ b/packages/widgetbook/lib/src/fields/fields_composable.dart
@@ -2,10 +2,12 @@ import 'package:flutter/widgets.dart';
 
 import 'field.dart';
 
+/// Interface for defining APIs for features that
+/// use [fields] as a building block.
 abstract class FieldsComposable<T> {
   List<Field> get fields;
 
-  /// Converts a query group to a setting of type [T].
+  /// Converts a query group to a value of type [T].
   T valueFromQueryGroup(Map<String, String> group);
 
   /// Converts the [fields] into a [Widget] that will be rendered in the

--- a/packages/widgetbook/lib/src/fields/fields_composable.dart
+++ b/packages/widgetbook/lib/src/fields/fields_composable.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/widgets.dart';
+
+import 'field.dart';
+
+abstract class FieldsComposable<T> {
+  List<Field> get fields;
+
+  /// Converts a query group to a setting of type [T].
+  T valueFromQueryGroup(Map<String, String> group);
+
+  /// Converts the [fields] into a [Widget] that will be rendered in the
+  /// settings side panel.
+  Widget buildFields(BuildContext context);
+}

--- a/packages/widgetbook/lib/src/knobs/knob.dart
+++ b/packages/widgetbook/lib/src/knobs/knob.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/widgets.dart';
 
-import '../fields/field.dart';
+import '../fields/fields.dart';
 import '../navigation/navigation.dart';
 import '../settings/settings.dart';
 import '../state/state.dart';
 
 /// Allows [WidgetbookUseCase]s to have dynamically adjustable parameters.
-abstract class Knob<T> {
+abstract class Knob<T> extends FieldsComposable<T> {
   Knob({
     required this.label,
     required this.value,
@@ -27,12 +27,8 @@ abstract class Knob<T> {
 
   bool get isNullable => null is T;
 
-  List<Field> get fields;
-
-  /// Converts a query group to a value of type [T].
-  T valueFromQueryGroup(Map<String, String> group);
-
-  Widget build(BuildContext context) {
+  @override
+  Widget buildFields(BuildContext context) {
     return KnobProperty<T>(
       name: label,
       description: description,

--- a/packages/widgetbook/lib/src/routing/widgetbook_shell.dart
+++ b/packages/widgetbook/lib/src/routing/widgetbook_shell.dart
@@ -43,14 +43,14 @@ class WidgetbookShell extends StatelessWidget {
                 SettingsPanelData(
                   name: 'Properties',
                   settings: state.addons!
-                      .map((addon) => addon.buildSetting(context))
+                      .map((addon) => addon.buildFields(context))
                       .toList(),
                 ),
               },
               SettingsPanelData(
                 name: 'Knobs',
                 settings: state.knobs.values
-                    .map((knob) => knob.build(context))
+                    .map((knob) => knob.buildFields(context))
                     .toList(),
               ),
             ],

--- a/packages/widgetbook/lib/src/workbench/workbench.dart
+++ b/packages/widgetbook/lib/src/workbench/workbench.dart
@@ -28,7 +28,7 @@ class Workbench extends StatelessWidget {
               state.queryParams[addon.slugName],
             );
 
-            final newSetting = addon.settingFromQueryGroup(groupMap);
+            final newSetting = addon.valueFromQueryGroup(groupMap);
 
             return addon.buildUseCase(
               context,

--- a/packages/widgetbook/test/src/addons/common/custom_addon.dart
+++ b/packages/widgetbook/test/src/addons/common/custom_addon.dart
@@ -12,5 +12,5 @@ class CustomAddon extends WidgetbookAddon<String> {
   List<Field> get fields => [];
 
   @override
-  String settingFromQueryGroup(Map<String, String> group) => initialSetting;
+  String valueFromQueryGroup(Map<String, String> group) => initialSetting;
 }

--- a/packages/widgetbook/test/src/addons/utils/addon_test_helper.dart
+++ b/packages/widgetbook/test/src/addons/utils/addon_test_helper.dart
@@ -23,7 +23,7 @@ Future<void> testAddon<T>({
         state: state,
         child: Scaffold(
           body: Builder(
-            builder: addon.buildSetting,
+            builder: addon.buildFields,
           ),
         ),
       ),
@@ -37,7 +37,7 @@ Future<void> testAddon<T>({
     state.queryParams[addon.slugName],
   );
 
-  final setting = addon.settingFromQueryGroup(groupMap);
+  final setting = addon.valueFromQueryGroup(groupMap);
 
   expect(setting);
 }

--- a/packages/widgetbook/test/src/knobs/knob_helper.dart
+++ b/packages/widgetbook/test/src/knobs/knob_helper.dart
@@ -30,7 +30,7 @@ extension KnobHelper on WidgetTester {
                   ),
                   ...state.knobs.values.map(
                     (knob) => Material(
-                      child: knob.build(context),
+                      child: knob.buildFields(context),
                     ),
                   ),
                 ],


### PR DESCRIPTION
The `FieldsComposable` is an interface for unifying how features that uses Fields as building blocks (i.e. Addons and Knobs) should behave. This lead to some breaking changes as follow:

| Class             | Old Method Name         | New Method Name       |
|-------------------|-------------------------|-----------------------|
| `WidgetbookAddon` | `settingFromQueryGroup` | `valueFromQueryGroup` |
| `WidgetbookAddon` | `buildSetting`          | `buildFields`         |
| `Knob`            | `build`                 | `buildFields`         |

