### PR TITLE
chore(generator): enforce `widgetbook` min version

### DIFF
--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+ - **REFACTOR**: Enforce `widgetbook` package minimum version (v3.1.0). ([#842](https://github.com/widgetbook/widgetbook/pull/842))
  - **REFACTOR**: Support `analyzer` v6.x. ([#841](https://github.com/widgetbook/widgetbook/pull/841))
  - **FIX**: Add type to `directories` list. ([#836](https://github.com/widgetbook/widgetbook/pull/836))
  - **FIX**: Resolve local packages paths. ([#829](https://github.com/widgetbook/widgetbook/pull/829))

--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   meta: ^1.7.0
   path: ^1.8.0
   source_gen: ^1.1.0
+  widgetbook: ^3.1.0
   widgetbook_annotation: ^3.0.0
   yaml: ^3.1.2
 


### PR DESCRIPTION
Since the next version of `widgetbook_generator` will only work with the next version of `widgetbook` (due to #836), a version constraint is added to enforce the version dependency.