### PR TITLE
refactor(generator): support analyzer 6.x

### DIFF
--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+ - **REFACTOR**: Support `analyzer` v6.x. ([#841](https://github.com/widgetbook/widgetbook/pull/841))
  - **FIX**: Resolve local packages paths. ([#829](https://github.com/widgetbook/widgetbook/pull/829))
  - **FIX**: Resolve "asset:" imports. ([#819](https://github.com/widgetbook/widgetbook/pull/819))
  - **FIX**: Remove unused imports. ([#786](https://github.com/widgetbook/widgetbook/pull/786))

--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
-  analyzer: ^5.10.0
+  analyzer: ">=5.10.0 <7.0.0"
   build: ^2.1.0
   collection: ^1.15.0
   glob: ^2.0.2


### PR DESCRIPTION
Support both v5 and v6 of `package:analyzer`.