### PR TITLE
chore: add more lint rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,6 +4,7 @@ analyzer:
   language:
     strict-casts: true
     strict-inference: true
+    strict-raw-types: true
 
   exclude:
     - "**/*.g.dart"
@@ -31,6 +32,9 @@ linter:
     - prefer_single_quotes
     - require_trailing_commas
     - noop_primitive_operations
+    - use_super_parameters
+    - avoid_redundant_argument_values
 
     # Types
     - unrelated_type_equality_checks
+    - avoid_types_on_closure_parameters

--- a/examples/custom_theme_example/lib/app_theme.dart
+++ b/examples/custom_theme_example/lib/app_theme.dart
@@ -10,13 +10,10 @@ class AppThemeData {
 
 class AppTheme extends InheritedWidget {
   const AppTheme({
-    Key? key,
+    super.key,
     required this.data,
-    required Widget child,
-  }) : super(
-          key: key,
-          child: child,
-        );
+    required super.child,
+  });
 
   final AppThemeData data;
 

--- a/examples/full_example/lib/components/custom_card.dart
+++ b/examples/full_example/lib/components/custom_card.dart
@@ -2,16 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
 class CustomCard extends StatelessWidget {
-  final Widget child;
-  final Color backgroundColor;
-  final double borderRadius;
-
   const CustomCard({
-    Key? key,
+    super.key,
     required this.child,
     this.backgroundColor = Colors.white,
     this.borderRadius = 8.0,
-  }) : super(key: key);
+  });
+
+  final Widget child;
+  final Color backgroundColor;
+  final double borderRadius;
 
   @override
   Widget build(BuildContext context) {

--- a/examples/full_example/lib/components/custom_text_field.dart
+++ b/examples/full_example/lib/components/custom_text_field.dart
@@ -3,14 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
 class CustomTextField extends StatelessWidget {
-  final TextEditingController controller;
-  final String hintText;
-
   const CustomTextField({
-    Key? key,
+    super.key,
     required this.controller,
     this.hintText = '',
-  }) : super(key: key);
+  });
+
+  final TextEditingController controller;
+  final String hintText;
 
   @override
   Widget build(BuildContext context) {

--- a/examples/full_example/lib/widgetbook.generator.dart
+++ b/examples/full_example/lib/widgetbook.generator.dart
@@ -14,7 +14,7 @@ void main() {
 
 @widgetbook.App()
 class WidgetbookApp extends StatelessWidget {
-  const WidgetbookApp({Key? key}) : super(key: key);
+  const WidgetbookApp({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
+++ b/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
@@ -20,6 +20,7 @@ import '../addons.dart';
 /// * [LocalizationAddon], changes the active [Locale].
 /// * [DeviceFrameAddon], an [WidgetbookAddon] to change the active frame that
 ///   allows to view the [WidgetbookUseCase] on different screens.
+@optionalTypeArgs
 abstract class WidgetbookAddon<T> extends FieldsComposable<T> {
   WidgetbookAddon({
     required this.name,

--- a/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
+++ b/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
@@ -23,7 +23,7 @@ class LocalizationAddon extends WidgetbookAddon<Locale> {
         );
 
   final List<Locale> locales;
-  final List<LocalizationsDelegate> localizationsDelegates;
+  final List<LocalizationsDelegate<dynamic>> localizationsDelegates;
 
   @override
   List<Field> get fields {

--- a/packages/widgetbook/lib/src/addons/theme_addon/cupertino_theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/cupertino_theme_addon.dart
@@ -1,17 +1,14 @@
 import 'package:flutter/cupertino.dart';
 
 import 'theme_addon.dart';
-import 'widgetbook_theme.dart';
 
 /// A [ThemeAddon] for changing the active [CupertinoThemeData] via
 /// [CupertinoTheme].
 class CupertinoThemeAddon extends ThemeAddon<CupertinoThemeData> {
   CupertinoThemeAddon({
-    required List<WidgetbookTheme<CupertinoThemeData>> themes,
-    WidgetbookTheme<CupertinoThemeData>? initialTheme,
+    required super.themes,
+    super.initialTheme,
   }) : super(
-          themes: themes,
-          initialTheme: initialTheme,
           themeBuilder: (context, theme, child) {
             return CupertinoTheme(
               data: theme,

--- a/packages/widgetbook/lib/src/addons/theme_addon/material_theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/material_theme_addon.dart
@@ -1,16 +1,13 @@
 import 'package:flutter/material.dart';
 
 import 'theme_addon.dart';
-import 'widgetbook_theme.dart';
 
 /// A [ThemeAddon] for changing the active [ThemeData] via [Theme].
 class MaterialThemeAddon extends ThemeAddon<ThemeData> {
   MaterialThemeAddon({
-    required List<WidgetbookTheme<ThemeData>> themes,
-    WidgetbookTheme<ThemeData>? initialTheme,
+    required super.themes,
+    super.initialTheme,
   }) : super(
-          themes: themes,
-          initialTheme: initialTheme,
           themeBuilder: (context, theme, child) {
             return Theme(
               data: theme,

--- a/packages/widgetbook/lib/src/fields/double_slider_field.dart
+++ b/packages/widgetbook/lib/src/fields/double_slider_field.dart
@@ -42,7 +42,6 @@ class DoubleSliderField extends Field<double> {
           ),
         ),
         Expanded(
-          flex: 1,
           child: Text(
             value?.toString() ?? '',
           ),

--- a/packages/widgetbook/lib/src/fields/field.dart
+++ b/packages/widgetbook/lib/src/fields/field.dart
@@ -21,6 +21,7 @@ import 'field_type.dart';
 /// | [group] | `foo` |
 /// | [name]  | `bar` |
 /// | value   | `qux` |
+@optionalTypeArgs
 abstract class Field<T> {
   const Field({
     required this.group,

--- a/packages/widgetbook/lib/src/knobs/knob.dart
+++ b/packages/widgetbook/lib/src/knobs/knob.dart
@@ -6,6 +6,7 @@ import '../settings/settings.dart';
 import '../state/state.dart';
 
 /// Allows [WidgetbookUseCase]s to have dynamically adjustable parameters.
+@optionalTypeArgs
 abstract class Knob<T> extends FieldsComposable<T> {
   Knob({
     required this.label,

--- a/packages/widgetbook/lib/src/navigation/widgets/navigation_panel.dart
+++ b/packages/widgetbook/lib/src/navigation/widgets/navigation_panel.dart
@@ -36,7 +36,7 @@ class _NavigationPanelState extends State<NavigationPanel> {
               padding: const EdgeInsets.symmetric(horizontal: 12),
               child: SearchField(
                 searchValue: searchQuery,
-                onSearchChanged: (String value) {
+                onSearchChanged: (value) {
                   setState(() => searchQuery = value);
                 },
                 onSearchCancelled: () {

--- a/packages/widgetbook/test/src/addons/common/multi_addon_builder_test.dart
+++ b/packages/widgetbook/test/src/addons/common/multi_addon_builder_test.dart
@@ -12,7 +12,7 @@ void main() {
     () {
       testWidgets(
         'returns child widget when addons are empty',
-        (WidgetTester tester) async {
+        (tester) async {
           await tester.pumpWidgetWithMaterialApp(
             MultiAddonBuilder(
               addons: [],
@@ -32,7 +32,7 @@ void main() {
 
       testWidgets(
         'returns [Nested] widget when addons are available',
-        (WidgetTester tester) async {
+        (tester) async {
           await tester.pumpWidgetWithMaterialApp(
             MultiAddonBuilder(
               addons: [

--- a/packages/widgetbook/test/src/addons/device_frame_addon/device_frame_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/device_frame_addon/device_frame_addon_test.dart
@@ -21,7 +21,7 @@ void main() {
 
       testWidgets(
         'can activate device',
-        (WidgetTester tester) async {
+        (tester) async {
           final device = devices.last;
 
           await testAddon<DeviceFrameSetting>(
@@ -52,7 +52,7 @@ void main() {
 
       testWidgets(
         'can activate device $Orientation',
-        (WidgetTester tester) async {
+        (tester) async {
           await testAddon<DeviceFrameSetting>(
             tester: tester,
             addon: addon,
@@ -81,7 +81,7 @@ void main() {
 
       testWidgets(
         'can activate frame',
-        (WidgetTester tester) async {
+        (tester) async {
           await testAddon<DeviceFrameSetting>(
             tester: tester,
             addon: addon,

--- a/packages/widgetbook/test/src/addons/locale_addon/locale_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/locale_addon/locale_addon_test.dart
@@ -23,7 +23,7 @@ void main() {
   group('$LocalizationAddon', () {
     testWidgets(
       'can activate locale',
-      (WidgetTester tester) async {
+      (tester) async {
         await testAddon<Locale>(
           tester: tester,
           addon: addon,

--- a/packages/widgetbook/test/src/addons/test_scale_factor/text_scale_factor_test.dart
+++ b/packages/widgetbook/test/src/addons/test_scale_factor/text_scale_factor_test.dart
@@ -14,7 +14,7 @@ void main() {
 
       testWidgets(
         'can activate text scale factor',
-        (WidgetTester tester) async {
+        (tester) async {
           await testAddon<double>(
             tester: tester,
             addon: addon,

--- a/packages/widgetbook/test/src/addons/theme_addon/cupertino_theme_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/theme_addon/cupertino_theme_addon_test.dart
@@ -37,7 +37,7 @@ void main() {
 
       testWidgets(
         'can activate theme',
-        (WidgetTester tester) async {
+        (tester) async {
           await testAddon<WidgetbookTheme<CupertinoThemeData>>(
             tester: tester,
             addon: addon,

--- a/packages/widgetbook/test/src/addons/theme_addon/material_theme_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/theme_addon/material_theme_addon_test.dart
@@ -33,7 +33,7 @@ void main() {
 
       testWidgets(
         'can activate theme',
-        (WidgetTester tester) async {
+        (tester) async {
           await testAddon<WidgetbookTheme<ThemeData>>(
             tester: tester,
             addon: addon,

--- a/packages/widgetbook/test/src/addons/theme_addon/theme_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/theme_addon/theme_addon_test.dart
@@ -56,7 +56,7 @@ void main() {
 
       testWidgets(
         'can activate theme via Widget',
-        (WidgetTester tester) async {
+        (tester) async {
           await testAddon<WidgetbookTheme<AppThemeData>>(
             tester: tester,
             addon: addon,

--- a/packages/widgetbook/test/src/app/navigation_tree/widgets/navigation_panel_test.dart
+++ b/packages/widgetbook/test/src/app/navigation_tree/widgets/navigation_panel_test.dart
@@ -28,7 +28,7 @@ void main() {
 
     testWidgets(
       'filters nodes when typing into search field',
-      (WidgetTester tester) async {
+      (tester) async {
         await tester.pumpWidgetWithMaterialApp(
           const NavigationPanel(
             directories: directories,
@@ -51,7 +51,7 @@ void main() {
 
     testWidgets(
       'resets filtered nodes when search field is cleared',
-      (WidgetTester tester) async {
+      (tester) async {
         await tester.pumpWidgetWithMaterialApp(
           const NavigationPanel(
             directories: directories,

--- a/packages/widgetbook/test/src/app/navigation_tree/widgets/navigation_tree_item_test.dart
+++ b/packages/widgetbook/test/src/app/navigation_tree/widgets/navigation_tree_item_test.dart
@@ -19,7 +19,7 @@ void main() {
 
       testWidgets(
         'onTap is executed',
-        (WidgetTester tester) async {
+        (tester) async {
           final voidCallbackMock = VoidCallbackMock();
           await tester.pumpWidgetWithMaterialApp(
             NavigationTreeItem(
@@ -35,7 +35,7 @@ void main() {
 
       testWidgets(
         'more menu icon is initially not rendered',
-        (WidgetTester tester) async {
+        (tester) async {
           await tester.pumpWidgetWithMaterialApp(
             const NavigationTreeItem(data: testNode),
           );
@@ -51,7 +51,7 @@ void main() {
 
       testWidgets(
         "adds indentation SizedBox's from level value",
-        (WidgetTester tester) async {
+        (tester) async {
           const level = 2;
           await tester.pumpWidgetWithMaterialApp(
             const NavigationTreeItem(
@@ -61,7 +61,7 @@ void main() {
           );
 
           final finder = find.byWidgetPredicate(
-            (Widget widget) =>
+            (widget) =>
                 widget is SizedBox &&
                 widget.width == NavigationTreeItem.indentation &&
                 widget.height == null,
@@ -73,7 +73,7 @@ void main() {
 
       testWidgets(
         '$ExpanderIcon is rendered for expandable nodes',
-        (WidgetTester tester) async {
+        (tester) async {
           const testNode = NavigationTreeNodeData(
             path: 'category',
             name: 'Category',
@@ -92,7 +92,7 @@ void main() {
 
       testWidgets(
         '$ExpanderIcon is not rendered for non expandable nodes',
-        (WidgetTester tester) async {
+        (tester) async {
           const testNode = NavigationTreeNodeData(
             path: 'use-case',
             name: 'Use Case',
@@ -111,7 +111,7 @@ void main() {
 
       testWidgets(
         'renders $ComponentIcon for component navigation node type',
-        (WidgetTester tester) async {
+        (tester) async {
           const testNode = NavigationTreeNodeData(
             path: 'component',
             name: 'Component',
@@ -129,7 +129,7 @@ void main() {
 
       testWidgets(
         'renders $UseCaseIcon for use case navigation node type',
-        (WidgetTester tester) async {
+        (tester) async {
           const testNode = NavigationTreeNodeData(
             path: 'use-case',
             name: 'Use Case',
@@ -147,7 +147,7 @@ void main() {
 
       testWidgets(
         'renders $UseCaseIcon for use case navigation node type',
-        (WidgetTester tester) async {
+        (tester) async {
           const testNode = NavigationTreeNodeData(
             path: 'use-case',
             name: 'Use Case',
@@ -164,7 +164,7 @@ void main() {
           );
 
           final coloredBoxWidgetFinder = find.byWidgetPredicate(
-            (Widget widget) => widget is Container && widget.child is InkWell,
+            (widget) => widget is Container && widget.child is InkWell,
           );
 
           final containerWidget =

--- a/packages/widgetbook/test/src/app/navigation_tree/widgets/navigation_tree_node_test.dart
+++ b/packages/widgetbook/test/src/app/navigation_tree/widgets/navigation_tree_node_test.dart
@@ -29,7 +29,7 @@ void main() {
   group('$NavigationTreeNode', () {
     testWidgets(
       'Can render correct number of first level child node widgets',
-      (WidgetTester tester) async {
+      (tester) async {
         await tester.pumpWidgetWithMaterialApp(
           const NavigationTreeNode(
             data: nodeWithOneLevelOfChildren,
@@ -45,7 +45,7 @@ void main() {
 
     testWidgets(
       'Calls onNodeSelected with selected node id',
-      (WidgetTester tester) async {
+      (tester) async {
         const useCaseNode = NavigationTreeNodeData(
           path: 'use_case_id',
           name: 'Use Case',
@@ -68,7 +68,7 @@ void main() {
 
     testWidgets(
       'Can expand children ListView',
-      (WidgetTester tester) async {
+      (tester) async {
         await tester.pumpWidgetWithMaterialApp(
           const NavigationTreeNode(
             data: nodeWithOneLevelOfChildren,

--- a/packages/widgetbook/test/src/app/navigation_tree/widgets/navigation_tree_test.dart
+++ b/packages/widgetbook/test/src/app/navigation_tree/widgets/navigation_tree_test.dart
@@ -30,7 +30,7 @@ void main() {
 
       testWidgets(
         'selectedNode gets updated when a node is tapped',
-        (WidgetTester tester) async {
+        (tester) async {
           await tester.pumpWidgetWithMaterialApp(
             const NavigationTree(
               directories: directories,
@@ -60,7 +60,7 @@ void main() {
 
       testWidgets(
         'Calls onNodeSelected when a node is tapped',
-        (WidgetTester tester) async {
+        (tester) async {
           final callbackMock = OnNodeSelectedCallbackMock<String, dynamic>();
 
           await tester.pumpWidgetWithMaterialApp(

--- a/packages/widgetbook/test/src/app/navigation_tree/widgets/search_field_test.dart
+++ b/packages/widgetbook/test/src/app/navigation_tree/widgets/search_field_test.dart
@@ -10,7 +10,7 @@ void main() {
   group('$SearchField', () {
     testWidgets(
       'Clear search button is initially not rendered',
-      (WidgetTester tester) async {
+      (tester) async {
         await tester.pumpWidgetWithMaterialApp(
           const SearchField(),
         );
@@ -25,7 +25,7 @@ void main() {
 
     testWidgets(
       'Clear search button is shown after entering text in the text field',
-      (WidgetTester tester) async {
+      (tester) async {
         await tester.pumpWidgetWithMaterialApp(
           const SearchField(searchValue: 'Search Value'),
         );
@@ -43,7 +43,7 @@ void main() {
     testWidgets(
       'Clicking on clear search button '
       'clears search value and removes the clear icon',
-      (WidgetTester tester) async {
+      (tester) async {
         await tester.pumpWidgetWithMaterialApp(
           const SearchField(
             searchValue: 'Search Value',
@@ -68,7 +68,7 @@ void main() {
 
     testWidgets(
       'onSearchPressed is executed',
-      (WidgetTester tester) async {
+      (tester) async {
         final voidCallbackMock = VoidCallbackMock();
         await tester.pumpWidgetWithMaterialApp(
           SearchField(

--- a/packages/widgetbook/test/src/knobs/boolean_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/boolean_knob_test.dart
@@ -7,7 +7,7 @@ import 'knob_helper.dart';
 void main() {
   testWidgets(
     'Equality operator works correctly',
-    (WidgetTester tester) async {
+    (tester) async {
       final first = BooleanKnob(label: 'first', value: true);
       final second = BooleanKnob(label: 'second', value: true);
       expect(first, equals(BooleanKnob(label: 'first', value: true)));
@@ -17,7 +17,7 @@ void main() {
 
   testWidgets(
     'Bool knob functions',
-    (WidgetTester tester) async {
+    (tester) async {
       await tester.pumpWithKnob(
         (context) => Text(
           context.knobs.boolean(

--- a/packages/widgetbook/test/src/knobs/boolean_or_null_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/boolean_or_null_knob_test.dart
@@ -7,7 +7,7 @@ import 'knob_helper.dart';
 void main() {
   testWidgets(
     'Equality operator works correctly',
-    (WidgetTester tester) async {
+    (tester) async {
       final first = BooleanOrNullKnob(label: 'first', value: null);
       final second = BooleanOrNullKnob(label: 'second', value: null);
       expect(first, equals(BooleanOrNullKnob(label: 'first', value: null)));
@@ -17,7 +17,7 @@ void main() {
 
   testWidgets(
     'Nullable Bool knob functions',
-    (WidgetTester tester) async {
+    (tester) async {
       await tester.pumpWithKnob(
         (context) {
           final value = context.knobs.booleanOrNull(
@@ -59,7 +59,7 @@ void main() {
 
   testWidgets(
     'Nullable Bool knob remembers previous value before null',
-    (WidgetTester tester) async {
+    (tester) async {
       await tester.pumpWithKnob(
         (context) {
           final value = context.knobs.booleanOrNull(

--- a/packages/widgetbook/test/src/knobs/color_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/color_knob_test.dart
@@ -8,7 +8,7 @@ void main() {
   group('$ColorKnob', () {
     testWidgets(
       'can return initial value',
-      (WidgetTester tester) async {
+      (tester) async {
         await tester.pumpWithKnob(
           (context) => Icon(
             key: const Key('coloredIcon'),

--- a/packages/widgetbook/test/src/knobs/double_input_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/double_input_knob_test.dart
@@ -7,7 +7,7 @@ import 'knob_helper.dart';
 void main() {
   testWidgets(
     'Equality operator works correctly',
-    (WidgetTester tester) async {
+    (tester) async {
       final first = DoubleInputKnob(label: 'first', value: 2);
       final second = DoubleInputKnob(label: 'second', value: 3);
 
@@ -18,7 +18,7 @@ void main() {
 
   testWidgets(
     'Number knob initial value works',
-    (WidgetTester tester) async {
+    (tester) async {
       await tester.pumpWithKnob(
         (context) => Text(
           context.knobs.double
@@ -36,7 +36,7 @@ void main() {
 
   testWidgets(
     'Number knob description displays',
-    (WidgetTester tester) async {
+    (tester) async {
       await tester.pumpWithKnob(
         (context) => Text(
           context.knobs.double
@@ -55,7 +55,7 @@ void main() {
 
   testWidgets(
     'Number knob functions',
-    (WidgetTester tester) async {
+    (tester) async {
       await tester.pumpWithKnob(
         (context) => Text(
           context.knobs.double

--- a/packages/widgetbook/test/src/knobs/double_slider_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/double_slider_knob_test.dart
@@ -7,7 +7,7 @@ import 'knob_helper.dart';
 void main() {
   testWidgets(
     'Equality operator works correctly',
-    (WidgetTester tester) async {
+    (tester) async {
       final first = DoubleSliderKnob(label: 'first', value: 3);
       final second = DoubleSliderKnob(label: 'second', value: 3);
       expect(first, equals(DoubleSliderKnob(label: 'first', value: 3)));
@@ -17,7 +17,7 @@ void main() {
 
   testWidgets(
     'Slider knob functions',
-    (WidgetTester tester) async {
+    (tester) async {
       await tester.pumpWithKnob(
         (context) => Text(
           context.knobs.double

--- a/packages/widgetbook/test/src/knobs/knob_helper.dart
+++ b/packages/widgetbook/test/src/knobs/knob_helper.dart
@@ -12,7 +12,6 @@ extension KnobHelper on WidgetTester {
       WidgetbookScope(
         state: WidgetbookState(
           path: '/',
-          previewMode: false,
           queryParams: {},
           addons: [],
           directories: [],

--- a/packages/widgetbook/test/src/knobs/knobs_test.dart
+++ b/packages/widgetbook/test/src/knobs/knobs_test.dart
@@ -8,7 +8,7 @@ import 'knob_helper.dart';
 void main() {
   testWidgets(
     'Bool knob added',
-    (WidgetTester tester) async {
+    (tester) async {
       await tester.pumpWithKnob(
         (context) => Text(
           context.knobs.boolean(

--- a/packages/widgetbook/test/src/knobs/list_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/list_knob_test.dart
@@ -7,7 +7,7 @@ import 'knob_helper.dart';
 void main() {
   testWidgets(
     'Equality operator works correctly',
-    (WidgetTester tester) async {
+    (tester) async {
       final first = ListKnob<int>(
         label: 'first',
         value: 10,
@@ -40,7 +40,7 @@ void main() {
 
   testWidgets(
     'Options knob functions',
-    (WidgetTester tester) async {
+    (tester) async {
       await tester.pumpWithKnob(
         (context) => Text(
           context.knobs.list<String>(
@@ -71,7 +71,7 @@ void main() {
 
   testWidgets(
     'Options knob works with non-string types',
-    (WidgetTester tester) async {
+    (tester) async {
       await tester.pumpWithKnob(
         (context) => Icon(
           context.knobs.list<IconData>(
@@ -99,7 +99,7 @@ void main() {
 
   testWidgets(
     'Options knob works with labelBuilder',
-    (WidgetTester tester) async {
+    (tester) async {
       await tester.pumpWithKnob(
         (context) => Icon(
           context.knobs.list<IconData>(
@@ -128,7 +128,7 @@ void main() {
 
   testWidgets(
     'Options knob respect initial selected option',
-    (WidgetTester tester) async {
+    (tester) async {
       await tester.pumpWithKnob(
         (context) => Icon(
           context.knobs.list<IconData>(

--- a/packages/widgetbook/test/src/knobs/string_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/string_knob_test.dart
@@ -7,7 +7,7 @@ import 'knob_helper.dart';
 void main() {
   testWidgets(
     'Equality operator works correctly',
-    (WidgetTester tester) async {
+    (tester) async {
       final first = StringKnob(
         label: 'first',
         value: 'hello',
@@ -32,7 +32,7 @@ void main() {
 
   testWidgets(
     'Text knob initial value works',
-    (WidgetTester tester) async {
+    (tester) async {
       await tester.pumpWithKnob(
         (context) => Text(
           context.knobs.string(
@@ -48,7 +48,7 @@ void main() {
 
   testWidgets(
     'Text knob description displays',
-    (WidgetTester tester) async {
+    (tester) async {
       await tester.pumpWithKnob(
         (context) => Text(
           context.knobs.string(
@@ -65,7 +65,7 @@ void main() {
 
   testWidgets(
     'Text knob functions',
-    (WidgetTester tester) async {
+    (tester) async {
       await tester.pumpWithKnob(
         (context) => Text(
           context.knobs.string(

--- a/packages/widgetbook/test/src/knobs/string_multiline_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/string_multiline_knob_test.dart
@@ -18,7 +18,7 @@ for (var level = 1; level <= 6; level++)
   group('$StringKnob', () {
     testWidgets(
       'is multiline',
-      (WidgetTester tester) async {
+      (tester) async {
         await tester.pumpWithKnob(
           (context) => Text(
             key: textFinderKey,
@@ -41,7 +41,7 @@ for (var level = 1; level <= 6; level++)
 
     testWidgets(
       'is not multiline',
-      (WidgetTester tester) async {
+      (tester) async {
         await tester.pumpWithKnob(
           (context) => Text(
             context.knobs.string(

--- a/packages/widgetbook/test/src/knobs/string_or_null_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/string_or_null_knob_test.dart
@@ -7,7 +7,7 @@ import 'knob_helper.dart';
 void main() {
   testWidgets(
     'Equality operator works correctly',
-    (WidgetTester tester) async {
+    (tester) async {
       final first = StringOrNullKnob(
         label: 'first',
         value: null,
@@ -31,7 +31,7 @@ void main() {
 
   testWidgets(
     'Nullable String knob functions',
-    (WidgetTester tester) async {
+    (tester) async {
       final text = 'widgetbook';
       final key = ValueKey(text);
 
@@ -67,7 +67,7 @@ void main() {
 
   testWidgets(
     'Nullable String remembers previous value',
-    (WidgetTester tester) async {
+    (tester) async {
       final text = 'widgetbook';
       final key = ValueKey(text);
 

--- a/packages/widgetbook/test/src/widgetbook_test.dart
+++ b/packages/widgetbook/test/src/widgetbook_test.dart
@@ -8,8 +8,8 @@ Matcher expectAssertionErrorWithMessage({
   return throwsA(
     allOf(
       isA<AssertionError>(),
-      predicate(
-        (AssertionError e) => e.message == message,
+      predicate<AssertionError>(
+        (e) => e.message == message,
       ),
     ),
   );

--- a/packages/widgetbook_cli/bin/git/branch_reference.dart
+++ b/packages/widgetbook_cli/bin/git/branch_reference.dart
@@ -7,8 +7,7 @@ class BranchReference extends CommitReference {
   factory BranchReference(String sha, String reference) =>
       BranchReference._internal(sha, reference);
 
-  BranchReference._internal(String sha, String reference)
-      : super(sha, reference);
+  BranchReference._internal(super.sha, super.reference);
 
   /// The name of the associated branch.
   ///

--- a/packages/widgetbook_cli/bin/git/git_dir.dart
+++ b/packages/widgetbook_cli/bin/git/git_dir.dart
@@ -503,7 +503,7 @@ class GitDir {
   /// If no content is added to the directory, an error is thrown.
   Future<Commit?> updateBranch(
     String branchName,
-    Future Function(Directory td) populater,
+    Future<void> Function(Directory td) populater,
     String commitMessage,
   ) async {
     // TODO: ponder restricting branch names

--- a/packages/widgetbook_cli/bin/parsers/generator_parser.dart
+++ b/packages/widgetbook_cli/bin/parsers/generator_parser.dart
@@ -60,7 +60,7 @@ abstract class GeneratorParser<T> {
           .directory(generatedFolderPath)
           .listSync(recursive: true)
           .whereType<File>()
-          .where((File file) => file.path.endsWith(fileExtension));
+          .where((file) => file.path.endsWith(fileExtension));
     }
   }
 

--- a/packages/widgetbook_cli/test/git/git_dir_test.dart
+++ b/packages/widgetbook_cli/test/git/git_dir_test.dart
@@ -471,7 +471,7 @@ line 2:y''',
   });
 }
 
-Future _testGetCommits() async {
+Future<void> _testGetCommits() async {
   const commitText = [
     '',
     ' \t leading white space is okay, too',
@@ -544,7 +544,7 @@ Future _testGetCommits() async {
   });
 }
 
-Future _doDescriptorGitRemove(
+Future<ProcessResult> _doDescriptorGitRemove(
   GitDir gd,
   List<String> filePaths,
   String commitMsg,
@@ -568,7 +568,7 @@ Future _doDescriptorGitRemove(
   return gd.runCommand(args);
 }
 
-Future _doDescriptorGitCommit(
+Future<ProcessResult> _doDescriptorGitCommit(
   GitDir gd,
   Map<String, String> contents,
   String commitMsg,
@@ -592,7 +592,7 @@ Future _doDescriptorGitCommit(
   return gd.runCommand(args);
 }
 
-Future _doDescriptorDepopulate(
+Future<void> _doDescriptorDepopulate(
   String dirPath,
   List<String> filePaths,
 ) async {
@@ -603,7 +603,7 @@ Future _doDescriptorDepopulate(
   }
 }
 
-Future _doDescriptorPopulate(
+Future<void> _doDescriptorPopulate(
   String dirPath,
   Map<String, String> contents,
 ) async {
@@ -618,7 +618,7 @@ Future _doDescriptorPopulate(
   }
 }
 
-Future _testPopulateBranch() async {
+Future<void> _testPopulateBranch() async {
   const initialMasterBranchContent = {'master.md': 'test file'};
 
   const testContent1 = {
@@ -720,7 +720,7 @@ Future<Tuple<Commit?, int>> _testPopulateBranchCore(
   }
 }
 
-Future _testPopulateBranchWithContent(
+Future<void> _testPopulateBranchWithContent(
   GitDir gitDir,
   String branchName,
   Map<String, String> contents,
@@ -769,7 +769,7 @@ Future _testPopulateBranchWithContent(
   expect(newCommitCount, originalCommitCount + 1);
 }
 
-Future _testPopulateBranchWithDupeContent(
+Future<void> _testPopulateBranchWithDupeContent(
   GitDir gitDir,
   String branchName,
   Map<String, String> contents,

--- a/packages/widgetbook_cli/test/utils/override_print.dart
+++ b/packages/widgetbook_cli/test/utils/override_print.dart
@@ -5,7 +5,7 @@ List<String> printLogs = <String>[];
 void Function() overridePrint(void Function() fn) {
   return () {
     final spec = ZoneSpecification(
-      print: (_, __, ___, String msg) {
+      print: (_, __, ___, msg) {
         printLogs.add(msg);
       },
     );

--- a/packages/widgetbook_generator/lib/generators/app_generator.dart
+++ b/packages/widgetbook_generator/lib/generators/app_generator.dart
@@ -50,7 +50,7 @@ class AppGenerator extends GeneratorForAnnotation<App> {
       final dynamic content = jsonDecode(await buildStep.readAsString(id));
       final decodedJson = content as List;
       final jsons = decodedJson.cast<Map<String, dynamic>>();
-      final something = jsons.map<T>((Map<String, dynamic> json) {
+      final something = jsons.map<T>((json) {
         return fromMap(json);
       }).toList();
 

--- a/packages/widgetbook_generator/lib/instances/boolean_instance.dart
+++ b/packages/widgetbook_generator/lib/instances/boolean_instance.dart
@@ -3,10 +3,8 @@ import 'primary_instance.dart';
 /// Implements a [bool] instance
 class BooleanInstance extends PrimaryInstance<bool> {
   const BooleanInstance.value({
-    required bool value,
-  }) : super(
-          value: value,
-        );
+    required super.value,
+  });
 
   @override
   String toCode() {

--- a/packages/widgetbook_generator/lib/models/widgetbook_use_case_data.dart
+++ b/packages/widgetbook_generator/lib/models/widgetbook_use_case_data.dart
@@ -2,20 +2,16 @@ import 'widgetbook_data.dart';
 
 class WidgetbookUseCaseData extends WidgetbookData {
   WidgetbookUseCaseData({
-    required String name,
-    required String importStatement,
-    required List<String> dependencies,
+    required super.name,
+    required super.importStatement,
+    required super.dependencies,
     required this.useCaseName,
     required this.componentName,
     required this.componentImportStatement,
     required this.componentDefinitionPath,
     required this.useCaseDefinitionPath,
     required this.designLink,
-  }) : super(
-          name: name,
-          importStatement: importStatement,
-          dependencies: dependencies,
-        );
+  });
 
   factory WidgetbookUseCaseData.fromJson(Map<String, dynamic> json) {
     return WidgetbookUseCaseData(

--- a/packages/widgetbook_generator/test/src/instances/instance_test.dart
+++ b/packages/widgetbook_generator/test/src/instances/instance_test.dart
@@ -33,11 +33,10 @@ class NamedCosntructorInstance extends Instance {
 
 class PropertyInstance extends Instance {
   PropertyInstance({
-    required bool trailingComma,
+    required super.trailingComma,
   }) : super(
           name: 'PropertyInstance',
           properties: [Property.string(key: 'p2', value: 'value')],
-          trailingComma: trailingComma,
         );
 }
 

--- a/sandbox/lib/navigation/navigation_tree.dart
+++ b/sandbox/lib/navigation/navigation_tree.dart
@@ -8,6 +8,5 @@ import 'navigation_test_data.dart';
 Widget navigationTreeDefaultUseCase(BuildContext context) {
   return const NavigationTree(
     directories: directories,
-    searchQuery: '',
   );
 }


### PR DESCRIPTION
In addition to enabling `strict-raw-types`, the following rules were added:

 1. `use_super_parameters`
 2. `avoid_redundant_argument_values`
 3. `avoid_types_on_closure_parameters`