### PR TITLE
docs: add `listOrNull` to knobs list

### DIFF
--- a/docs/knobs/overview.mdx
+++ b/docs/knobs/overview.mdx
@@ -78,5 +78,5 @@ Widgetbook's UI:
 | doubleOrNull.slider | `double?` |
 | double.input        | `num`     |
 | doubleOrNull.input  | `num?`    |
-| listOrNull          | `T?`      |
 | list                | `T`       |
+| listOrNull          | `T?`      |

--- a/docs/knobs/overview.mdx
+++ b/docs/knobs/overview.mdx
@@ -78,4 +78,5 @@ Widgetbook's UI:
 | doubleOrNull.slider | `double?` |
 | double.input        | `num`     |
 | doubleOrNull.input  | `num?`    |
+| listOrNull          | `T?`      |
 | list                | `T`       |


### PR DESCRIPTION
According to this PR https://github.com/widgetbook/widgetbook/pull/741/files

we need to add listOrNull to the doc. 


### Checklist

- [ x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing.



<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
