### PR TITLE
fix: add `Material` to `materialAppBuilder`

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
  - **FIX**: Replace the `Scaffold` around use-cases with a `ColoredBox` below the `Theme` widget. ([#789](https://github.com/widgetbook/widgetbook/pull/789))
+ - **FIX**: Add `Material` widget through default `appBuilder` of `Widgetbook.material`. ([#792](https://github.com/widgetbook/widgetbook/pull/792))
 
 ## 3.0.0
 

--- a/packages/widgetbook/lib/src/state/default_app_builders.dart
+++ b/packages/widgetbook/lib/src/state/default_app_builders.dart
@@ -4,7 +4,9 @@ import 'package:flutter/material.dart';
 Widget materialAppBuilder(BuildContext context, Widget child) {
   return MaterialApp(
     debugShowCheckedModeBanner: false,
-    home: child,
+    home: Material(
+      child: child,
+    ),
   );
 }
 


### PR DESCRIPTION
After removing `Scaffold` in #789, the widgets tree lacked the `Material` widget.
This PR aims at re-adding the `Material` widget through the default `appBuilder` of `Widgetbook.material`.