### PR TITLE
feat: send fields composables to cloud

### DIFF
--- a/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
+++ b/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
@@ -52,4 +52,13 @@ abstract class WidgetbookAddon<T> extends FieldsComposable<T> {
   ) {
     return child;
   }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'group': slugName,
+      'fields': fields.map((field) => field.toFullJson()).toList(),
+    };
+  }
 }

--- a/packages/widgetbook/lib/src/fields/fields_composable.dart
+++ b/packages/widgetbook/lib/src/fields/fields_composable.dart
@@ -24,4 +24,6 @@ abstract class FieldsComposable<T> {
 
     return field.valueFrom(group);
   }
+
+  Map<String, dynamic> toJson();
 }

--- a/packages/widgetbook/lib/src/integrations/widgetbook_cloud_integration/widgetbook_cloud_integration.dart
+++ b/packages/widgetbook/lib/src/integrations/widgetbook_cloud_integration/widgetbook_cloud_integration.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 import '../../state/state.dart';
 import '../widgetbook_integration.dart';
 import 'no_messaging.dart' if (dart.library.html) 'web_messaging.dart';
@@ -9,17 +7,21 @@ import 'no_messaging.dart' if (dart.library.html) 'web_messaging.dart';
 class WidgetbookCloudIntegration extends WidgetbookIntegration {
   @override
   void onInit(WidgetbookState state) {
-    if (!kIsWeb || state.addons == null) return;
+    if (state.addons == null) return;
 
-    final addonsJsonEntries = state.addons!.map(
-      (addon) => MapEntry(
-        addon.slugName,
-        addon.fields.map((field) => field.toFullJson()).toList(),
-      ),
-    );
+    final addonsJson = state.addons! //
+        .map((addon) => addon.toJson())
+        .toList();
 
-    sendMessage(
-      Map.fromEntries(addonsJsonEntries),
-    );
+    sendMessage({'addons': addonsJson});
+  }
+
+  @override
+  void onKnobsRegistered(WidgetbookState state) {
+    final knobsJson = state.knobs.values //
+        .map((knob) => knob.toJson())
+        .toList();
+
+    sendMessage({'knobs': knobsJson});
   }
 }

--- a/packages/widgetbook/lib/src/integrations/widgetbook_integration.dart
+++ b/packages/widgetbook/lib/src/integrations/widgetbook_integration.dart
@@ -13,6 +13,9 @@ abstract class WidgetbookIntegration {
   /// Gets called on first launch of [Widgetbook] with the initial [state].
   void onInit(WidgetbookState state) {}
 
+  /// Gets called when all knobs are registered after.
+  void onKnobsRegistered(WidgetbookState state) {}
+
   /// Gets called on every [WidgetbookState] change.
   void onChange(WidgetbookState state) {}
 }

--- a/packages/widgetbook/lib/src/knobs/knob.dart
+++ b/packages/widgetbook/lib/src/knobs/knob.dart
@@ -58,4 +58,14 @@ abstract class Knob<T> extends FieldsComposable<T> {
 
   @override
   int get hashCode => label.hashCode;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': label,
+      'group': 'knobs',
+      'nullable': isNullable,
+      'fields': fields.map((field) => field.toFullJson()).toList(),
+    };
+  }
 }

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -125,6 +125,15 @@ class WidgetbookState extends ChangeNotifier {
     return knob.valueFromQueryGroup(knobsQueryGroup);
   }
 
+  @internal
+  void notifyKnobsReady() {
+    notifyListeners();
+
+    integrations?.forEach(
+      (integration) => integration.onKnobsRegistered(this),
+    );
+  }
+
   /// Update the current state using [AppRouteConfig] to update
   /// the [path], [previewMode] and [queryParams] fields. Since these fields
   /// can be manipulated from the router's query parameters, as opposed to the

--- a/packages/widgetbook/lib/src/workbench/use_case_builder.dart
+++ b/packages/widgetbook/lib/src/workbench/use_case_builder.dart
@@ -22,7 +22,7 @@ class _UseCaseBuilderState extends State<UseCaseBuilder> {
     // Notify that the use case finished building,
     // to rebuild the use case with all registered knobs
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      WidgetbookState.of(context).notifyListeners();
+      WidgetbookState.of(context).notifyKnobsReady();
     });
   }
 


### PR DESCRIPTION
Addons and Knobs are sent to Widgetbook Cloud via the `WidgetbookCloudIntegration` as follows:

```json
// Sent on initialization once
{
  "addons": [
    {
      "name": "Addon Name",
      "group": "addon-name",
      "fields": [
        {
          "name": "field-name",
          "type": "..."
          // ...
        }
      ]
    }
  ]
}

// Sent after knobs get registered
{
  "knobs": [
    {
      "name": "Knob Name",
      "group": "knobs",
      "nullable": false,
      "fields": [
        {
          "name": "field-name",
          "type": "..."
          // ...
        }
      ]
    }
  ]
}
```