### PR TITLE
refactor: support Flutter 3.13.0

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+ - **REFACTOR**: Support Flutter 3.13.0. ([#847](https://github.com/widgetbook/widgetbook/pull/847))
  - **REFACTOR**: Update `DropdownMenu` theme. ([#844](https://github.com/widgetbook/widgetbook/pull/844))
  - **REFACTOR**: Make `appBuilder` optional. ([#843](https://github.com/widgetbook/widgetbook/pull/843))
  - **REFACTOR**: Replace `MultiChildNavigationData` with `WidgetbookNode`. ([#833](https://github.com/widgetbook/widgetbook/pull/833))

--- a/packages/widgetbook/lib/src/routing/app_route_config.dart
+++ b/packages/widgetbook/lib/src/routing/app_route_config.dart
@@ -3,13 +3,12 @@ import 'package:meta/meta.dart';
 @internal
 class AppRouteConfig {
   AppRouteConfig({
-    required this.location,
-  }) : queryParameters = Uri.parse(location).queryParameters;
+    required this.uri,
+  });
 
-  final String location;
-  final Map<String, String> queryParameters;
+  final Uri uri;
 
-  String? get path => queryParameters['path'];
+  String? get path => uri.queryParameters['path'];
 
-  bool get previewMode => queryParameters.containsKey('preview');
+  bool get previewMode => uri.queryParameters.containsKey('preview');
 }

--- a/packages/widgetbook/lib/src/routing/app_route_parser.dart
+++ b/packages/widgetbook/lib/src/routing/app_route_parser.dart
@@ -10,7 +10,7 @@ class AppRouteParser extends RouteInformationParser<AppRouteConfig> {
     RouteInformation routeInformation,
   ) async {
     return AppRouteConfig(
-      location: routeInformation.location ?? '/',
+      uri: routeInformation.uri,
     );
   }
 
@@ -19,7 +19,7 @@ class AppRouteParser extends RouteInformationParser<AppRouteConfig> {
     AppRouteConfig configuration,
   ) {
     return RouteInformation(
-      location: configuration.location,
+      uri: configuration.uri,
     );
   }
 }

--- a/packages/widgetbook/lib/src/routing/app_route_parser.dart
+++ b/packages/widgetbook/lib/src/routing/app_route_parser.dart
@@ -5,12 +5,29 @@ import 'app_route_config.dart';
 
 @internal
 class AppRouteParser extends RouteInformationParser<AppRouteConfig> {
+  /// This allows a value of type T or T?
+  /// to be treated as a value of type T?.
+  ///
+  /// We use this so that APIs that have become
+  /// non-nullable can still be used with `!` and `?`
+  /// to support older versions of the API as well.
+  T? _ambiguate<T>(T? value) => value;
+
   @override
   Future<AppRouteConfig> parseRouteInformation(
     RouteInformation routeInformation,
   ) async {
+    // Not backwards compatible with Flutter < 3.13.0
+    // ignore: deprecated_member_use
+    final location = routeInformation.location;
+
+    // We use [_ambiguate] to support older versions of Flutter,
+    // since [RouteInformation.location] has changed to be non-nullable
+    // in Flutter 3.13.0.
+    final ambiguousLocation = _ambiguate(location);
+
     return AppRouteConfig(
-      uri: routeInformation.uri,
+      uri: Uri.parse(ambiguousLocation ?? '/'),
     );
   }
 
@@ -19,7 +36,9 @@ class AppRouteParser extends RouteInformationParser<AppRouteConfig> {
     AppRouteConfig configuration,
   ) {
     return RouteInformation(
-      uri: configuration.uri,
+      // Not backwards compatible with Flutter < 3.13.0
+      // ignore: deprecated_member_use
+      location: configuration.uri.toString(),
     );
   }
 }

--- a/packages/widgetbook/lib/src/routing/app_router.dart
+++ b/packages/widgetbook/lib/src/routing/app_router.dart
@@ -15,7 +15,9 @@ class AppRouter extends RouterConfig<AppRouteConfig> {
           routeInformationParser: AppRouteParser(),
           routeInformationProvider: PlatformRouteInformationProvider(
             initialRouteInformation: RouteInformation(
-              uri: Uri.parse(initialRoute),
+              // Not backwards compatible with Flutter < 3.13.0
+              // ignore: deprecated_member_use
+              location: initialRoute,
             ),
           ),
           routerDelegate: AppRouterDelegate(

--- a/packages/widgetbook/lib/src/routing/app_router.dart
+++ b/packages/widgetbook/lib/src/routing/app_router.dart
@@ -15,7 +15,7 @@ class AppRouter extends RouterConfig<AppRouteConfig> {
           routeInformationParser: AppRouteParser(),
           routeInformationProvider: PlatformRouteInformationProvider(
             initialRouteInformation: RouteInformation(
-              location: initialRoute,
+              uri: Uri.parse(initialRoute),
             ),
           ),
           routerDelegate: AppRouterDelegate(

--- a/packages/widgetbook/lib/src/routing/app_router_delegate.dart
+++ b/packages/widgetbook/lib/src/routing/app_router_delegate.dart
@@ -14,7 +14,7 @@ class AppRouterDelegate extends RouterDelegate<AppRouteConfig>
     required this.state,
   })  : _navigatorKey = GlobalKey<NavigatorState>(),
         _configuration = AppRouteConfig(
-          location: initialRoute,
+          uri: Uri.parse(initialRoute),
         );
 
   final String initialRoute;

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -77,7 +77,9 @@ class WidgetbookState extends ChangeNotifier {
   /// Syncs this with the router's location using [SystemNavigator].
   void _syncRouteInformation() {
     SystemNavigator.routeInformationUpdated(
-      uri: uri,
+      // Not backwards compatible with Flutter < 3.13.0
+      // ignore: deprecated_member_use
+      location: uri.toString(),
     );
   }
 

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -77,7 +77,7 @@ class WidgetbookState extends ChangeNotifier {
   /// Syncs this with the router's location using [SystemNavigator].
   void _syncRouteInformation() {
     SystemNavigator.routeInformationUpdated(
-      location: uri.toString(),
+      uri: uri,
     );
   }
 
@@ -146,7 +146,7 @@ class WidgetbookState extends ChangeNotifier {
     previewMode = routeConfig.previewMode;
     queryParams = {
       // Copy from UnmodifiableMap
-      ...routeConfig.queryParameters
+      ...routeConfig.uri.queryParameters,
     }
       ..remove('path')
       ..remove('preview');

--- a/packages/widgetbook/test/src/routing/app_route_config_test.dart
+++ b/packages/widgetbook/test/src/routing/app_route_config_test.dart
@@ -10,11 +10,11 @@ void main() {
         'then query parameters are parsed',
         () {
           final config = AppRouteConfig(
-            location: '/?foo=bar&baz=qux',
+            uri: Uri.parse('/?foo=bar&baz=qux'),
           );
 
           expect(
-            config.queryParameters,
+            config.uri.queryParameters,
             {
               'foo': 'bar',
               'baz': 'qux',
@@ -28,7 +28,7 @@ void main() {
         'then path is extracted',
         () {
           final config = AppRouteConfig(
-            location: '/?path=component-x&baz=qux',
+            uri: Uri.parse('/?path=component-x&baz=qux'),
           );
 
           expect(config.path, 'component-x');
@@ -40,7 +40,7 @@ void main() {
         'then preview mode is extracted',
         () {
           final config = AppRouteConfig(
-            location: '/?path=component-x&preview',
+            uri: Uri.parse('/?path=component-x&preview'),
           );
 
           expect(config.previewMode, true);

--- a/packages/widgetbook/test/src/routing/app_router_delegate_test.dart
+++ b/packages/widgetbook/test/src/routing/app_router_delegate_test.dart
@@ -14,7 +14,7 @@ void main() {
         'given an initial route, '
         'then the current configuration has the exact location',
         () {
-          const initialLocation = '/path=use-case';
+          const initialLocation = '/?path=use-case';
 
           final delegate = AppRouterDelegate(
             initialRoute: initialLocation,
@@ -22,7 +22,7 @@ void main() {
           );
 
           expect(
-            delegate.currentConfiguration!.location,
+            delegate.currentConfiguration!.uri.toString(),
             initialLocation,
           );
         },
@@ -35,7 +35,7 @@ void main() {
         () {
           final state = MockWidgetbookState();
           final config = AppRouteConfig(
-            location: '/path=use-case',
+            uri: Uri.parse('/?path=use-case'),
           );
 
           final delegate = AppRouterDelegate(

--- a/packages/widgetbook/test/src/state/widgetbook_state_test.dart
+++ b/packages/widgetbook/test/src/state/widgetbook_state_test.dart
@@ -140,7 +140,7 @@ void main() {
 
           const path = 'component/use-case';
           final routeConfig = AppRouteConfig(
-            location: '/?path=$path&foo=bar&preview',
+            uri: Uri.parse('/?path=$path&foo=bar&preview'),
           );
 
           state.updateFromRouteConfig(routeConfig);


### PR DESCRIPTION
This PR makes Widgetbook work with **Flutter 3.13.0**, by:

 1. Ignoring* the [deprecated](https://docs.flutter.dev/release/breaking-changes/route-information-uri) member `RouteInformation.location`.
 1. Resolving the type-conflict happened from changing `RouteInformation.location` type from `String?` (in < 3.13.0) to `String` (in 3.13.0).

*We cannot fully migrate to `RouteInformation.uri` because it will not be backwards compatible with all Flutter versions prior to 3.13.0. That's why we do a partial migration by converting `AppRouteConfig.location` to `AppRouteConfig.uri`, to make it easier in the future to do the full migration once we drop support to old Flutter versions.

