### PR TITLE
ci: make analyzer's infos fatal

### DIFF
--- a/.github/workflows/_package.yml
+++ b/.github/workflows/_package.yml
@@ -63,7 +63,7 @@ jobs:
         run: dart format --set-exit-if-changed .
 
       - name: Analyze
-        run: dart analyze .
+        run: dart analyze . --fatal-infos
 
       - name: Run Tests
         run: flutter test --coverage


### PR DESCRIPTION
It's all about equality 🌟
Treat infos and warnings the same.
