### PR TITLE
fix: correct `listOrNull` knob type cast

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -2,6 +2,7 @@
 
  - **FIX**: Ensure widget is mounted on change. ([#814](https://github.com/widgetbook/widgetbook/pull/814))
  - **FIX**: Allow commas in `string` knobs. ([#817](https://github.com/widgetbook/widgetbook/pull/817))
+ - **FIX**: Correct `listOrNull` knob type cast. ([#818](https://github.com/widgetbook/widgetbook/pull/818))
 
 ## 3.1.0
 

--- a/packages/widgetbook/lib/src/knobs/list_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/list_knob.dart
@@ -74,6 +74,6 @@ class ListOrNullKnob<T> extends Knob<T?> {
 
   @override
   T? valueFromQueryGroup(Map<String, String> group) {
-    return valueOf(label, group);
+    return valueOf<T?>(label, group);
   }
 }


### PR DESCRIPTION
Use explicit type casting instead of implicit one.