### PR TITLE
refactor: move `group` to `FieldsComposable`

### DIFF
--- a/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
+++ b/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
@@ -30,7 +30,8 @@ abstract class WidgetbookAddon<T> extends FieldsComposable<T> {
   final String name;
   final T initialSetting;
 
-  String get slugName => name.trim().toLowerCase().replaceAll(RegExp(' '), '-');
+  @override
+  String get groupName => slugify(name);
 
   @override
   Widget buildFields(BuildContext context) {
@@ -38,7 +39,9 @@ abstract class WidgetbookAddon<T> extends FieldsComposable<T> {
       name: name,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: fields.map((field) => field.build(context)).toList(),
+        children: fields //
+            .map((field) => field.build(context, groupName))
+            .toList(),
       ),
     );
   }
@@ -57,7 +60,7 @@ abstract class WidgetbookAddon<T> extends FieldsComposable<T> {
   Map<String, dynamic> toJson() {
     return {
       'name': name,
-      'group': slugName,
+      'group': groupName,
       'fields': fields.map((field) => field.toFullJson()).toList(),
     };
   }

--- a/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
@@ -33,14 +33,12 @@ class DeviceFrameAddon extends WidgetbookAddon<DeviceFrameSetting> {
   List<Field> get fields {
     return [
       ListField<DeviceInfo?>(
-        group: slugName,
         name: 'name',
         values: devices,
         initialValue: initialSetting.device,
         labelBuilder: (device) => device?.name ?? 'None',
       ),
       ListField<Orientation>(
-        group: slugName,
         name: 'orientation',
         values: Orientation.values,
         initialValue: initialSetting.orientation,
@@ -49,7 +47,6 @@ class DeviceFrameAddon extends WidgetbookAddon<DeviceFrameSetting> {
             orientation.name.substring(1),
       ),
       ListField<bool>(
-        group: slugName,
         name: 'frame',
         values: [false, true],
         initialValue: initialSetting.hasFrame,

--- a/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
+++ b/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
@@ -29,7 +29,6 @@ class LocalizationAddon extends WidgetbookAddon<Locale> {
   List<Field> get fields {
     return [
       ListField<Locale>(
-        group: slugName,
         name: 'name',
         values: locales,
         initialValue: initialSetting,

--- a/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
+++ b/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
@@ -28,7 +28,6 @@ class TextScaleAddon extends WidgetbookAddon<double> {
   List<Field> get fields {
     return [
       ListField<double>(
-        group: slugName,
         name: 'factor',
         values: scales,
         initialValue: initialSetting,

--- a/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
@@ -37,7 +37,6 @@ class ThemeAddon<T> extends WidgetbookAddon<WidgetbookTheme<T>> {
   List<Field> get fields {
     return [
       ListField<WidgetbookTheme<T>>(
-        group: slugName,
         name: 'name',
         values: themes,
         initialValue: initialSetting,

--- a/packages/widgetbook/lib/src/fields/boolean_field.dart
+++ b/packages/widgetbook/lib/src/fields/boolean_field.dart
@@ -7,7 +7,6 @@ import 'field_type.dart';
 /// [Field] that builds [Switch] for [bool] values.
 class BooleanField extends Field<bool> {
   BooleanField({
-    required super.group,
     required super.name,
     super.initialValue = true,
     super.onChanged,
@@ -20,10 +19,10 @@ class BooleanField extends Field<bool> {
         );
 
   @override
-  Widget toWidget(BuildContext context, bool? value) {
+  Widget toWidget(BuildContext context, String group, bool? value) {
     return Switch(
       value: value ?? initialValue ?? true,
-      onChanged: (value) => updateField(context, value),
+      onChanged: (value) => updateField(context, group, value),
     );
   }
 }

--- a/packages/widgetbook/lib/src/fields/color_field.dart
+++ b/packages/widgetbook/lib/src/fields/color_field.dart
@@ -7,7 +7,6 @@ import 'field_type.dart';
 /// [Field] that builds [TextFormField] for [Color] values.
 class ColorField extends Field<Color> {
   ColorField({
-    required super.group,
     required super.name,
     super.initialValue = defaultColor,
     super.onChanged,
@@ -29,11 +28,12 @@ class ColorField extends Field<Color> {
   static const defaultColor = Colors.white;
 
   @override
-  Widget toWidget(BuildContext context, Color? value) {
+  Widget toWidget(BuildContext context, String group, Color? value) {
     return TextFormField(
       initialValue: codec.toParam(value ?? initialValue ?? defaultColor),
       onChanged: (value) => updateField(
         context,
+        group,
         codec.toValue(value) ?? initialValue ?? defaultColor,
       ),
     );

--- a/packages/widgetbook/lib/src/fields/double_input_field.dart
+++ b/packages/widgetbook/lib/src/fields/double_input_field.dart
@@ -7,7 +7,6 @@ import 'field_type.dart';
 /// [Field] that builds [TextFormField] for [double] values.
 class DoubleInputField extends Field<double> {
   DoubleInputField({
-    required super.group,
     required super.name,
     super.initialValue = 0,
     super.onChanged,
@@ -20,12 +19,13 @@ class DoubleInputField extends Field<double> {
         );
 
   @override
-  Widget toWidget(BuildContext context, double? value) {
+  Widget toWidget(BuildContext context, String group, double? value) {
     return TextFormField(
       initialValue: codec.toParam(value ?? initialValue ?? 0),
       keyboardType: TextInputType.number,
       onChanged: (value) => updateField(
         context,
+        group,
         codec.toValue(value) ?? initialValue ?? 0,
       ),
     );

--- a/packages/widgetbook/lib/src/fields/double_slider_field.dart
+++ b/packages/widgetbook/lib/src/fields/double_slider_field.dart
@@ -7,7 +7,6 @@ import 'field_type.dart';
 /// [Field] that builds [Slider] for [double] values.
 class DoubleSliderField extends Field<double> {
   DoubleSliderField({
-    required super.group,
     required super.name,
     super.initialValue = 0,
     required this.min,
@@ -27,7 +26,7 @@ class DoubleSliderField extends Field<double> {
   final int? divisions;
 
   @override
-  Widget toWidget(BuildContext context, double? value) {
+  Widget toWidget(BuildContext context, String group, double? value) {
     return Row(
       children: [
         Expanded(
@@ -38,7 +37,7 @@ class DoubleSliderField extends Field<double> {
             max: max,
             label: (value ?? 0).toStringAsFixed(2),
             divisions: divisions,
-            onChanged: (value) => updateField(context, value),
+            onChanged: (value) => updateField(context, group, value),
           ),
         ),
         Expanded(

--- a/packages/widgetbook/lib/src/fields/field.dart
+++ b/packages/widgetbook/lib/src/fields/field.dart
@@ -16,15 +16,14 @@ import 'field_type.dart';
 /// with the query parameters. A [Field] is encoded into a query parameter using
 /// a JSON-like format (e.g. `/?foo={bar:qux}`), it has the following parts:
 ///
-/// | Part    | Value |
-/// | :-----  | :---- |
-/// | [group] | `foo` |
-/// | [name]  | `bar` |
-/// | value   | `qux` |
+/// | Part   | Value |
+/// | :----  | :---- |
+/// | group  | `foo` |
+/// | [name] | `bar` |
+/// | value  | `qux` |
 @optionalTypeArgs
 abstract class Field<T> {
   const Field({
-    required this.group,
     required this.name,
     required this.type,
     required this.initialValue,
@@ -32,11 +31,7 @@ abstract class Field<T> {
     this.onChanged,
   });
 
-  /// A set of [Field]s can be grouped under the same query parameter
-  /// by using [group] for all of them.
-  final String group;
-
-  /// Name of this inside the [group] query parameter.
+  /// Name of this inside the query group.
   final String name;
 
   /// Type of this, helps providing some metadata about this,
@@ -60,19 +55,19 @@ abstract class Field<T> {
     return codec.toValue(groupMap[name]) ?? initialValue;
   }
 
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, String group) {
     final state = WidgetbookState.of(context);
     final groupMap = FieldCodec.decodeQueryGroup(state.queryParams[group]);
     final value = valueFrom(groupMap);
 
-    return toWidget(context, value);
+    return toWidget(context, group, value);
   }
 
   /// Builds the current field into a [Widget] to be used for input in the
   /// side panel.
-  Widget toWidget(BuildContext context, T? value);
+  Widget toWidget(BuildContext context, String group, T? value);
 
-  void updateField(BuildContext context, T value) {
+  void updateField(BuildContext context, String group, T value) {
     final state = WidgetbookState.of(context);
     final groupMap = FieldCodec.decodeQueryGroup(state.queryParams[group]);
 

--- a/packages/widgetbook/lib/src/fields/fields_composable.dart
+++ b/packages/widgetbook/lib/src/fields/fields_composable.dart
@@ -6,7 +6,14 @@ import 'field_codec.dart';
 /// Interface for defining APIs for features that
 /// use [fields] as a building block.
 abstract class FieldsComposable<T> {
+  // The name of the query group param.
+  String get groupName;
+
   List<Field> get fields;
+
+  String slugify(String name) {
+    return name.trim().toLowerCase().replaceAll(RegExp(' '), '-');
+  }
 
   /// Converts a query group to a value of type [T].
   T valueFromQueryGroup(Map<String, String> group);

--- a/packages/widgetbook/lib/src/fields/list_field.dart
+++ b/packages/widgetbook/lib/src/fields/list_field.dart
@@ -11,7 +11,6 @@ typedef LabelBuilder<T> = String Function(T value);
 /// [Field] that builds [DropdownSetting] for [List]<[T]> values.
 class ListField<T> extends Field<T> {
   ListField({
-    required super.group,
     required super.name,
     required this.values,
     required super.initialValue,
@@ -42,12 +41,12 @@ class ListField<T> extends Field<T> {
   final LabelBuilder<T>? labelBuilder;
 
   @override
-  Widget toWidget(BuildContext context, T? value) {
+  Widget toWidget(BuildContext context, String group, T? value) {
     return DropdownSetting<T>(
       options: values,
       initialSelection: value,
       optionValueBuilder: labelBuilder,
-      onSelected: (value) => updateField(context, value),
+      onSelected: (value) => updateField(context, group, value),
     );
   }
 

--- a/packages/widgetbook/lib/src/fields/string_field.dart
+++ b/packages/widgetbook/lib/src/fields/string_field.dart
@@ -7,7 +7,6 @@ import 'field_type.dart';
 /// [Field] that builds [TextFormField] for [String] values.
 class StringField extends Field<String> {
   StringField({
-    required super.group,
     required super.name,
     super.initialValue = '',
     this.maxLines,
@@ -23,11 +22,11 @@ class StringField extends Field<String> {
   final int? maxLines;
 
   @override
-  Widget toWidget(BuildContext context, String? value) {
+  Widget toWidget(BuildContext context, String group, String? value) {
     return TextFormField(
       maxLines: maxLines,
       initialValue: value ?? initialValue,
-      onChanged: (value) => updateField(context, value),
+      onChanged: (value) => updateField(context, group, value),
     );
   }
 

--- a/packages/widgetbook/lib/src/knobs/boolean_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/boolean_knob.dart
@@ -16,7 +16,6 @@ class BooleanKnob extends Knob<bool> {
   List<Field> get fields {
     return [
       BooleanField(
-        group: 'knobs',
         name: label,
         initialValue: value,
         onChanged: (context, value) {
@@ -45,7 +44,6 @@ class BooleanOrNullKnob extends Knob<bool?> {
   List<Field> get fields {
     return [
       BooleanField(
-        group: 'knobs',
         name: label,
         initialValue: value,
         onChanged: (context, value) {

--- a/packages/widgetbook/lib/src/knobs/color_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/color_knob.dart
@@ -18,7 +18,6 @@ class ColorKnob extends Knob<Color> {
   List<Field> get fields {
     return [
       ColorField(
-        group: 'knobs',
         name: label,
         initialValue: value,
         onChanged: (context, value) {

--- a/packages/widgetbook/lib/src/knobs/double_input_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/double_input_knob.dart
@@ -16,7 +16,6 @@ class DoubleInputKnob extends Knob<double> {
   List<Field> get fields {
     return [
       DoubleInputField(
-        group: 'knobs',
         name: label,
         initialValue: value,
         onChanged: (context, value) {
@@ -45,7 +44,6 @@ class DoubleOrNullInputKnob extends Knob<double?> {
   List<Field> get fields {
     return [
       DoubleInputField(
-        group: 'knobs',
         name: label,
         initialValue: value,
         onChanged: (context, value) {

--- a/packages/widgetbook/lib/src/knobs/double_slider_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/double_slider_knob.dart
@@ -23,7 +23,6 @@ class DoubleSliderKnob extends Knob<double> {
   List<Field> get fields {
     return [
       DoubleSliderField(
-        group: 'knobs',
         name: label,
         initialValue: value,
         min: min,
@@ -62,7 +61,6 @@ class DoubleOrNullSliderKnob extends Knob<double?> {
   List<Field> get fields {
     return [
       DoubleSliderField(
-        group: 'knobs',
         name: label,
         initialValue: value,
         min: min,

--- a/packages/widgetbook/lib/src/knobs/knob.dart
+++ b/packages/widgetbook/lib/src/knobs/knob.dart
@@ -29,6 +29,9 @@ abstract class Knob<T> extends FieldsComposable<T> {
   bool get isNullable => null is T;
 
   @override
+  String get groupName => 'knobs';
+
+  @override
   Widget buildFields(BuildContext context) {
     return KnobProperty<T>(
       name: label,
@@ -43,7 +46,9 @@ abstract class Knob<T> extends FieldsComposable<T> {
       },
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: fields.map((field) => field.build(context)).toList(),
+        children: fields //
+            .map((field) => field.build(context, groupName))
+            .toList(),
       ),
     );
   }
@@ -63,7 +68,7 @@ abstract class Knob<T> extends FieldsComposable<T> {
   Map<String, dynamic> toJson() {
     return {
       'name': label,
-      'group': 'knobs',
+      'group': groupName,
       'nullable': isNullable,
       'fields': fields.map((field) => field.toFullJson()).toList(),
     };

--- a/packages/widgetbook/lib/src/knobs/list_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/list_knob.dart
@@ -25,7 +25,6 @@ class ListKnob<T> extends Knob<T> {
   List<Field> get fields {
     return [
       ListField<T>(
-        group: 'knobs',
         name: label,
         values: options,
         initialValue: value,
@@ -61,7 +60,6 @@ class ListOrNullKnob<T> extends Knob<T?> {
   List<Field> get fields {
     return [
       ListField<T?>(
-        group: 'knobs',
         name: label,
         values: options,
         initialValue: value,

--- a/packages/widgetbook/lib/src/knobs/string_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/string_knob.dart
@@ -19,7 +19,6 @@ class StringKnob extends Knob<String> {
   List<Field> get fields {
     return [
       StringField(
-        group: 'knobs',
         name: label,
         initialValue: value,
         maxLines: maxLines,
@@ -52,7 +51,6 @@ class StringOrNullKnob extends Knob<String?> {
   List<Field> get fields {
     return [
       StringField(
-        group: 'knobs',
         name: label,
         initialValue: value,
         maxLines: maxLines,

--- a/packages/widgetbook/lib/src/workbench/workbench.dart
+++ b/packages/widgetbook/lib/src/workbench/workbench.dart
@@ -21,7 +21,7 @@ class Workbench extends StatelessWidget {
           builder: (context, addon, child) {
             final state = WidgetbookState.of(context);
             final groupMap = FieldCodec.decodeQueryGroup(
-              state.queryParams[addon.slugName],
+              state.queryParams[addon.groupName],
             );
 
             final newSetting = addon.valueFromQueryGroup(groupMap);

--- a/packages/widgetbook/test/src/addons/utils/addon_test_helper.dart
+++ b/packages/widgetbook/test/src/addons/utils/addon_test_helper.dart
@@ -34,7 +34,7 @@ Future<void> testAddon<T>({
   await tester.pumpAndSettle();
 
   final groupMap = FieldCodec.decodeQueryGroup(
-    state.queryParams[addon.slugName],
+    state.queryParams[addon.groupName],
   );
 
   final setting = addon.valueFromQueryGroup(groupMap);


### PR DESCRIPTION
Instead of passing `group` to each `Field`, a new property called `groupName` is added to `FieldsComposable`, this value is passed to all `fields`.