### PR TITLE
fix(generator): resolve local packages paths

### DIFF
--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+ - **FIX**: Resolve local packages paths. ([#829](https://github.com/widgetbook/widgetbook/pull/829))
  - **FIX**: Resolve "asset:" imports. ([#819](https://github.com/widgetbook/widgetbook/pull/819))
  - **FIX**: Remove unused imports. ([#786](https://github.com/widgetbook/widgetbook/pull/786))
 

--- a/packages/widgetbook_generator/lib/generators/use_case_resolver.dart
+++ b/packages/widgetbook_generator/lib/generators/use_case_resolver.dart
@@ -1,19 +1,31 @@
+import 'dart:io';
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
+import 'package:yaml/yaml.dart';
 
 import '../extensions/element_extensions.dart';
 import '../extensions/json_list_formatter.dart';
 import '../models/widgetbook_use_case_data.dart';
 
 class UseCaseResolver extends GeneratorForAnnotation<UseCase> {
+  final packagesMapResource = Resource<YamlMap>(
+    () async {
+      final lockFile = await File('pubspec.lock').readAsString();
+      final yaml = loadYaml(lockFile) as YamlMap;
+
+      return yaml['packages'] as YamlMap;
+    },
+  );
+
   @override
-  String generateForAnnotatedElement(
+  Future<String> generateForAnnotatedElement(
     Element element,
     ConstantReader annotation,
     BuildStep buildStep,
-  ) {
+  ) async {
     if (element.isPrivate) {
       throw InvalidGenerationSourceError(
         'Widgetbook annotations cannot be applied to private methods',
@@ -41,8 +53,6 @@ class UseCaseResolver extends GeneratorForAnnotation<UseCase> {
           '',
         );
 
-    final componentDefinitionPath = typeValue.element!.librarySource!.fullName;
-
     final data = WidgetbookUseCaseData(
       name: element.name!,
       useCaseName: useCaseName,
@@ -50,11 +60,47 @@ class UseCaseResolver extends GeneratorForAnnotation<UseCase> {
       importStatement: element.importStatement,
       componentImportStatement: typeElement.importStatement,
       dependencies: typeElement.dependencies,
-      componentDefinitionPath: componentDefinitionPath,
-      useCaseDefinitionPath: element.librarySource!.fullName,
+      componentDefinitionPath: await resolveElementPath(typeElement, buildStep),
+      useCaseDefinitionPath: await resolveElementPath(element, buildStep),
       designLink: designLink,
     );
 
     return [data].toJson();
+  }
+
+  /// This method resolves the path of a local package by retrieving
+  /// the path from the `pubspec.lock` file because its name might not
+  /// match its path.
+  ///
+  /// Example:
+  /// A package with the name "shared_package" could be located in
+  /// a folder named "shared". The path of the [element] would be
+  /// `/shared_package/lib/...` which is not an actual path and should
+  /// be resolved into `/shared/lib/...`.
+  ///
+  /// See also:
+  /// - [#791](https://github.com/widgetbook/widgetbook/issues/791)
+  Future<String> resolveElementPath(
+    Element element,
+    BuildStep buildStep,
+  ) async {
+    final path = element.librarySource!.fullName;
+    final packageName = element.librarySource!.uri.pathSegments[0];
+    final resource = await buildStep.fetchResource(packagesMapResource);
+
+    // In case the package is the same as the `pubsec.lock` file's.
+    if (!resource.containsKey(packageName)) return path;
+
+    final packageData = resource[packageName] as YamlMap;
+    final isLocalPackage = packageData['source'] == 'path';
+
+    if (!isLocalPackage) return path;
+
+    final packagePath = packageData['description']['path'] as String;
+
+    return path.replaceFirst(
+      RegExp(packageName),
+      packagePath,
+    );
   }
 }

--- a/packages/widgetbook_generator/lib/generators/use_case_resolver.dart
+++ b/packages/widgetbook_generator/lib/generators/use_case_resolver.dart
@@ -110,10 +110,14 @@ class UseCaseResolver extends GeneratorForAnnotation<UseCase> {
     if (!isLocalPackage) return elementPath;
 
     final packagePath = packageData['description']['path'] as String;
+    final normalizedPackagePath = packagePath.replaceAll(
+      RegExp(r'(\.)?\.\/'), // Match "./" and "../"
+      '',
+    );
 
     return elementPath.replaceFirst(
       RegExp(elementPackage),
-      packagePath,
+      normalizedPackagePath,
     );
   }
 }

--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   path: ^1.8.0
   source_gen: ^1.1.0
   widgetbook_annotation: ^3.0.0
+  yaml: ^3.1.2
 
 dev_dependencies:
   test: ^1.24.1


### PR DESCRIPTION
The `analyzer` cannot provide the actual paths of files, instead it returns the path as `{package_name}/lib/...`, which can be mismatching when the `package_name` is **not the actual directory** name holding the package.

This mismatch leads into another mismatch within the CLI, when it's comparing **the component path** and the **git diff pathes**, which leads to missing the component changes on Widgetbook Cloud.