### PR TITLE
feat: add use-case builder addon

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -64,8 +64,9 @@
         ["3. Device Frame Addon", "/addons/device-frame-addon"],
         ["4. Localization Addon", "/addons/localization-addon"],
         ["5. Text Scale Addon", "/addons/text-scale-addon"],
-        ["5. Alignment Addon", "/addons/alignment-addon"],
-        ["6. Custom Addon", "/addons/custom-addon"]
+        ["6. Alignment Addon", "/addons/alignment-addon"],
+        ["7. Custom Addon", "/addons/use-case-builder-addon"],
+        ["8. Custom Addon", "/addons/custom-addon"]
       ]
     ],
     [

--- a/docs.json
+++ b/docs.json
@@ -65,7 +65,7 @@
         ["4. Localization Addon", "/addons/localization-addon"],
         ["5. Text Scale Addon", "/addons/text-scale-addon"],
         ["6. Alignment Addon", "/addons/alignment-addon"],
-        ["7. Custom Addon", "/addons/use-case-builder-addon"],
+        ["7. Use-case Builder Addon", "/addons/use-case-builder-addon"],
         ["8. Custom Addon", "/addons/custom-addon"]
       ]
     ],

--- a/docs/addons/use-case-builder-addon.mdx
+++ b/docs/addons/use-case-builder-addon.mdx
@@ -10,7 +10,7 @@ Here's how to configure it:
 UseCaseBuilderAddon(
     name: 'Red',
     builder: (context, child) => ColoredBox(
-        color: color,
+        color: Colors.red,
         child: child,
     ),
 )

--- a/docs/addons/use-case-builder-addon.mdx
+++ b/docs/addons/use-case-builder-addon.mdx
@@ -1,0 +1,39 @@
+# Use-case Builder Addon
+
+The Use-case Builder Addon is utility to wrap all use-cases with a certain widget.
+
+## Setup
+
+Here's how to configure it:
+
+```dart
+UseCaseBuilderAddon(
+    name: 'Red',
+    builder: (context, child) => ColoredBox(
+        color: color,
+        child: child,
+    ),
+)
+```
+
+## Usage
+
+This can be used to quickly setup a custom addon with much less boilerplate.
+For example, here's an addon for [`flutter_screenutil`](https://pub.dev/packages/flutter_screenutil) package:
+
+```dart
+UseCaseBuilderAddon(
+    name: 'ScreenUtil',
+    builder: (context, child) {
+        return ScreenUtilInit(
+            designSize: const Size(375, 812),
+            minTextAdapt: true,
+            splitScreenMode: true,
+            // This is needed to use the workbench [MediaQuery]
+            useInheritedMediaQuery: true,
+            builder: (context, child) => child!,
+            child: child,
+        );
+    },
+)
+```

--- a/examples/screen_util_example/lib/widgetbook.dart
+++ b/examples/screen_util_example/lib/widgetbook.dart
@@ -26,6 +26,20 @@ class WidgetbookApp extends StatelessWidget {
             Devices.ios.iPhone13,
           ],
         ),
+        UseCaseBuilderAddon(
+          name: 'ScreenUtil',
+          builder: (context, child) {
+            return ScreenUtilInit(
+              designSize: const Size(375, 812),
+              minTextAdapt: true,
+              splitScreenMode: true,
+              // This is needed to use the workbench [MediaQuery]
+              useInheritedMediaQuery: true,
+              builder: (context, child) => child!,
+              child: child,
+            );
+          },
+        ),
       ],
       directories: [
         WidgetbookComponent(
@@ -46,36 +60,14 @@ class WidgetbookApp extends StatelessWidget {
               name: 'Default',
               builder: (context) {
                 return const ResponsiveImage(
-                  url:
-                      'https://images.nintendolife.com/bb503ef1f79ff/ash-and-pikachu.original.jpg',
+                  url: 'https://images.nintendolife.com/bb503ef1f79ff/'
+                      'ash-and-pikachu.original.jpg',
                 );
               },
             ),
           ],
         ),
       ],
-
-      /// Customize your appBuilder function so the [ScreenUtilInit] widget is
-      /// injected into the [Widget] tree.
-      ///
-      /// For more context on how to create the app builder see
-      /// [materialAppBuilder] or have a look at the documentation.
-      appBuilder: (context, child) {
-        return ScreenUtilInit(
-          designSize: const Size(375, 812),
-          minTextAdapt: true,
-          splitScreenMode: true,
-          // This is needed to use the workbench [MediaQuery]
-          useInheritedMediaQuery: true,
-          builder: (context, child) {
-            return MaterialApp(
-              debugShowCheckedModeBanner: false,
-              home: child,
-            );
-          },
-          child: child,
-        );
-      },
     );
   }
 }

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FEAT**: Add Use-case Builder Addon. ([#880](https://github.com/widgetbook/widgetbook/pull/880))
+
 ## 3.2.0
 
  - **BREAKING**: `DeviceFrameAddon.devices` is no longer nullable, in favor of the new `NoneDevice`. ([#854](https://github.com/widgetbook/widgetbook/pull/854))

--- a/packages/widgetbook/lib/src/addons/addons.dart
+++ b/packages/widgetbook/lib/src/addons/addons.dart
@@ -4,3 +4,4 @@ export 'device_frame_addon/addon.dart';
 export 'localization_addon/addon.dart';
 export 'text_scale_addon/addon.dart';
 export 'theme_addon/addon.dart';
+export 'use_case_builder_addon/addon.dart';

--- a/packages/widgetbook/lib/src/addons/use_case_builder_addon/addon.dart
+++ b/packages/widgetbook/lib/src/addons/use_case_builder_addon/addon.dart
@@ -1,0 +1,1 @@
+export 'use_case_builder_addon.dart';

--- a/packages/widgetbook/lib/src/addons/use_case_builder_addon/use_case_builder_addon.dart
+++ b/packages/widgetbook/lib/src/addons/use_case_builder_addon/use_case_builder_addon.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import '../../fields/fields.dart';
+import '../common/common.dart';
+
+/// A [WidgetbookAddon] for wrapping use-cases with a [builder].
+class UseCaseBuilderAddon extends WidgetbookAddon<bool> {
+  UseCaseBuilderAddon({
+    required super.name,
+    required this.builder,
+    bool isEnabled = true,
+  }) : super(
+          initialSetting: isEnabled,
+        );
+
+  final Widget Function(BuildContext context, Widget child) builder;
+
+  @override
+  List<Field> get fields {
+    return [
+      BooleanField(
+        name: 'enable',
+        initialValue: initialSetting,
+      ),
+    ];
+  }
+
+  @override
+  bool valueFromQueryGroup(Map<String, String> group) {
+    return valueOf('enable', group)!;
+  }
+
+  @override
+  Widget buildUseCase(
+    BuildContext context,
+    Widget child,
+    bool setting,
+  ) {
+    return setting ? builder(context, child) : child;
+  }
+}

--- a/packages/widgetbook/test/src/addons/use_case_builder_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/use_case_builder_addon_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import '../../helper/mocks.dart';
+import '../../helper/tester_extension.dart';
+
+void main() {
+  group(
+    '$UseCaseBuilderAddon',
+    () {
+      final color = Colors.red;
+      final addon = UseCaseBuilderAddon(
+        name: 'Red',
+        builder: (context, child) => ColoredBox(
+          color: color,
+          child: child,
+        ),
+      );
+
+      test(
+        'given a query group, '
+        'then [valueFromQueryGroup] can parse the value',
+        () {
+          final result = addon.valueFromQueryGroup({
+            'enable': 'true',
+          });
+
+          expect(result, equals(true));
+        },
+      );
+
+      testWidgets(
+        'given a [true] setting, '
+        'then [buildUseCase] wraps child with [ColoredBox] widget',
+        (tester) async {
+          await tester.pumpWidgetWithBuilder(
+            (context) => addon.buildUseCase(
+              context,
+              const Text('child'),
+              true,
+            ),
+          );
+
+          final coloredBox = tester.widget<ColoredBox>(
+            find.byType(ColoredBox),
+          );
+
+          expect(
+            coloredBox.color,
+            equals(color),
+          );
+        },
+      );
+
+      test(
+        'given a [false] setting, '
+        'then [buildUseCase] returns child as-is',
+        () {
+          const child = Text('child');
+          final useCase = addon.buildUseCase(
+            MockBuildContext(),
+            child,
+            false,
+          );
+
+          expect(
+            useCase,
+            equals(child),
+          );
+        },
+      );
+    },
+  );
+}

--- a/sandbox/lib/widgetbook.dart
+++ b/sandbox/lib/widgetbook.dart
@@ -49,6 +49,18 @@ class WidgetbookApp extends StatelessWidget {
             DefaultMaterialLocalizations.delegate,
           ],
         ),
+        UseCaseBuilderAddon(
+          name: 'Bounds',
+          isEnabled: false,
+          builder: (context, child) => Container(
+            decoration: BoxDecoration(
+              border: Border.all(
+                color: Colors.white,
+              ),
+            ),
+            child: child,
+          ),
+        ),
       ],
     );
   }


### PR DESCRIPTION
Wrap all use-cases in a widget on the go, without the need to create a custom addon.

```dart
UseCaseBuilderAddon(
    name: 'Red',
    builder: (context, child) => ColoredBox(
        color: Colors.red,
        child: child,
    ),
)
```