### PR TITLE
docs: Add widgetbook library to dev dependencies

### DIFF
--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -34,16 +34,16 @@ There are two approaches to configuring Widgetbook:
 >
   <TabItem value="generator">
 
-To get started with the `widgetbook` you'll need the following production dependency:
+To get started with the `widgetbook_annotation` you'll need the following production dependency:
 
 ```bash
-flutter pub add widgetbook_annotation widgetbook
+flutter pub add widgetbook_annotation
 ```
 
-and the following dev dependencies:
+Then, add `widgetbook` and `widgetbook_generator` to dev dependencies. Notice that you need to also add `build_runner`.
 
 ```bash
-flutter pub add widgetbook_generator  build_runner --dev
+flutter pub add widgetbook_generator widgetbook build_runner --dev
 ```
 
 This will add a line like this to your package's pubspec.yaml (and run an implicit
@@ -52,9 +52,9 @@ This will add a line like this to your package's pubspec.yaml (and run an implic
 ```yaml
 dependencies:
   widgetbook_annotation: ^{{ versions.annotation }}
-  widgetbook: ^{{ versions.widgetbook }}
 
 dev_dependencies:
+  widgetbook: ^{{ versions.widgetbook }}
   widgetbook_generator: ^{{ versions.generator }}
   build_runner:
 ```
@@ -68,17 +68,17 @@ focus on what you do best - creating excellent code.
   </TabItem>
   <TabItem value="manual">
 
-To get started with the `widgetbook` you'll need the following production dependency:
+To get started with the `widgetbook` you'll need the following developer dependency:
 
 ```bash
-flutter pub add widgetbook
+flutter pub add widgetbook --dev
 ```
 
 This will add a line like this to your package's `pubspec.yaml` (and run an implicit
 `flutter pub get`):
 
 ```yaml
-dependencies:
+dev_dependencies:
   widgetbook: ^{{ versions.widgetbook }}
 ```
 

--- a/examples/full_example/pubspec.lock
+++ b/examples/full_example/pubspec.lock
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.17.1"
   convert:
     dependency: transitive
     description:
@@ -282,10 +282,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -475,14 +475,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -492,7 +484,7 @@ packages:
     source: hosted
     version: "2.4.0"
   widgetbook:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       path: "../../packages/widgetbook"
       relative: true
@@ -521,5 +513,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=1.17.0"

--- a/examples/full_example/pubspec.yaml
+++ b/examples/full_example/pubspec.yaml
@@ -9,11 +9,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  widgetbook: ^3.1.0
   widgetbook_annotation: ^3.0.0
 
 dev_dependencies:
   build_runner: ^2.4.4
+  widgetbook: ^3.1.0
   widgetbook_generator: ^3.0.0
 
 flutter:

--- a/examples/knobs_example/pubspec.lock
+++ b/examples/knobs_example/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.17.1"
   device_frame:
     dependency: transitive
     description:
@@ -38,6 +38,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -50,10 +58,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -91,21 +99,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   widgetbook:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       path: "../../packages/widgetbook"
       relative: true
     source: path
     version: "3.1.0"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=1.17.0"

--- a/examples/knobs_example/pubspec.yaml
+++ b/examples/knobs_example/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+
+dev_dependencies: 
   widgetbook: ^3.1.0
 
 flutter:

--- a/examples/screen_util_example/pubspec.lock
+++ b/examples/screen_util_example/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.17.1"
   device_frame:
     dependency: transitive
     description:
@@ -46,6 +46,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -58,10 +66,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -99,21 +107,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   widgetbook:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       path: "../../packages/widgetbook"
       relative: true
     source: path
     version: "3.1.0"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=3.10.0"

--- a/examples/screen_util_example/pubspec.yaml
+++ b/examples/screen_util_example/pubspec.yaml
@@ -10,7 +10,10 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_screenutil: ^5.7.0
+
+dev_dependencies:
   widgetbook: ^3.1.0
+  
 
 flutter:
   uses-material-design: true

--- a/sandbox/pubspec.lock
+++ b/sandbox/pubspec.lock
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.17.1"
   convert:
     dependency: transitive
     description:
@@ -282,10 +282,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -475,14 +475,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -521,5 +513,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=1.17.0"


### PR DESCRIPTION
The `widgetbook`  is supposed to be a dev dependency, therefore, it makes sense that we enforce the best practices in the documentation. 

### Checklist

- [ x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
