### PR TITLE
refactor: remove *-`OrNullKnob` classes

### DIFF
--- a/packages/widgetbook/lib/src/knobs/boolean_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/boolean_knob.dart
@@ -5,40 +5,18 @@ import '../state/state.dart';
 import 'knob.dart';
 
 @internal
-class BooleanKnob extends Knob<bool> {
+class BooleanKnob extends Knob<bool?> {
   BooleanKnob({
     required super.label,
     required super.value,
     super.description,
   });
 
-  @override
-  List<Field> get fields {
-    return [
-      BooleanField(
-        name: label,
-        initialValue: value,
-        onChanged: (context, value) {
-          if (value == null) return;
-          WidgetbookState.of(context).updateKnobValue(label, value);
-        },
-      ),
-    ];
-  }
-
-  @override
-  bool valueFromQueryGroup(Map<String, String> group) {
-    return valueOf(label, group)!;
-  }
-}
-
-@internal
-class BooleanOrNullKnob extends Knob<bool?> {
-  BooleanOrNullKnob({
+  BooleanKnob.nullable({
     required super.label,
     required super.value,
     super.description,
-  });
+  }) : super(isNullable: true);
 
   @override
   List<Field> get fields {

--- a/packages/widgetbook/lib/src/knobs/builders/double_knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/double_knobs_builder.dart
@@ -66,8 +66,8 @@ class DoubleOrNullKnobsBuilder {
     int? divisions,
   }) {
     initialValue ??= max ?? min ?? 10;
-    return onKnobAdded<double?>(
-      DoubleOrNullSliderKnob(
+    return onKnobAdded(
+      DoubleSliderKnob.nullable(
         label: label,
         value: initialValue,
         description: description,
@@ -86,8 +86,8 @@ class DoubleOrNullKnobsBuilder {
     String? description,
     double? initialValue,
   }) {
-    return onKnobAdded<double?>(
-      DoubleOrNullInputKnob(
+    return onKnobAdded(
+      DoubleInputKnob.nullable(
         label: label,
         value: initialValue,
         description: description,

--- a/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
@@ -8,7 +8,7 @@ import '../list_knob.dart';
 import '../string_knob.dart';
 import 'double_knobs_builder.dart';
 
-typedef KnobAdded = T? Function<T>(Knob<T> knob);
+typedef KnobAdded = T? Function<T>(Knob<T?> knob);
 
 class KnobsBuilder {
   KnobsBuilder(
@@ -42,8 +42,8 @@ class KnobsBuilder {
     String? description,
     bool? initialValue = false,
   }) {
-    return onKnobAdded<bool?>(
-      BooleanOrNullKnob(
+    return onKnobAdded(
+      BooleanKnob.nullable(
         label: label,
         description: description,
         value: initialValue,
@@ -91,8 +91,8 @@ class KnobsBuilder {
     String? initialValue,
     int? maxLines = 1,
   }) {
-    return onKnobAdded<String?>(
-      StringOrNullKnob(
+    return onKnobAdded(
+      StringKnob.nullable(
         label: label,
         value: initialValue,
         description: description,
@@ -132,8 +132,8 @@ class KnobsBuilder {
     LabelBuilder<T?>? labelBuilder,
   }) {
     assert(options.isNotEmpty, 'Must specify at least one option');
-    return onKnobAdded<T?>(
-      ListOrNullKnob<T>(
+    return onKnobAdded(
+      ListKnob<T?>.nullable(
         label: label,
         value: initialOption ?? options.first,
         description: description,

--- a/packages/widgetbook/lib/src/knobs/double_input_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/double_input_knob.dart
@@ -5,40 +5,18 @@ import '../state/widgetbook_state.dart';
 import 'knob.dart';
 
 @internal
-class DoubleInputKnob extends Knob<double> {
+class DoubleInputKnob extends Knob<double?> {
   DoubleInputKnob({
     required super.label,
     required super.value,
     super.description,
   });
 
-  @override
-  List<Field> get fields {
-    return [
-      DoubleInputField(
-        name: label,
-        initialValue: value,
-        onChanged: (context, value) {
-          if (value == null) return;
-          WidgetbookState.of(context).updateKnobValue(label, value);
-        },
-      ),
-    ];
-  }
-
-  @override
-  double valueFromQueryGroup(Map<String, String> group) {
-    return valueOf(label, group)!;
-  }
-}
-
-@internal
-class DoubleOrNullInputKnob extends Knob<double?> {
-  DoubleOrNullInputKnob({
+  DoubleInputKnob.nullable({
     required super.label,
     required super.value,
     super.description,
-  });
+  }) : super(isNullable: true);
 
   @override
   List<Field> get fields {

--- a/packages/widgetbook/lib/src/knobs/double_slider_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/double_slider_knob.dart
@@ -5,7 +5,7 @@ import '../state/state.dart';
 import 'knob.dart';
 
 @internal
-class DoubleSliderKnob extends Knob<double> {
+class DoubleSliderKnob extends Knob<double?> {
   DoubleSliderKnob({
     required super.label,
     required super.value,
@@ -15,43 +15,14 @@ class DoubleSliderKnob extends Knob<double> {
     this.divisions,
   });
 
-  final double max;
-  final double min;
-  final int? divisions;
-
-  @override
-  List<Field> get fields {
-    return [
-      DoubleSliderField(
-        name: label,
-        initialValue: value,
-        min: min,
-        max: max,
-        divisions: divisions,
-        onChanged: (context, value) {
-          if (value == null) return;
-          WidgetbookState.of(context).updateKnobValue(label, value);
-        },
-      ),
-    ];
-  }
-
-  @override
-  double valueFromQueryGroup(Map<String, String> group) {
-    return valueOf(label, group)!;
-  }
-}
-
-@internal
-class DoubleOrNullSliderKnob extends Knob<double?> {
-  DoubleOrNullSliderKnob({
+  DoubleSliderKnob.nullable({
     required super.label,
-    required double super.value,
+    required super.value,
     super.description,
     this.max = 1,
     this.min = 0,
     this.divisions,
-  });
+  }) : super(isNullable: true);
 
   final double max;
   final double min;

--- a/packages/widgetbook/lib/src/knobs/knob.dart
+++ b/packages/widgetbook/lib/src/knobs/knob.dart
@@ -10,8 +10,9 @@ import '../state/state.dart';
 abstract class Knob<T> extends FieldsComposable<T> {
   Knob({
     required this.label,
-    required this.value,
     this.description,
+    required this.value,
+    this.isNullable = false,
     @Deprecated(
       'This parameter is not used anymore. '
       'It defaults to [value == null] instead of [false]',
@@ -21,28 +22,28 @@ abstract class Knob<T> extends FieldsComposable<T> {
     this.isNull = value == null;
   }
 
-  /// This is the current value the knob is set to
-  T value;
-
-  /// This is a description the user can put on the knob
-  final String? description;
-
-  /// This is the label that's put above a knob
+  /// The label that's put above a knob.
   final String label;
 
-  bool isNull;
+  /// The Description of what the user can put on the knob.
+  final String? description;
 
-  bool get isNullable => null is T;
+  /// The current value the knob is set to.
+  T value;
+
+  final bool isNullable;
+
+  bool isNull;
 
   @override
   String get groupName => 'knobs';
 
   @override
   Widget buildFields(BuildContext context) {
-    return KnobProperty<T>(
+    return KnobProperty<T?>(
       name: label,
       description: description,
-      value: value,
+      value: isNull ? null : value,
       isNullable: isNullable,
       changedNullable: (isEnabled) {
         WidgetbookState.of(context).updateKnobNullability(

--- a/packages/widgetbook/lib/src/knobs/list_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/list_knob.dart
@@ -5,7 +5,7 @@ import '../state/state.dart';
 import 'knob.dart';
 
 @internal
-class ListKnob<T> extends Knob<T> {
+class ListKnob<T> extends Knob<T?> {
   ListKnob({
     required super.label,
     required super.value,
@@ -13,6 +13,14 @@ class ListKnob<T> extends Knob<T> {
     super.description,
     this.labelBuilder,
   });
+
+  ListKnob.nullable({
+    required super.label,
+    required super.value,
+    required this.options,
+    super.description,
+    this.labelBuilder,
+  }) : super(isNullable: true);
 
   final List<T> options;
   final LabelBuilder<T>? labelBuilder;
@@ -38,42 +46,7 @@ class ListKnob<T> extends Knob<T> {
   }
 
   @override
-  T valueFromQueryGroup(Map<String, String> group) {
-    return valueOf(label, group)!;
-  }
-}
-
-@internal
-class ListOrNullKnob<T> extends Knob<T?> {
-  ListOrNullKnob({
-    required super.label,
-    required super.value,
-    required this.options,
-    super.description,
-    this.labelBuilder,
-  });
-
-  final List<T?> options;
-  final LabelBuilder<T?>? labelBuilder;
-
-  @override
-  List<Field> get fields {
-    return [
-      ListField<T?>(
-        name: label,
-        values: options,
-        initialValue: value,
-        labelBuilder: labelBuilder,
-        onChanged: (context, value) {
-          if (value == null) return;
-          WidgetbookState.of(context).updateKnobValue<T>(label, value);
-        },
-      ),
-    ];
-  }
-
-  @override
   T? valueFromQueryGroup(Map<String, String> group) {
-    return valueOf<T?>(label, group);
+    return valueOf(label, group);
   }
 }

--- a/packages/widgetbook/lib/src/knobs/string_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/string_knob.dart
@@ -5,7 +5,7 @@ import '../state/state.dart';
 import 'knob.dart';
 
 @internal
-class StringKnob extends Knob<String> {
+class StringKnob extends Knob<String?> {
   StringKnob({
     required super.label,
     required super.value,
@@ -13,37 +13,12 @@ class StringKnob extends Knob<String> {
     this.maxLines,
   });
 
-  final int? maxLines;
-
-  @override
-  List<Field> get fields {
-    return [
-      StringField(
-        name: label,
-        initialValue: value,
-        maxLines: maxLines,
-        onChanged: (context, value) {
-          if (value == null) return;
-          WidgetbookState.of(context).updateKnobValue(label, value);
-        },
-      ),
-    ];
-  }
-
-  @override
-  String valueFromQueryGroup(Map<String, String> group) {
-    return valueOf(label, group)!;
-  }
-}
-
-@internal
-class StringOrNullKnob extends Knob<String?> {
-  StringOrNullKnob({
+  StringKnob.nullable({
     required super.label,
     required super.value,
     super.description,
     this.maxLines,
-  });
+  }) : super(isNullable: true);
 
   final int? maxLines;
 

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -114,7 +114,7 @@ class WidgetbookState extends ChangeNotifier {
   }
 
   @internal
-  T? registerKnob<T>(Knob<T> knob) {
+  T? registerKnob<T>(Knob<T?> knob) {
     final cachedKnob = knobs.putIfAbsent(
       knob.label,
       () => knob,
@@ -122,7 +122,7 @@ class WidgetbookState extends ChangeNotifier {
 
     // Return `null` even if the knob has value, but it was marked as null
     // using [updateKnobNullability].
-    if (cachedKnob.isNull) return null;
+    if (cachedKnob.isNullable && cachedKnob.isNull) return null;
 
     final knobsQueryGroup = FieldCodec.decodeQueryGroup(queryParams['knobs']);
 

--- a/packages/widgetbook/lib/widgetbook.dart
+++ b/packages/widgetbook/lib/widgetbook.dart
@@ -8,16 +8,11 @@ export 'src/integrations/integrations.dart';
 export 'src/knobs/knobs.dart'
     hide
         BooleanKnob,
-        BooleanOrNullKnob,
         ColorKnob,
         DoubleInputKnob,
-        DoubleOrNullInputKnob,
-        DoubleOrNullSliderKnob,
         DoubleSliderKnob,
         ListKnob,
-        ListOrNullKnob,
-        StringKnob,
-        StringOrNullKnob;
+        StringKnob;
 export 'src/navigation/nodes/nodes.dart';
 export 'src/state/state.dart' hide WidgetbookScope;
 export 'src/widgetbook.dart';

--- a/packages/widgetbook/test/src/knobs/boolean_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/boolean_knob_test.dart
@@ -33,7 +33,7 @@ void main() {
   );
 
   group(
-    '$BooleanOrNullKnob',
+    '$BooleanKnob.nullable',
     () {
       testWidgets(
         'when field is updated, '

--- a/packages/widgetbook/test/src/knobs/knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/knob_test.dart
@@ -1,14 +1,16 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widgetbook/src/settings/knob_property.dart';
 import 'package:widgetbook/widgetbook.dart';
 
 import '../../helper/helper.dart';
 
-class MockKnob extends Knob<bool> {
+class MockKnob extends Knob<bool?> {
   MockKnob({
     required super.label,
     super.value = true,
     super.description,
+    super.isNullable = false,
   });
 
   @override
@@ -21,23 +23,23 @@ class MockKnob extends Knob<bool> {
 }
 
 void main() {
-  final knob = MockKnob(
-    label: 'Mock Knob',
-    description: 'Knob Description',
-  );
-
   group(
     '$Knob',
     () {
       testWidgets(
         'then it should build a [KnobProperty]',
         (tester) async {
+          final knob = MockKnob(
+            label: 'Mock Knob',
+            description: 'Knob Description',
+          );
+
           await tester.pumpKnob(
             (context) => knob.buildFields(context),
           );
 
           expect(
-            find.byType(KnobProperty<bool>),
+            find.byType(KnobProperty<bool?>),
             findsOneWidget,
           );
         },
@@ -54,6 +56,56 @@ void main() {
           expect(
             firstKnob,
             isNot(equals(secondKnob)),
+          );
+        },
+      );
+
+      testWidgets(
+        'given a nullable knob with a null value, '
+        'then it should build a [KnobProperty] with a uncheck checkbox',
+        (tester) async {
+          final knob = MockKnob(
+            label: 'Mock Knob',
+            isNullable: true,
+            value: null,
+          );
+
+          await tester.pumpKnob(
+            (context) => knob.buildFields(context),
+          );
+
+          final checkbox = tester.widget<Checkbox>(
+            find.byType(Checkbox),
+          );
+
+          expect(
+            checkbox.value,
+            false,
+          );
+        },
+      );
+
+      testWidgets(
+        'given a nullable knob with a value, '
+        'then it should build a [KnobProperty] with a checked checkbox',
+        (tester) async {
+          final knob = MockKnob(
+            label: 'Mock Knob',
+            isNullable: true,
+            value: false,
+          );
+
+          await tester.pumpKnob(
+            (context) => knob.buildFields(context),
+          );
+
+          final checkbox = tester.widget<Checkbox>(
+            find.byType(Checkbox),
+          );
+
+          expect(
+            checkbox.value,
+            true,
           );
         },
       );

--- a/packages/widgetbook/test/src/knobs/string_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/string_knob_test.dart
@@ -49,7 +49,7 @@ void main() {
   );
 
   group(
-    '$StringOrNullKnob',
+    '$StringKnob.nullable',
     () {
       testWidgets(
         'when field is updated, '

--- a/packages/widgetbook/test/src/state/widgetbook_state_test.dart
+++ b/packages/widgetbook/test/src/state/widgetbook_state_test.dart
@@ -76,7 +76,7 @@ void main() {
         'when the knob is update to be null, '
         'then the knob value is null when retrieved',
         () {
-          final knob = StringKnob(
+          final knob = StringKnob.nullable(
             label: 'Knob',
             value: 'Widgetbook',
           );


### PR DESCRIPTION
For each `X` nullable knob we had two classes:
1. `XKnob`
2. `XOrNullKnob`

The two classes shared almost all code, that's why it was a good idea to merge them into one that is controlled by 1 parameter called `isNullable`.