### PR TITLE
fix: loosen `UseCaseBuilder` constraints

### DIFF
--- a/packages/widgetbook/lib/src/workbench/workbench.dart
+++ b/packages/widgetbook/lib/src/workbench/workbench.dart
@@ -32,12 +32,21 @@ class Workbench extends StatelessWidget {
               newSetting,
             );
           },
-          child: UseCaseBuilder(
-            key: ValueKey(state.uri),
-            builder: (context) {
-              return WidgetbookState.of(context).useCase?.builder(context) ??
-                  const SizedBox.shrink();
-            },
+          child: Stack(
+            // The Stack is used to loosen the constraints of
+            // the UseCaseBuilder. Without the Stack, UseCaseBuilder
+            // would expand to the whole size of the Workbench.
+            children: [
+              UseCaseBuilder(
+                key: ValueKey(state.uri),
+                builder: (context) {
+                  return WidgetbookState.of(context)
+                          .useCase
+                          ?.builder(context) ??
+                      const SizedBox.shrink();
+                },
+              )
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
After removing `Scaffold` in #789, the `UseCaseBuilder` was expanding to the whole size of `Workbench`, which caused some widets like `DropdownMenu` to misbehave as show below.

| Before | After |
| :-----: |  :---: |
| ![before](https://github.com/widgetbook/widgetbook/assets/41103290/bf8d604a-2164-40ee-916d-68f68fed12dd) | ![after](https://github.com/widgetbook/widgetbook/assets/41103290/3b239d48-6d96-49b6-b45a-3bb151c13267) |

