### PR TITLE
fix: ensure widget is mounted on change

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ - **FIX**: Ensure widget is mounted on change. ([#814](https://github.com/widgetbook/widgetbook/pull/814))
+
 ## 3.1.0
 
  - **FEAT**: Add Alignment Addon. ([#798](https://github.com/widgetbook/widgetbook/pull/798))

--- a/packages/widgetbook/lib/src/workbench/use_case_builder.dart
+++ b/packages/widgetbook/lib/src/workbench/use_case_builder.dart
@@ -22,7 +22,9 @@ class _UseCaseBuilderState extends State<UseCaseBuilder> {
     // Notify that the use case finished building,
     // to rebuild the use case with all registered knobs
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      WidgetbookState.of(context).notifyKnobsReady();
+      if (mounted) {
+        WidgetbookState.of(context).notifyKnobsReady();
+      }
     });
   }
 


### PR DESCRIPTION
While working on conditional addon availability (https://github.com/widgetbook/widgetbook/issues/811) I've encountered an assertion violation in `UseCaseBuilder` when the addon changes its behavior. And actually there's an existing issue logged about this already

```
The following assertion was thrown during a scheduler callback:
This widget has been unmounted, so the State no longer has a context (and should be considered defunct). 

Consider canceling any active work during "dispose" or using the "mounted" getter to determine if the State is still active.
When the exception was thrown, this was the stack: 
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 288:49      throw_
packages/flutter/src/widgets/framework.dart 951:9                                 <fn>
packages/flutter/src/widgets/framework.dart 956:14                                get context
packages/widgetbook/src/workbench/use_case_builder.dart 25:26                     <fn>
```

### List of issues which are fixed by the PR
https://github.com/widgetbook/widgetbook/issues/779

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] _Irrelevant_ I updated/added relevant documentation (doc comments with `///`).
- [ ] _Irrelevant_ I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
