### PR TITLE
docs: add mocking page reference to component page

### DIFF
--- a/docs/getting-started/components.mdx
+++ b/docs/getting-started/components.mdx
@@ -163,3 +163,5 @@ Then, run again, and you should be able to see your container in Widgetbook.
 
   </TabItem>
 </Tabs>
+
+<Info>Read how to optimize widget dependencies and mocking for testability and development on [Mocking](/mocking) page.</Info>

--- a/docs/getting-started/components.mdx
+++ b/docs/getting-started/components.mdx
@@ -164,4 +164,4 @@ Then, run again, and you should be able to see your container in Widgetbook.
   </TabItem>
 </Tabs>
 
-<Info>Read how to optimize widget dependencies and mocking for testability and development on [Mocking](/mocking) page.</Info>
+<Info>Read how to optimize widget dependencies and mocking for testability and development on [Mocking](/getting-started/mocking) page.</Info>


### PR DESCRIPTION
Adding a reference to the mocking page from the component page, as it's in the middle of the getting started and may help developer 

### Checklist

- [x ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
