### PR TITLE
refactor: add background color to device frame

### DIFF
--- a/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
@@ -74,15 +74,18 @@ class DeviceFrameAddon extends WidgetbookAddon<DeviceFrameSetting> {
       return child;
     }
 
-    return DeviceFrame(
-      orientation: setting.orientation,
-      device: setting.device!,
-      isFrameVisible: setting.hasFrame,
-      screen: setting.hasFrame
-          ? child
-          : SafeArea(
-              child: child,
-            ),
+    return Padding(
+      padding: const EdgeInsets.all(32),
+      child: DeviceFrame(
+        orientation: setting.orientation,
+        device: setting.device!,
+        isFrameVisible: setting.hasFrame,
+        screen: setting.hasFrame
+            ? child
+            : SafeArea(
+                child: child,
+              ),
+      ),
     );
   }
 }

--- a/packages/widgetbook/lib/src/workbench/workbench.dart
+++ b/packages/widgetbook/lib/src/workbench/workbench.dart
@@ -16,37 +16,42 @@ class Workbench extends StatelessWidget {
     return SafeBoundaries(
       child: state.appBuilder(
         context,
-        MultiAddonBuilder(
-          addons: state.addons,
-          builder: (context, addon, child) {
-            final state = WidgetbookState.of(context);
-            final groupMap = FieldCodec.decodeQueryGroup(
-              state.queryParams[addon.groupName],
-            );
+        ColoredBox(
+          // Background color for the area behind device frame if
+          // the [DeviceFrameAddon] is used.
+          color: Theme.of(context).scaffoldBackgroundColor,
+          child: MultiAddonBuilder(
+            addons: state.addons,
+            builder: (context, addon, child) {
+              final state = WidgetbookState.of(context);
+              final groupMap = FieldCodec.decodeQueryGroup(
+                state.queryParams[addon.groupName],
+              );
 
-            final newSetting = addon.valueFromQueryGroup(groupMap);
+              final newSetting = addon.valueFromQueryGroup(groupMap);
 
-            return addon.buildUseCase(
-              context,
-              child,
-              newSetting,
-            );
-          },
-          child: Stack(
-            // The Stack is used to loosen the constraints of
-            // the UseCaseBuilder. Without the Stack, UseCaseBuilder
-            // would expand to the whole size of the Workbench.
-            children: [
-              UseCaseBuilder(
-                key: ValueKey(state.uri),
-                builder: (context) {
-                  return WidgetbookState.of(context)
-                          .useCase
-                          ?.builder(context) ??
-                      const SizedBox.shrink();
-                },
-              )
-            ],
+              return addon.buildUseCase(
+                context,
+                child,
+                newSetting,
+              );
+            },
+            child: Stack(
+              // The Stack is used to loosen the constraints of
+              // the UseCaseBuilder. Without the Stack, UseCaseBuilder
+              // would expand to the whole size of the Workbench.
+              children: [
+                UseCaseBuilder(
+                  key: ValueKey(state.uri),
+                  builder: (context) {
+                    return WidgetbookState.of(context)
+                            .useCase
+                            ?.builder(context) ??
+                        const SizedBox.shrink();
+                  },
+                )
+              ],
+            ),
           ),
         ),
       ),

--- a/sandbox/lib/widgetbook.dart
+++ b/sandbox/lib/widgetbook.dart
@@ -21,6 +21,13 @@ class WidgetbookApp extends StatelessWidget {
         WidgetbookCloudIntegration(),
       ],
       addons: [
+        DeviceFrameAddon(
+          devices: [
+            Devices.ios.iPhoneSE,
+            Devices.ios.iPhone12,
+            Devices.ios.iPhone13,
+          ],
+        ),
         MaterialThemeAddon(
           themes: [
             WidgetbookTheme(
@@ -33,6 +40,7 @@ class WidgetbookApp extends StatelessWidget {
             ),
           ],
         ),
+        AlignmentAddon(),
         TextScaleAddon(
           scales: [1.0, 2.0],
         ),
@@ -45,14 +53,6 @@ class WidgetbookApp extends StatelessWidget {
             DefaultMaterialLocalizations.delegate,
           ],
         ),
-        DeviceFrameAddon(
-          devices: [
-            Devices.ios.iPhoneSE,
-            Devices.ios.iPhone12,
-            Devices.ios.iPhone13,
-          ],
-        ),
-        AlignmentAddon(),
       ],
     );
   }


### PR DESCRIPTION
When device frame is active, the background area used to match the `ThemeAddon`'s active theme.
This PR uses the Widgetbook theme for the background color.

| Before | After |
| :---: |  :---: |
| ![Screenshot 2023-06-30 at 6 42 31 PM](https://github.com/widgetbook/widgetbook/assets/41103290/aabaaa59-a53f-4446-af8c-687bcc52b43c) | ![Screenshot 2023-06-30 at 6 41 07 PM](https://github.com/widgetbook/widgetbook/assets/41103290/26102dac-1974-4b81-9fb4-ac49c80a0c95) |
