### PR TITLE
refactor(generator): create `ResolverAllocator`

### DIFF
--- a/packages/widgetbook_generator/lib/code/refer.dart
+++ b/packages/widgetbook_generator/lib/code/refer.dart
@@ -1,31 +1,8 @@
 import 'package:code_builder/code_builder.dart';
-import 'package:path/path.dart' as path;
 
 const widgetbookUrl = 'package:widgetbook/widgetbook.dart';
 
 /// Same as [refer] but uses [widgetbookUrl] as default url.
 Reference referWidgetbook(String symbol) {
   return refer(symbol, widgetbookUrl);
-}
-
-/// Same as [refer] but converts [url] to a relative path.
-///
-/// If the file is located outside the lib directory, then the [url] will
-/// be an "asset:" uri. In this case, it is converted to a relative path,
-/// relative to the [from] directory.
-Reference referRelative(
-  String symbol,
-  String url,
-  String from,
-) {
-  final uri = Uri.parse(url);
-  final relativeUrl = path.relative(
-    uri.path,
-    from: from,
-  );
-
-  return refer(
-    symbol,
-    uri.scheme == 'asset' ? relativeUrl : url,
-  );
 }

--- a/packages/widgetbook_generator/lib/code/resolver_allocator.dart
+++ b/packages/widgetbook_generator/lib/code/resolver_allocator.dart
@@ -1,0 +1,35 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:path/path.dart' as path;
+
+/// Converts 'asset:' import URIs to relative paths, relative to [baseDir].
+///
+/// The 'asset:' URIs happen when a file is located outside the
+/// `lib` directory, for example in the `test` directory.
+class ResolverAllocator implements Allocator {
+  ResolverAllocator(this.baseDir);
+
+  final String baseDir;
+  final _allocator = Allocator();
+
+  @override
+  String allocate(Reference reference) {
+    return _allocator.allocate(reference);
+  }
+
+  @override
+  Iterable<Directive> get imports => _allocator.imports.map(
+        (directive) => Directive.import(
+          convertToRelative(directive.url, baseDir),
+        ),
+      );
+
+  String convertToRelative(String url, String from) {
+    final uri = Uri.parse(url);
+    final relativeUrl = path.relative(
+      uri.path,
+      from: from,
+    );
+
+    return uri.scheme == 'asset' ? relativeUrl : url;
+  }
+}

--- a/packages/widgetbook_generator/lib/code/widgetbook_component_instance.dart
+++ b/packages/widgetbook_generator/lib/code/widgetbook_component_instance.dart
@@ -7,13 +7,12 @@ import 'widgetbook_instance.dart';
 class WidgetbookComponentInstance extends WidgetbookInstance {
   WidgetbookComponentInstance({
     required TreeNode<String> node,
-    required super.baseDir,
   }) : super(
           type: 'WidgetbookComponent',
           args: {
             'name': literalString(node.data),
             'useCases': literalList(
-              node.getInstances(baseDir),
+              node.instances,
             ),
           },
         );

--- a/packages/widgetbook_generator/lib/code/widgetbook_folder_instance.dart
+++ b/packages/widgetbook_generator/lib/code/widgetbook_folder_instance.dart
@@ -7,13 +7,12 @@ import 'widgetbook_instance.dart';
 class WidgetbookFolderInstance extends WidgetbookInstance {
   WidgetbookFolderInstance({
     required TreeNode<String> node,
-    required super.baseDir,
   }) : super(
           type: 'WidgetbookFolder',
           args: {
             'name': literalString(node.data),
             'children': literalList(
-              node.getInstances(baseDir),
+              node.instances,
             ),
           },
         );

--- a/packages/widgetbook_generator/lib/code/widgetbook_instance.dart
+++ b/packages/widgetbook_generator/lib/code/widgetbook_instance.dart
@@ -11,21 +11,16 @@ class WidgetbookInstance extends InvokeExpression {
   WidgetbookInstance({
     required String type,
     required Map<String, Expression> args,
-    required String baseDir,
   }) : super.newOf(
           referWidgetbook(type),
           [],
           args,
         );
 
-  factory WidgetbookInstance.fromNode(
-    TreeNode node,
-    String baseDir,
-  ) {
+  factory WidgetbookInstance.fromNode(TreeNode node) {
     if (node.data is UseCaseMetadata) {
       return WidgetbookUseCaseInstance(
         useCase: node.data as UseCaseMetadata,
-        baseDir: baseDir,
       );
     }
 
@@ -38,11 +33,9 @@ class WidgetbookInstance extends InvokeExpression {
     return isComponentNode
         ? WidgetbookComponentInstance(
             node: node as TreeNode<String>,
-            baseDir: baseDir,
           )
         : WidgetbookFolderInstance(
             node: node as TreeNode<String>,
-            baseDir: baseDir,
           );
   }
 }

--- a/packages/widgetbook_generator/lib/code/widgetbook_use_case_instance.dart
+++ b/packages/widgetbook_generator/lib/code/widgetbook_use_case_instance.dart
@@ -1,22 +1,19 @@
 import 'package:code_builder/code_builder.dart';
 
 import '../models/use_case_metadata.dart';
-import 'refer.dart';
 import 'widgetbook_instance.dart';
 
 /// [InvokeExpression] for [WidgetbookUseCase]
 class WidgetbookUseCaseInstance extends WidgetbookInstance {
   WidgetbookUseCaseInstance({
     required UseCaseMetadata useCase,
-    required super.baseDir,
   }) : super(
           type: 'WidgetbookUseCase',
           args: {
             'name': literalString(useCase.name),
-            'builder': referRelative(
+            'builder': refer(
               useCase.functionName,
               useCase.importUri,
-              baseDir,
             ),
           },
         );

--- a/packages/widgetbook_generator/lib/generators/app_generator.dart
+++ b/packages/widgetbook_generator/lib/generators/app_generator.dart
@@ -10,6 +10,7 @@ import 'package:source_gen/source_gen.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 
 import '../code/refer.dart';
+import '../code/resolver_allocator.dart';
 import '../code/widgetbook_instance.dart';
 import '../models/use_case_metadata.dart';
 import '../tree/tree.dart';
@@ -25,21 +26,19 @@ class AppGenerator extends GeneratorForAnnotation<App> {
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
-    final useCases = await readUseCases(buildStep);
-
     // The directory containing the `widgetbook.dart` file
     // without the leading `/`
     final inputPath = element.librarySource!.fullName;
     final inputDir = path.dirname(inputPath).substring(1);
 
-    final root = Tree.build(useCases);
-    final library = buildLibrary(
-      root.getInstances(inputDir),
+    final emitter = DartEmitter(
+      allocator: ResolverAllocator(inputDir),
+      orderDirectives: true,
     );
 
-    final emitter = DartEmitter(
-      allocator: Allocator(),
-    );
+    final useCases = await readUseCases(buildStep);
+    final root = Tree.build(useCases);
+    final library = buildLibrary(root.instances);
 
     return library.accept(emitter).toString();
   }

--- a/packages/widgetbook_generator/lib/tree/tree_node.dart
+++ b/packages/widgetbook_generator/lib/tree/tree_node.dart
@@ -16,6 +16,12 @@ class TreeNode<T> {
   final T data;
   Map<String, TreeNode> children;
 
+  List<WidgetbookInstance> get instances {
+    return children.values //
+        .map(WidgetbookInstance.fromNode)
+        .toList();
+  }
+
   /// Uses [toString] on [data]
   static String defaultKeyResolver(dynamic data) {
     return data.toString();
@@ -32,11 +38,5 @@ class TreeNode<T> {
       key,
       () => TreeNode<TData>(data),
     ) as TreeNode<TData>;
-  }
-
-  List<WidgetbookInstance> getInstances(String baseDir) {
-    return children.values
-        .map((child) => WidgetbookInstance.fromNode(child, baseDir))
-        .toList();
   }
 }

--- a/packages/widgetbook_generator/test/src/code/refer_test.dart
+++ b/packages/widgetbook_generator/test/src/code/refer_test.dart
@@ -4,30 +4,7 @@ import 'package:widgetbook_generator/code/refer.dart';
 void main() {
   test('referWidgetbook', () {
     final actual = referWidgetbook('WidgetbookType');
+
     expect(actual.url, widgetbookUrl);
-  });
-
-  test('referRelative (package)', () {
-    final url = 'package:foo/bar/baz/qux.dart';
-    final actual = referRelative(
-      'UseCase',
-      url,
-      'foo/lib/widgetbook.dart',
-    );
-
-    expect(actual.url, equals(url));
-  });
-
-  test('referRelative (asset)', () {
-    final actual = referRelative(
-      'UseCase',
-      'asset:foo/bar/baz/qux.dart',
-      'foo/lib/widgetbook.dart',
-    );
-
-    expect(
-      actual.url,
-      equals('../../bar/baz/qux.dart'),
-    );
   });
 }

--- a/packages/widgetbook_generator/test/src/code/resolver_allocator_test.dart
+++ b/packages/widgetbook_generator/test/src/code/resolver_allocator_test.dart
@@ -1,0 +1,39 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+import 'package:widgetbook_generator/code/resolver_allocator.dart';
+
+void main() {
+  group('$ResolverAllocator', () {
+    test('converts asset imports', () {
+      final allocator = ResolverAllocator('foo/widgetbook.dart');
+
+      allocator.allocate(
+        refer(
+          'testUseCase',
+          'asset:foo/test/bar/qux.dart',
+        ),
+      );
+
+      expect(
+        allocator.imports.map((import) => import.url),
+        equals(['../test/bar/qux.dart']),
+      );
+    });
+
+    test('keeps package imports as-is', () {
+      final allocator = ResolverAllocator('foo/widgetbook.dart');
+
+      allocator.allocate(
+        refer(
+          'defaultUseCase',
+          'package:foo/bar/qux.dart',
+        ),
+      );
+
+      expect(
+        allocator.imports.map((import) => import.url),
+        equals(['package:foo/bar/qux.dart']),
+      );
+    });
+  });
+}

--- a/packages/widgetbook_generator/test/src/code/widgetbook_component_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code/widgetbook_component_instance_test.dart
@@ -11,7 +11,6 @@ void main() {
     test('empty use cases', () {
       final actual = WidgetbookComponentInstance(
         node: TreeNode<String>('Component'),
-        baseDir: '/',
       );
 
       expectExpression(
@@ -26,13 +25,12 @@ void main() {
     });
 
     test('with use cases', () {
-      final useCase = MockUseCaseMetadata();
       final actual = WidgetbookComponentInstance(
-        node: TreeNode<String>(
-          'Component',
-          {'Default': TreeNode<UseCaseMetadata>(useCase)},
-        ),
-        baseDir: '/',
+        node: TreeNode<String>('Component', {
+          'Default': TreeNode<UseCaseMetadata>(
+            MockUseCaseMetadata(),
+          ),
+        }),
       );
 
       expectExpression(

--- a/packages/widgetbook_generator/test/src/code/widgetbook_folder_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code/widgetbook_folder_instance_test.dart
@@ -11,7 +11,6 @@ void main() {
     test('empty children', () {
       final actual = WidgetbookFolderInstance(
         node: TreeNode<String>('folder'),
-        baseDir: '/',
       );
 
       expectExpression(
@@ -26,18 +25,16 @@ void main() {
     });
 
     test('with children', () {
-      final useCase = MockUseCaseMetadata();
-      final root = TreeNode<String>('root', {
-        'Folder1': TreeNode<String>('Folder1'),
-        'Folder2': TreeNode<String>('Folder2'),
-        'Component': TreeNode<String>('Component', {
-          'Default': TreeNode<UseCaseMetadata>(useCase),
-        }),
-      });
-
       final actual = WidgetbookFolderInstance(
-        node: root,
-        baseDir: '/',
+        node: TreeNode<String>('root', {
+          'Folder1': TreeNode<String>('Folder1'),
+          'Folder2': TreeNode<String>('Folder2'),
+          'Component': TreeNode<String>('Component', {
+            'Default': TreeNode<UseCaseMetadata>(
+              MockUseCaseMetadata(),
+            ),
+          }),
+        }),
       );
 
       expectExpression(

--- a/packages/widgetbook_generator/test/src/code/widgetbook_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code/widgetbook_instance_test.dart
@@ -12,8 +12,9 @@ void main() {
   group('$WidgetbookInstance', () {
     test('fromNode (UseCase)', () {
       final actual = WidgetbookInstance.fromNode(
-        TreeNode<UseCaseMetadata>(MockUseCaseMetadata()),
-        '/',
+        TreeNode<UseCaseMetadata>(
+          MockUseCaseMetadata(),
+        ),
       );
 
       expect(
@@ -24,11 +25,11 @@ void main() {
 
     test('fromNode (Component)', () {
       final actual = WidgetbookInstance.fromNode(
-        TreeNode<String>(
-          'Component',
-          {'Default': TreeNode<UseCaseMetadata>(MockUseCaseMetadata())},
-        ),
-        '/',
+        TreeNode<String>('Component', {
+          'Default': TreeNode<UseCaseMetadata>(
+            MockUseCaseMetadata(),
+          ),
+        }),
       );
 
       expect(
@@ -39,11 +40,9 @@ void main() {
 
     test('fromNode (Folder)', () {
       final actual = WidgetbookInstance.fromNode(
-        TreeNode<String>(
-          'Folder',
-          {'Component': TreeNode<String>('Component')},
-        ),
-        '/',
+        TreeNode<String>('Folder', {
+          'Component': TreeNode<String>('Component'),
+        }),
       );
 
       expect(
@@ -55,7 +54,6 @@ void main() {
     test('fromNode (Empty Folder)', () {
       final actual = WidgetbookInstance.fromNode(
         TreeNode<String>('Folder'),
-        '/',
       );
 
       expect(

--- a/packages/widgetbook_generator/test/src/code/widgetbook_use_case_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code/widgetbook_use_case_instance_test.dart
@@ -9,7 +9,6 @@ void main() {
     test('single use case', () {
       final actual = WidgetbookUseCaseInstance(
         useCase: MockUseCaseMetadata(),
-        baseDir: '/',
       );
 
       expectExpression(


### PR DESCRIPTION
Instead of passing down `baseDir` to all `WidgetbookInstance`s, a single `ResolverAllocator` is used to resolve imports directly from the `DartEmitter`.