### PR TITLE
refactor: add `FieldsComposable.valueOf`

### DIFF
--- a/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:device_frame/device_frame.dart';
 import 'package:flutter/material.dart';
 
@@ -62,17 +61,9 @@ class DeviceFrameAddon extends WidgetbookAddon<DeviceFrameSetting> {
   @override
   DeviceFrameSetting valueFromQueryGroup(Map<String, String> group) {
     return DeviceFrameSetting(
-      device: !group.containsKey('name')
-          ? initialSetting.device
-          : devices.firstWhereOrNull(
-              (device) => device?.name == group['name'],
-            ),
-      orientation: Orientation.values.byName(
-        group['orientation']?.toLowerCase() ?? Orientation.portrait.name,
-      ),
-      hasFrame: !group.containsKey('frame')
-          ? initialSetting.hasFrame
-          : group['frame'] == 'Device Frame',
+      device: valueOf<DeviceInfo?>('name', group),
+      orientation: valueOf('orientation', group)!,
+      hasFrame: valueOf('frame', group)!,
     );
   }
 

--- a/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
+++ b/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
@@ -40,10 +40,7 @@ class LocalizationAddon extends WidgetbookAddon<Locale> {
 
   @override
   Locale valueFromQueryGroup(Map<String, String> group) {
-    return locales.firstWhere(
-      (locale) => locale.toLanguageTag() == group['name'],
-      orElse: () => initialSetting,
-    );
+    return valueOf('name', group)!;
   }
 
   @override

--- a/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
+++ b/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
@@ -39,9 +39,7 @@ class TextScaleAddon extends WidgetbookAddon<double> {
 
   @override
   double valueFromQueryGroup(Map<String, String> group) {
-    return double.parse(
-      group['factor'] ?? initialSetting.toStringAsFixed(2),
-    );
+    return valueOf('factor', group)!;
   }
 
   @override

--- a/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
@@ -48,10 +48,7 @@ class ThemeAddon<T> extends WidgetbookAddon<WidgetbookTheme<T>> {
 
   @override
   WidgetbookTheme<T> valueFromQueryGroup(Map<String, String> group) {
-    return themes.firstWhere(
-      (theme) => theme.name == group['name'],
-      orElse: () => initialSetting,
-    );
+    return valueOf('name', group)!;
   }
 
   @override

--- a/packages/widgetbook/lib/src/fields/field.dart
+++ b/packages/widgetbook/lib/src/fields/field.dart
@@ -53,10 +53,16 @@ abstract class Field<T> {
   /// 2. [Field]'s widget from the side panel.
   final void Function(BuildContext context, T? value)? onChanged;
 
+  /// Extracts the value from [groupMap],
+  /// fallback to [initialValue] if not found.
+  T? valueFrom(Map<String, String> groupMap) {
+    return codec.toValue(groupMap[name]) ?? initialValue;
+  }
+
   Widget build(BuildContext context) {
     final state = WidgetbookState.of(context);
     final groupMap = FieldCodec.decodeQueryGroup(state.queryParams[group]);
-    final value = codec.toValue(groupMap[name]) ?? initialValue;
+    final value = valueFrom(groupMap);
 
     return toWidget(context, value);
   }

--- a/packages/widgetbook/lib/src/fields/fields_composable.dart
+++ b/packages/widgetbook/lib/src/fields/fields_composable.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 
 import 'field.dart';
+import 'field_codec.dart';
 
 /// Interface for defining APIs for features that
 /// use [fields] as a building block.
@@ -13,4 +14,14 @@ abstract class FieldsComposable<T> {
   /// Converts the [fields] into a [Widget] that will be rendered in the
   /// settings side panel.
   Widget buildFields(BuildContext context);
+
+  /// Decodes the value of the [Field] with [name] from the query [group]
+  /// using the [FieldCodec.toValue] from [Field.codec].
+  TField? valueOf<TField>(String name, Map<String, String> group) {
+    final field = fields.firstWhere(
+      (field) => field.name == name,
+    ) as Field<TField>;
+
+    return field.valueFrom(group);
+  }
 }

--- a/packages/widgetbook/lib/src/knobs/boolean_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/boolean_knob.dart
@@ -29,7 +29,7 @@ class BooleanKnob extends Knob<bool> {
 
   @override
   bool valueFromQueryGroup(Map<String, String> group) {
-    return group.containsKey(label) ? group[label] == 'true' : value;
+    return valueOf(label, group)!;
   }
 }
 
@@ -58,6 +58,6 @@ class BooleanOrNullKnob extends Knob<bool?> {
 
   @override
   bool? valueFromQueryGroup(Map<String, String> group) {
-    return group.containsKey(label) ? group[label] == 'true' : value;
+    return valueOf(label, group);
   }
 }

--- a/packages/widgetbook/lib/src/knobs/color_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/color_knob.dart
@@ -31,13 +31,6 @@ class ColorKnob extends Knob<Color> {
 
   @override
   Color valueFromQueryGroup(Map<String, String> group) {
-    return group.containsKey(label)
-        ? Color(
-            int.parse(
-              group[label]!,
-              radix: 16,
-            ),
-          )
-        : value;
+    return valueOf(label, group)!;
   }
 }

--- a/packages/widgetbook/lib/src/knobs/double_input_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/double_input_knob.dart
@@ -29,7 +29,7 @@ class DoubleInputKnob extends Knob<double> {
 
   @override
   double valueFromQueryGroup(Map<String, String> group) {
-    return group.containsKey(label) ? double.parse(group[label]!) : value;
+    return valueOf(label, group)!;
   }
 }
 
@@ -58,6 +58,6 @@ class DoubleOrNullInputKnob extends Knob<double?> {
 
   @override
   double? valueFromQueryGroup(Map<String, String> group) {
-    return group.containsKey(label) ? double.parse(group[label]!) : value;
+    return valueOf(label, group);
   }
 }

--- a/packages/widgetbook/lib/src/knobs/double_slider_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/double_slider_knob.dart
@@ -39,7 +39,7 @@ class DoubleSliderKnob extends Knob<double> {
 
   @override
   double valueFromQueryGroup(Map<String, String> group) {
-    return group.containsKey(label) ? double.parse(group[label]!) : value;
+    return valueOf(label, group)!;
   }
 }
 
@@ -78,6 +78,6 @@ class DoubleOrNullSliderKnob extends Knob<double?> {
 
   @override
   double? valueFromQueryGroup(Map<String, String> group) {
-    return group.containsKey(label) ? double.parse(group[label]!) : value;
+    return valueOf(label, group);
   }
 }

--- a/packages/widgetbook/lib/src/knobs/list_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/list_knob.dart
@@ -40,13 +40,7 @@ class ListKnob<T> extends Knob<T> {
 
   @override
   T valueFromQueryGroup(Map<String, String> group) {
-    return options.firstWhere(
-      (option) {
-        final optionLabel = labelBuilder?.call(option);
-        return (optionLabel ?? option.toString()) == group[label];
-      },
-      orElse: () => value,
-    );
+    return valueOf(label, group)!;
   }
 }
 
@@ -82,12 +76,6 @@ class ListOrNullKnob<T> extends Knob<T?> {
 
   @override
   T? valueFromQueryGroup(Map<String, String> group) {
-    return options.firstWhere(
-      (option) {
-        final optionLabel = labelBuilder?.call(option);
-        return (optionLabel ?? option.toString()) == group[label];
-      },
-      orElse: () => value,
-    );
+    return valueOf(label, group);
   }
 }

--- a/packages/widgetbook/lib/src/knobs/string_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/string_knob.dart
@@ -33,7 +33,7 @@ class StringKnob extends Knob<String> {
 
   @override
   String valueFromQueryGroup(Map<String, String> group) {
-    return group.containsKey(label) ? group[label]! : value;
+    return valueOf(label, group)!;
   }
 }
 
@@ -66,6 +66,6 @@ class StringOrNullKnob extends Knob<String?> {
 
   @override
   String? valueFromQueryGroup(Map<String, String> group) {
-    return group.containsKey(label) ? group[label]! : value;
+    return valueOf(label, group);
   }
 }


### PR DESCRIPTION
Make use of `Field`'s `codec`s to decode the query groups inside `valueFromQueryGroup`, instead of duplicating the logic and doing the decoding logic manually. This is much less error-prune and and cleaner

```dart
// Before
@override
SomeSetting valueFromQueryGroup(Map<String, String> group) {
  return SomeSetting(
    foo: group['foo'] == 'true',
    bar: list.firstWhereOrNull(
            (item) => item?.name == group['bar'],
          ),
  );
}

// After
@override
SomeSetting valueFromQueryGroup(Map<String, String> group) {
  return SomeSetting(
    foo: valueOf('foo', group),
    bar: valueOf('bar', group),
  );
}
```