### PR TITLE
fix(generator): apply imports prefixing

### DIFF
--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **FIX**: Sort generated nodes. ([#871](https://github.com/widgetbook/widgetbook/pull/871))
+- **FIX**: Apply imports prefixing. ([#872](https://github.com/widgetbook/widgetbook/pull/872))
 
 ## 3.1.0
 

--- a/packages/widgetbook_generator/lib/code/resolver_allocator.dart
+++ b/packages/widgetbook_generator/lib/code/resolver_allocator.dart
@@ -1,7 +1,8 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:path/path.dart' as path;
 
-/// Converts 'asset:' import URIs to relative paths, relative to [baseDir].
+/// Converts 'asset:' import URIs to relative paths, relative to [baseDir],
+/// then delegates all imports to [Allocator.simplePrefixing].
 ///
 /// The 'asset:' URIs happen when a file is located outside the
 /// `lib` directory, for example in the `test` directory.
@@ -9,7 +10,7 @@ class ResolverAllocator implements Allocator {
   ResolverAllocator(this.baseDir);
 
   final String baseDir;
-  final _allocator = Allocator();
+  final _allocator = Allocator.simplePrefixing();
 
   @override
   String allocate(Reference reference) {
@@ -20,6 +21,7 @@ class ResolverAllocator implements Allocator {
   Iterable<Directive> get imports => _allocator.imports.map(
         (directive) => Directive.import(
           convertToRelative(directive.url, baseDir),
+          as: directive.as,
         ),
       );
 


### PR DESCRIPTION
When two use-cases have the same function name (e.g. `deafultUseCase(BuildContext context)`), then the generated file will have imports collision. 

This PR adds prefixing to all imports to avoid that collision.