### PR TITLE
fix: use fresh `context` for state

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -15,6 +15,7 @@
  - **FIX**: Add `key` to use cases to prevent out-of-sync builds. ([#720](https://github.com/widgetbook/widgetbook/pull/720))
  - **Fix**: Prevent `onNodeSelected` from being called if the node is already selected. ([#725](https://github.com/widgetbook/widgetbook/pull/725))
  - **Fix**: Use `ListView` for `SettingsPanel`. ([#732](https://github.com/widgetbook/widgetbook/pull/732))
+ - **Fix**: Use fresh `context` while retrieving state to avoid out-of-sync UI. ([#751](https://github.com/widgetbook/widgetbook/pull/751))
 
 ## 3.0.0-rc.1
 

--- a/packages/widgetbook/lib/src/routing/widgetbook_shell.dart
+++ b/packages/widgetbook/lib/src/routing/widgetbook_shell.dart
@@ -41,15 +41,18 @@ class WidgetbookShell extends StatelessWidget {
             settings: [
               if (state.addons != null) ...{
                 SettingsPanelData(
-                  name: 'Properties',
-                  settings: state.addons!
+                  name: 'Addons',
+                  builder: (context) => WidgetbookState.of(context)
+                      .addons!
                       .map((addon) => addon.buildFields(context))
                       .toList(),
                 ),
               },
               SettingsPanelData(
                 name: 'Knobs',
-                settings: state.knobs.values
+                builder: (context) => WidgetbookState.of(context)
+                    .knobs
+                    .values
                     .map((knob) => knob.buildFields(context))
                     .toList(),
               ),

--- a/packages/widgetbook/lib/src/settings/settings_panel.dart
+++ b/packages/widgetbook/lib/src/settings/settings_panel.dart
@@ -3,11 +3,11 @@ import 'package:flutter/material.dart';
 class SettingsPanelData {
   const SettingsPanelData({
     required this.name,
-    required this.settings,
+    required this.builder,
   });
 
   final String name;
-  final List<Widget> settings;
+  final List<Widget> Function(BuildContext context) builder;
 }
 
 class SettingsPanel extends StatelessWidget {
@@ -49,21 +49,22 @@ class SettingsPanel extends StatelessWidget {
         child: ListView.builder(
           itemCount: settings.length,
           itemBuilder: (context, index) {
-            final item = settings[index];
+            final setting = settings[index];
+            final children = setting.builder(context);
 
             return ExpansionTile(
               collapsedShape: const RoundedRectangleBorder(),
               shape: const RoundedRectangleBorder(),
               initiallyExpanded: true,
-              title: Text(item.name),
-              children: item.settings.isEmpty
-                  ? [
+              title: Text(setting.name),
+              children: children.isNotEmpty
+                  ? children
+                  : [
                       Padding(
                         padding: const EdgeInsets.all(8),
-                        child: Text('No ${item.name} available'),
+                        child: Text('No ${setting.name} available'),
                       )
-                    ]
-                  : item.settings,
+                    ],
             );
           },
         ),

--- a/packages/widgetbook/lib/src/workbench/use_case_builder.dart
+++ b/packages/widgetbook/lib/src/workbench/use_case_builder.dart
@@ -1,15 +1,14 @@
 import 'package:flutter/material.dart';
 
-import '../navigation/navigation.dart';
 import '../state/state.dart';
 
 class UseCaseBuilder extends StatefulWidget {
   const UseCaseBuilder({
     super.key,
-    required this.useCase,
+    required this.builder,
   });
 
-  final WidgetbookUseCase useCase;
+  final Widget Function(BuildContext context) builder;
 
   @override
   State<UseCaseBuilder> createState() => _UseCaseBuilderState();
@@ -29,6 +28,6 @@ class _UseCaseBuilderState extends State<UseCaseBuilder> {
 
   @override
   Widget build(BuildContext context) {
-    return widget.useCase.builder(context);
+    return widget.builder(context);
   }
 }

--- a/packages/widgetbook/lib/src/workbench/workbench.dart
+++ b/packages/widgetbook/lib/src/workbench/workbench.dart
@@ -13,10 +13,6 @@ class Workbench extends StatelessWidget {
   Widget build(BuildContext context) {
     final state = WidgetbookState.of(context);
 
-    if (state.useCase == null) {
-      return const SizedBox.shrink();
-    }
-
     return SafeBoundaries(
       child: state.appBuilder(
         context,
@@ -39,7 +35,10 @@ class Workbench extends StatelessWidget {
           child: Scaffold(
             body: UseCaseBuilder(
               key: ValueKey(state.uri),
-              useCase: state.useCase!,
+              builder: (context) {
+                return WidgetbookState.of(context).useCase?.builder(context) ??
+                    const SizedBox.shrink();
+              },
             ),
           ),
         ),

--- a/packages/widgetbook/test/src/app/settings/settings_panel_test.dart
+++ b/packages/widgetbook/test/src/app/settings/settings_panel_test.dart
@@ -13,9 +13,12 @@ void main() {
         'shows Tab and hint text',
         (tester) async {
           await tester.pumpWidgetWithMaterialApp(
-            const SettingsPanel(
+            SettingsPanel(
               settings: [
-                SettingsPanelData(name: content, settings: []),
+                SettingsPanelData(
+                  name: content,
+                  builder: (_) => [],
+                ),
               ],
             ),
           );
@@ -40,11 +43,11 @@ void main() {
             key: ValueKey('Text'),
           );
           await tester.pumpWidgetWithMaterialApp(
-            const SettingsPanel(
+            SettingsPanel(
               settings: [
                 SettingsPanelData(
                   name: content,
-                  settings: [
+                  builder: (_) => [
                     widget,
                   ],
                 ),

--- a/sandbox/lib/settings/settings_panel.widgetbook.dart
+++ b/sandbox/lib/settings/settings_panel.widgetbook.dart
@@ -4,15 +4,15 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 
 @UseCase(name: 'Default', type: SettingsPanel)
 Widget settingsPanel(BuildContext context) {
-  return const SettingsPanel(
+  return SettingsPanel(
     settings: [
       SettingsPanelData(
-        name: 'Properties',
-        settings: [],
+        name: 'Addons',
+        builder: (_) => [],
       ),
       SettingsPanelData(
         name: 'Knobs',
-        settings: [],
+        builder: (_) => [],
       ),
     ],
   );


### PR DESCRIPTION
The following pattern was used in a lot of `Widget`s, which caused the UI to not reflect the actual `WidgetbookState`, because the `SomeWidget` will now have outdated values of `state` on some rebuilds.

```dart
// Before
@override
Widget build(BuildContext context) {
  final state = WidgetbookState.of(context);
  
  return SomeWidget(
    child: state.someValue,
  );
}

// After
@override
Widget build(BuildContext context) {  
  return SomeWidget(
    builder: (context) => WidgetbookState.of(context).someValue,
  );
}
```