### PR TITLE
refactor: update `DropdownMenu` theme

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+ - **REFACTOR**: Update `DropdownMenu` theme. ([#844](https://github.com/widgetbook/widgetbook/pull/844))
  - **REFACTOR**: Make `appBuilder` optional. ([#843](https://github.com/widgetbook/widgetbook/pull/843))
  - **REFACTOR**: Replace `MultiChildNavigationData` with `WidgetbookNode`. ([#833](https://github.com/widgetbook/widgetbook/pull/833))
  - **REFACTOR**: Deprecate `WidgetbookUseCase.center` in favor of [AlignmentAddon]. ([#826](https://github.com/widgetbook/widgetbook/pull/826))

--- a/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
+++ b/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
@@ -39,8 +39,15 @@ abstract class WidgetbookAddon<T> extends FieldsComposable<T> {
       name: name,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: fields //
-            .map((field) => field.build(context, groupName))
+        children: fields
+            .map(
+              (field) => Padding(
+                padding: const EdgeInsets.symmetric(
+                  vertical: 4.0,
+                ),
+                child: field.build(context, groupName),
+              ),
+            )
             .toList(),
       ),
     );

--- a/packages/widgetbook/lib/src/knobs/knob.dart
+++ b/packages/widgetbook/lib/src/knobs/knob.dart
@@ -46,8 +46,15 @@ abstract class Knob<T> extends FieldsComposable<T> {
       },
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: fields //
-            .map((field) => field.build(context, groupName))
+        children: fields
+            .map(
+              (field) => Padding(
+                padding: const EdgeInsets.symmetric(
+                  vertical: 4.0,
+                ),
+                child: field.build(context, groupName),
+              ),
+            )
             .toList(),
       ),
     );

--- a/packages/widgetbook/lib/src/navigation/widgets/search_field.dart
+++ b/packages/widgetbook/lib/src/navigation/widgets/search_field.dart
@@ -29,28 +29,25 @@ class _SearchFieldState extends State<SearchField> {
 
   @override
   Widget build(BuildContext context) {
+    final border = OutlineInputBorder(
+      borderRadius: BorderRadius.circular(50),
+      borderSide: const BorderSide(
+        color: Colors.transparent,
+        width: 0,
+      ),
+    );
+
     return TextFormField(
       controller: controller,
       focusNode: focusNode,
       onChanged: widget.onChanged,
       decoration: InputDecoration(
         hintText: 'Search',
-        border: OutlineInputBorder(
-          borderSide: const BorderSide(color: Colors.transparent, width: 0),
-          borderRadius: BorderRadius.circular(50),
+        enabledBorder: border,
+        focusedBorder: border,
+        contentPadding: const EdgeInsets.symmetric(
+          vertical: 5,
         ),
-        enabledBorder: OutlineInputBorder(
-          borderSide: const BorderSide(color: Colors.transparent, width: 0),
-          borderRadius: BorderRadius.circular(50),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderSide: const BorderSide(color: Colors.transparent, width: 0),
-          borderRadius: BorderRadius.circular(50),
-        ),
-        filled: true,
-        focusColor: Colors.white,
-        iconColor: Colors.white,
-        contentPadding: const EdgeInsets.symmetric(vertical: 5),
         prefixIcon: const Padding(
           padding: EdgeInsets.all(12),
           child: Icon(Icons.search),

--- a/packages/widgetbook/lib/src/themes.dart
+++ b/packages/widgetbook/lib/src/themes.dart
@@ -34,6 +34,21 @@ class Themes {
     surfaceTint: Color(0xFFA1C9FF),
   );
 
+  static final _inputDecorationTheme = InputDecorationTheme(
+    filled: true,
+    isDense: true,
+    focusedBorder: OutlineInputBorder(
+      borderSide: BorderSide(
+        color: _darkColorScheme.primary,
+      ),
+    ),
+    enabledBorder: const OutlineInputBorder(
+      borderSide: BorderSide(
+        color: Colors.transparent,
+      ),
+    ),
+  );
+
   static ThemeData dark = ThemeData(
     useMaterial3: true,
     brightness: Brightness.dark,
@@ -43,46 +58,9 @@ class Themes {
     sliderTheme: SliderThemeData(
       overlayShape: SliderComponentShape.noThumb,
     ),
-    inputDecorationTheme: InputDecorationTheme(
-      filled: true,
-      isDense: true,
-      fillColor: _darkColorScheme.surfaceVariant,
-      focusedBorder: OutlineInputBorder(
-        borderSide: BorderSide(
-          color: _darkColorScheme.primary,
-        ),
-      ),
-      enabledBorder: const OutlineInputBorder(
-        borderSide: BorderSide(
-          color: Colors.transparent,
-        ),
-      ),
-      border: const OutlineInputBorder(
-        borderSide: BorderSide(
-          color: Colors.transparent,
-        ),
-      ),
-    ),
+    inputDecorationTheme: _inputDecorationTheme,
     dropdownMenuTheme: DropdownMenuThemeData(
-      inputDecorationTheme: InputDecorationTheme(
-        contentPadding: const EdgeInsets.only(left: 24),
-        border: const OutlineInputBorder(
-          borderSide: BorderSide(
-            color: Colors.transparent,
-          ),
-        ),
-        filled: true,
-        fillColor: Colors.transparent,
-        hoverColor: _darkColorScheme.onBackground.withOpacity(0.08),
-        enabledBorder: const OutlineInputBorder(
-          borderSide: BorderSide(color: Colors.transparent),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderSide: BorderSide(
-            color: _darkColorScheme.onBackground.withOpacity(0.12),
-          ),
-        ),
-      ),
+      inputDecorationTheme: _inputDecorationTheme,
     ),
     expansionTileTheme: const ExpansionTileThemeData(
       collapsedShape: RoundedRectangleBorder(),


### PR DESCRIPTION
Match `DropdownMenu` theme with `TextField`.

| Before | After |
|--------|-------|
| <img width="1512" alt="Before" src="https://github.com/widgetbook/widgetbook/assets/41103290/f058023b-b5a7-4fd9-b834-411d2333334e"> | <img width="1512" alt="After" src="https://github.com/widgetbook/widgetbook/assets/41103290/a37e4dbc-b5c2-4749-a09f-b7cdf4f8ca47"> |