### PR TITLE
docs: corrected the name of the file created by build_runner

### DIFF
--- a/docs/addons/overview.mdx
+++ b/docs/addons/overview.mdx
@@ -74,7 +74,7 @@ import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 import 'package:widgetbook_core/widgetbook_core.dart';
 
-import 'widgetbook.g.dart';
+import 'widgetbook.directories.g.dart';
 
 void main() {
   runApp(const WidgetbookApp());

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -71,7 +71,7 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 @widgetbook.App()
 ```
 
-2. The generator will create a `widgetbook.g.dart` file in the same directory as
+2. The generator will create a `widgetbook.directories.g.dart` file in the same directory as
    the annotated file. This file will contain a directories variable.
 
 ```bash
@@ -79,19 +79,19 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 ├─ lib
 ├ ├─ main.dart
 ├ ├─ widgetbook.dart
-├ ├─ widgetbook.g.dart
+├ ├─ widgetbook.directories.g.dart
 ├─ pubspec.yaml
 ```
 
-3. Import the `widgetbook.g.dart` file into your `widgetbook.dart` file or any
+3. Import the `widgetbook.directories.g.dart` file into your `widgetbook.dart` file or any
    other file where you set up your Widgetbook.
 
 ```dart
-import 'widgetbook.g.dart';
+import 'widgetbook.directories.g.dart';
 ```
 
 4. Set up your Widgetbook as usual. For the `directories` property, use the
-   generated directories variable from the `widgetbook.g.dart` file. For
+   generated directories variable from the `widgetbook.directories.g.dart` file. For
    instance, you can define and launch your Widgetbook app as follows:
 
 ```dart
@@ -102,7 +102,7 @@ import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
 // Import the generated directories variable
-import 'widgetbook.g.dart';
+import 'widgetbook.directories.g.dart';
 
 void main() {
   runApp(const WidgetbookApp());


### PR DESCRIPTION
Renames all instances of `widgetbook.g.dart` to `widgetbook.directories.g.dart` within the documentation. 

### List of issues that are fixed by the PR
- closes #807 