### PR TITLE
fix: sync settings data

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -15,6 +15,7 @@
  - **FIX**: Add `key` to use cases to prevent out-of-sync builds. ([#720](https://github.com/widgetbook/widgetbook/pull/720))
  - **Fix**: Prevent `onNodeSelected` from being called if the node is already selected. ([#725](https://github.com/widgetbook/widgetbook/pull/725))
  - **Fix**: Use `ListView` for `SettingsPanel`. ([#732](https://github.com/widgetbook/widgetbook/pull/732))
+ - **Fix**: Sync `SettingsPanel` data with `WidgetbookState`. ([#750](https://github.com/widgetbook/widgetbook/pull/750))
 
 ## 3.0.0-rc.1
 

--- a/packages/widgetbook/lib/src/routing/widgetbook_shell.dart
+++ b/packages/widgetbook/lib/src/routing/widgetbook_shell.dart
@@ -41,15 +41,18 @@ class WidgetbookShell extends StatelessWidget {
             settings: [
               if (state.addons != null) ...{
                 SettingsPanelData(
-                  name: 'Properties',
-                  settings: state.addons!
+                  name: 'Addons',
+                  builder: (context) => WidgetbookState.of(context)
+                      .addons!
                       .map((addon) => addon.buildFields(context))
                       .toList(),
                 ),
               },
               SettingsPanelData(
                 name: 'Knobs',
-                settings: state.knobs.values
+                builder: (context) => WidgetbookState.of(context)
+                    .knobs
+                    .values
                     .map((knob) => knob.buildFields(context))
                     .toList(),
               ),

--- a/packages/widgetbook/lib/src/settings/settings_panel.dart
+++ b/packages/widgetbook/lib/src/settings/settings_panel.dart
@@ -3,11 +3,11 @@ import 'package:flutter/material.dart';
 class SettingsPanelData {
   const SettingsPanelData({
     required this.name,
-    required this.settings,
+    required this.builder,
   });
 
   final String name;
-  final List<Widget> settings;
+  final List<Widget> Function(BuildContext context) builder;
 }
 
 class SettingsPanel extends StatelessWidget {
@@ -49,21 +49,22 @@ class SettingsPanel extends StatelessWidget {
         child: ListView.builder(
           itemCount: settings.length,
           itemBuilder: (context, index) {
-            final item = settings[index];
+            final setting = settings[index];
+            final children = setting.builder(context);
 
             return ExpansionTile(
               collapsedShape: const RoundedRectangleBorder(),
               shape: const RoundedRectangleBorder(),
               initiallyExpanded: true,
-              title: Text(item.name),
-              children: item.settings.isEmpty
-                  ? [
+              title: Text(setting.name),
+              children: children.isNotEmpty
+                  ? children
+                  : [
                       Padding(
                         padding: const EdgeInsets.all(8),
-                        child: Text('No ${item.name} available'),
+                        child: Text('No ${setting.name} available'),
                       )
-                    ]
-                  : item.settings,
+                    ],
             );
           },
         ),

--- a/packages/widgetbook/test/src/app/settings/settings_panel_test.dart
+++ b/packages/widgetbook/test/src/app/settings/settings_panel_test.dart
@@ -13,9 +13,12 @@ void main() {
         'shows Tab and hint text',
         (tester) async {
           await tester.pumpWidgetWithMaterialApp(
-            const SettingsPanel(
+            SettingsPanel(
               settings: [
-                SettingsPanelData(name: content, settings: []),
+                SettingsPanelData(
+                  name: content,
+                  builder: (_) => [],
+                ),
               ],
             ),
           );
@@ -40,11 +43,11 @@ void main() {
             key: ValueKey('Text'),
           );
           await tester.pumpWidgetWithMaterialApp(
-            const SettingsPanel(
+            SettingsPanel(
               settings: [
                 SettingsPanelData(
                   name: content,
-                  settings: [
+                  builder: (_) => [
                     widget,
                   ],
                 ),

--- a/sandbox/lib/settings/settings_panel.widgetbook.dart
+++ b/sandbox/lib/settings/settings_panel.widgetbook.dart
@@ -4,15 +4,15 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 
 @UseCase(name: 'Default', type: SettingsPanel)
 Widget settingsPanel(BuildContext context) {
-  return const SettingsPanel(
+  return SettingsPanel(
     settings: [
       SettingsPanelData(
-        name: 'Properties',
-        settings: [],
+        name: 'Addons',
+        builder: (_) => [],
       ),
       SettingsPanelData(
         name: 'Knobs',
-        settings: [],
+        builder: (_) => [],
       ),
     ],
   );


### PR DESCRIPTION
`WidgetbookShell`  passed the `state` local variable to `SettingsPanelData` which caused `SettingsPanel` to not use a fresh `context` causing knobs to not render properly sometimes.