### PR TITLE
fix: make `path` first query param

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -6,6 +6,7 @@
  - **REFACTOR**: Make `appBuilder` optional. ([#843](https://github.com/widgetbook/widgetbook/pull/843))
  - **REFACTOR**: Replace `MultiChildNavigationData` with `WidgetbookNode`. ([#833](https://github.com/widgetbook/widgetbook/pull/833))
  - **REFACTOR**: Deprecate `WidgetbookUseCase.center` in favor of [AlignmentAddon]. ([#826](https://github.com/widgetbook/widgetbook/pull/826))
+ - **FIX**: Make `path` the first query parameter. ([#855](https://github.com/widgetbook/widgetbook/pull/855))
  - **FIX**: Correct initial Checkbox value for null knobs. ([#851](https://github.com/widgetbook/widgetbook/pull/851))
  - **FIX**: Ensure widget is mounted on change. ([#814](https://github.com/widgetbook/widgetbook/pull/814))
  - **FIX**: Allow commas in `string` knobs. ([#817](https://github.com/widgetbook/widgetbook/pull/817))

--- a/packages/widgetbook/lib/src/routing/app_route_config.dart
+++ b/packages/widgetbook/lib/src/routing/app_route_config.dart
@@ -6,9 +6,20 @@ class AppRouteConfig {
     required this.uri,
   });
 
+  static const reservedKeys = ['path', 'preview'];
+
   final Uri uri;
 
   String? get path => uri.queryParameters['path'];
 
   bool get previewMode => uri.queryParameters.containsKey('preview');
+
+  /// Returns a modifiable copy of the query parameters without the
+  /// keys: `path` and `preview`.
+  Map<String, String> get queryParams {
+    return Map<String, String>.from(uri.queryParameters)
+      ..removeWhere(
+        (key, _) => reservedKeys.contains(key),
+      );
+  }
 }

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -41,8 +41,8 @@ class WidgetbookState extends ChangeNotifier {
   /// A [Uri] representation of the current state.
   Uri get uri {
     final queryParameters = {
-      ...queryParams,
       if (path != null) 'path': path,
+      ...queryParams,
     };
 
     return Uri(
@@ -86,6 +86,12 @@ class WidgetbookState extends ChangeNotifier {
   /// Update the [name] query parameter with the given [value].
   @internal
   void updateQueryParam(String name, String value) {
+    if (AppRouteConfig.reservedKeys.contains(name)) {
+      throw ArgumentError(
+        'The query parameter $name is reserved and cannot be updated.',
+      );
+    }
+
     queryParams[name] = value;
     notifyListeners();
   }
@@ -146,12 +152,7 @@ class WidgetbookState extends ChangeNotifier {
   void updateFromRouteConfig(AppRouteConfig routeConfig) {
     path = routeConfig.path;
     previewMode = routeConfig.previewMode;
-    queryParams = {
-      // Copy from UnmodifiableMap
-      ...routeConfig.uri.queryParameters,
-    }
-      ..remove('path')
-      ..remove('preview');
+    queryParams = routeConfig.queryParams;
 
     notifyListeners();
   }

--- a/packages/widgetbook/test/src/routing/app_route_config_test.dart
+++ b/packages/widgetbook/test/src/routing/app_route_config_test.dart
@@ -6,15 +6,15 @@ void main() {
     '$AppRouteConfig',
     () {
       test(
-        'given a location, '
-        'then query parameters are parsed',
+        'given a uri, '
+        'then query parameters are parsed without reserved keys',
         () {
           final config = AppRouteConfig(
-            uri: Uri.parse('/?foo=bar&baz=qux'),
+            uri: Uri.parse('/?path=component-x&foo=bar&baz=qux'),
           );
 
           expect(
-            config.uri.queryParameters,
+            config.queryParams,
             {
               'foo': 'bar',
               'baz': 'qux',
@@ -24,7 +24,7 @@ void main() {
       );
 
       test(
-        'given a location, '
+        'given a uri, '
         'then path is extracted',
         () {
           final config = AppRouteConfig(
@@ -36,7 +36,7 @@ void main() {
       );
 
       test(
-        'given a location, '
+        'given a uri, '
         'then preview mode is extracted',
         () {
           final config = AppRouteConfig(

--- a/packages/widgetbook/test/src/state/widgetbook_state_test.dart
+++ b/packages/widgetbook/test/src/state/widgetbook_state_test.dart
@@ -31,6 +31,46 @@ void main() {
 
       test(
         'given a state, '
+        'when [updateQueryParam] is called with a reserved key, '
+        'then an $ArgumentError exception is thrown',
+        () {
+          final state = WidgetbookState(
+            queryParams: {},
+            root: WidgetbookRoot(
+              children: [],
+            ),
+          );
+
+          final reservedKey = AppRouteConfig.reservedKeys.first;
+
+          expect(
+            () => state.updateQueryParam(reservedKey, '*'),
+            throwsArgumentError,
+          );
+        },
+      );
+
+      test(
+        'given a state, '
+        'then the Uri has path as the first query parameter',
+        () {
+          final state = WidgetbookState(
+            path: 'component/use-case',
+            queryParams: {'foo': 'bar'},
+            root: WidgetbookRoot(
+              children: [],
+            ),
+          );
+
+          expect(
+            state.uri.toString(),
+            '/?path=component%2Fuse-case&foo=bar',
+          );
+        },
+      );
+
+      test(
+        'given a state, '
         'when the path is updated, '
         'then the knobs are cleared and removed from query params',
         () {


### PR DESCRIPTION
This issue resulted after merging #782, causing URL to be
`/#/?device={name:None}&path=navigation/default` (notice `device` appears before `path`)

