### PR TITLE
refactor: deprecate `WidgetbookUseCase.center`

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+ - **REFACTOR**: Deprecate `WidgetbookUseCase.center` in favor of [AlignmentAddon]. ([#826](https://github.com/widgetbook/widgetbook/pull/826))
  - **FIX**: Ensure widget is mounted on change. ([#814](https://github.com/widgetbook/widgetbook/pull/814))
  - **FIX**: Allow commas in `string` knobs. ([#817](https://github.com/widgetbook/widgetbook/pull/817))
  - **FIX**: Correct `listOrNull` knob type cast. ([#818](https://github.com/widgetbook/widgetbook/pull/818))

--- a/packages/widgetbook/lib/src/navigation/directories/widgetbook_use_case.dart
+++ b/packages/widgetbook/lib/src/navigation/directories/widgetbook_use_case.dart
@@ -15,6 +15,11 @@ class WidgetbookUseCase extends LeafNavigationNodeData {
           data: builder,
         );
 
+  @Deprecated(
+    'Use [AlignmentAddon] instead to '
+    'control your use-cases alignment. '
+    'For more info: https://docs.widgetbook.io/addons/alignment-addon',
+  )
   factory WidgetbookUseCase.center({
     required String name,
     required Widget child,


### PR DESCRIPTION
The `AlignmentAddon` was introduced in #798, which is available in version 3.1.0, and it serves as a better alternative for `WidgetbookUseCase.center`.