### PR TITLE
docs: remove `appBuilder` from material example

### DIFF
--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -118,9 +118,6 @@ class WidgetbookApp extends StatelessWidget {
       // Use the generated directories variable
       directories: directories,
       addons: [],
-      appBuilder: (context, child) {
-        return child;
-      },
     );
   }
 }


### PR DESCRIPTION
- removes the `appBuilder` from the material example as this will remove the `MaterialApp` widget from the tree. In my opinion, this is required to display Material themes properly. 