### PR TITLE
fix(generator): resolve "asset:" imports

### DIFF
--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+ - **FIX**: Resolve "asset:" imports. ([#819](https://github.com/widgetbook/widgetbook/pull/819))
  - **FIX**: Remove unused imports. ([#786](https://github.com/widgetbook/widgetbook/pull/786))
 
 ## 3.0.0

--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   glob: ^2.0.2
   json_annotation: ^4.8.0
   meta: ^1.7.0
+  path: ^1.8.0
   source_gen: ^1.1.0
   widgetbook_annotation: ^3.0.0
 


### PR DESCRIPTION
When a use-case file exists outside the `lib` directory, the import statement starts with `asset:` instead of `package:`, which causes the use-case method to not be imported properly. This usually happens with users who define their use-cases inside `test` or `widgetbook` folders.

To fix this issue, the user must move the `widgetbook.dart` file to the folder containing the use-cases' definition, and all `asset:` imports will be converted to relative ones.