### PR TITLE
fix: replace `Scaffold` with `ColoredBox`

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ - **FIX**: Replace the `Scaffold` around use-cases with a `ColoredBox` below the `Theme` widget. ([#789](https://github.com/widgetbook/widgetbook/pull/789))
+
 ## 3.0.0
 
 Check out the [migration guide](https://docs.widgetbook.io/migration/2.4.0-to-3.0.0) for more information.

--- a/packages/widgetbook/lib/src/addons/theme_addon/cupertino_theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/cupertino_theme_addon.dart
@@ -12,7 +12,10 @@ class CupertinoThemeAddon extends ThemeAddon<CupertinoThemeData> {
           themeBuilder: (context, theme, child) {
             return CupertinoTheme(
               data: theme,
-              child: child,
+              child: ColoredBox(
+                color: theme.scaffoldBackgroundColor,
+                child: child,
+              ),
             );
           },
         );

--- a/packages/widgetbook/lib/src/addons/theme_addon/material_theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/material_theme_addon.dart
@@ -11,7 +11,10 @@ class MaterialThemeAddon extends ThemeAddon<ThemeData> {
           themeBuilder: (context, theme, child) {
             return Theme(
               data: theme,
-              child: child,
+              child: ColoredBox(
+                color: theme.scaffoldBackgroundColor,
+                child: child,
+              ),
             );
           },
         );

--- a/packages/widgetbook/lib/src/workbench/workbench.dart
+++ b/packages/widgetbook/lib/src/workbench/workbench.dart
@@ -32,14 +32,12 @@ class Workbench extends StatelessWidget {
               newSetting,
             );
           },
-          child: Scaffold(
-            body: UseCaseBuilder(
-              key: ValueKey(state.uri),
-              builder: (context) {
-                return WidgetbookState.of(context).useCase?.builder(context) ??
-                    const SizedBox.shrink();
-              },
-            ),
+          child: UseCaseBuilder(
+            key: ValueKey(state.uri),
+            builder: (context) {
+              return WidgetbookState.of(context).useCase?.builder(context) ??
+                  const SizedBox.shrink();
+            },
           ),
         ),
       ),


### PR DESCRIPTION
The `Scaffold` around the `UseCaseBuilder` has the responsibility of making the `Workbench`'s background color match the current theme. But the `Scaffold` filled the whole `Workbench` area, causing issues like #787.

This PR adds a `ColoredBox` iniside the `ThemeAddon`s, to allow alignment later on.