### PR TITLE
fix: remove false overriding for `listOrNull` knob

### DIFF
--- a/packages/widgetbook/lib/src/knobs/list_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/list_knob.dart
@@ -25,10 +25,6 @@ class ListKnob<T> extends Knob<T?> {
   final List<T> options;
   final LabelBuilder<T>? labelBuilder;
 
-  // Force non-nullable behavior
-  @override
-  bool get isNullable => false;
-
   @override
   List<Field> get fields {
     return [

--- a/packages/widgetbook/test/src/knobs/list_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/list_knob_test.dart
@@ -56,4 +56,70 @@ void main() {
       );
     },
   );
+
+  group(
+    '$ListKnob.nullable',
+    () {
+      testWidgets(
+        'when field is updated, '
+        'then the value should be updated',
+        (tester) async {
+          await tester.pumpKnob(
+            (context) => Text(
+              context.knobs.listOrNull(
+                label: 'Knob',
+                options: ['A', 'B', 'C'],
+              ).toString(),
+            ),
+          );
+
+          const value = 'C';
+          await tester.findAndTap(find.byType(DropdownMenu<String?>));
+          await tester.findAndTap(find.text(value).last);
+
+          expect(
+            find.textWidget(value),
+            findsNWidgets(2),
+          );
+        },
+      );
+
+      testWidgets(
+        'when nullability is changed twice, '
+        'then the value should remain the same as before',
+        (tester) async {
+          await tester.pumpKnob(
+            (context) => Text(
+              context.knobs.listOrNull(
+                label: 'Knob',
+                options: ['A', 'B', 'C'],
+              ).toString(),
+            ),
+          );
+
+          expect(
+            find.textWidget('A'),
+            findsNWidgets(2),
+          );
+
+          const value = 'C';
+          await tester.findAndTap(find.byType(DropdownMenu<String?>));
+          await tester.findAndTap(find.text(value).last);
+          expect(
+            find.textWidget(value),
+            findsNWidgets(2),
+          );
+
+          await tester.findAndTap(find.byType(Checkbox));
+          expect(find.textWidget('null'), findsOneWidget);
+
+          await tester.findAndTap(find.byType(Checkbox));
+          expect(
+            find.textWidget(value),
+            findsNWidgets(2),
+          );
+        },
+      );
+    },
+  );
 }


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why.*

### List of issues which are fixed by the PR
*You must list at least one issue.*

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
