### PR TITLE
fix: prevent `DoubleSliderField` from overflow

### DIFF
--- a/packages/widgetbook/lib/src/fields/double_slider_field.dart
+++ b/packages/widgetbook/lib/src/fields/double_slider_field.dart
@@ -28,9 +28,10 @@ class DoubleSliderField extends Field<double> {
   @override
   Widget toWidget(BuildContext context, String group, double? value) {
     return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         Expanded(
-          flex: 7,
+          flex: 8,
           child: Slider(
             value: value ?? 0,
             min: min,
@@ -42,7 +43,9 @@ class DoubleSliderField extends Field<double> {
         ),
         Expanded(
           child: Text(
-            value?.toString() ?? '',
+            value?.toStringAsFixed(2) ?? '',
+            textAlign: TextAlign.end,
+            maxLines: 1,
           ),
         )
       ],

--- a/packages/widgetbook/lib/src/themes.dart
+++ b/packages/widgetbook/lib/src/themes.dart
@@ -74,6 +74,10 @@ class Themes {
           fontFamily: 'Poppins',
         ),
     useMaterial3: true,
+  ).copyWith(
+    sliderTheme: SliderThemeData(
+      overlayShape: SliderComponentShape.noThumb,
+    ),
   );
 
   static ThemeData dark = ThemeData.from(
@@ -86,5 +90,8 @@ class Themes {
     useMaterial3: true,
   ).copyWith(
     hoverColor: const Color(0xFFE3E2E6).withOpacity(0.08),
+    sliderTheme: SliderThemeData(
+      overlayShape: SliderComponentShape.noThumb,
+    ),
   );
 }

--- a/packages/widgetbook/test/src/knobs/double_slider_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/double_slider_knob_test.dart
@@ -32,7 +32,7 @@ void main() {
         ),
       );
 
-      expect(find.text('5.0'), findsNWidgets(2));
+      expect(find.text('5.00'), findsOneWidget);
       await tester.pumpAndSettle();
       await tester.drag(
         find.byType(Slider),
@@ -40,7 +40,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('7.0'), findsNWidgets(2));
+      expect(find.text('7.00'), findsOneWidget);
     },
   );
 }


### PR DESCRIPTION
Give the `DoubleSliderField` some improvements:
1. Remove leading thumb space.
2. Round labels to 2 digit points.
3. Adjust Flex ratios.