### PR TITLE
feat: add `updateQueryField` to state

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **FEAT**: Add Use-case Builder Addon. ([#880](https://github.com/widgetbook/widgetbook/pull/880))
 - **FEAT**: Add Experimental Time Dilation Addon. ([#887](https://github.com/widgetbook/widgetbook/pull/887))
+- **FEAT**: Add `WidgetbookState.updateQueryField`. ([#888](https://github.com/widgetbook/widgetbook/pull/888))
 - **REFACTOR**: Change `WidgetbookState.knobs` type from `Map<String, Knob>` to `KnobsRegistry`. ([#885](https://github.com/widgetbook/widgetbook/pull/885))
 - **REFACTOR**: Deprecate `WidgetbookState.updateKnobValue` in favor of `WidgetbookState.knobs.updateValue`. ([#885](https://github.com/widgetbook/widgetbook/pull/885))
 

--- a/packages/widgetbook/lib/src/fields/field.dart
+++ b/packages/widgetbook/lib/src/fields/field.dart
@@ -68,21 +68,12 @@ abstract class Field<T> {
   Widget toWidget(BuildContext context, String group, T? value);
 
   void updateField(BuildContext context, String group, T value) {
-    final state = WidgetbookState.of(context);
-    final groupMap = FieldCodec.decodeQueryGroup(state.queryParams[group]);
-
-    final newGroupMap = Map<String, String>.from(groupMap)
-      ..update(
-        name,
-        (_) => codec.toParam(value),
-        ifAbsent: () => codec.toParam(value),
-      );
-
     onChanged?.call(context, value);
 
-    state.updateQueryParam(
-      group,
-      FieldCodec.encodeQueryGroup(newGroupMap),
+    WidgetbookState.of(context).updateQueryField(
+      group: group,
+      field: name,
+      value: codec.toParam(value),
     );
   }
 

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 
 import '../addons/addons.dart';
+import '../fields/fields.dart';
 import '../integrations/widgetbook_integration.dart';
 import '../knobs/knobs.dart';
 import '../navigation/navigation.dart';
@@ -105,6 +106,27 @@ class WidgetbookState extends ChangeNotifier {
 
     queryParams[name] = value;
     notifyListeners();
+  }
+
+  /// Update the field withing the query [group] with the given [value].
+  void updateQueryField({
+    required String group,
+    required String field,
+    required String value,
+  }) {
+    final groupMap = FieldCodec.decodeQueryGroup(queryParams[group]);
+
+    final newGroupMap = Map<String, String>.from(groupMap)
+      ..update(
+        field,
+        (_) => value,
+        ifAbsent: () => value,
+      );
+
+    updateQueryParam(
+      group,
+      FieldCodec.encodeQueryGroup(newGroupMap),
+    );
   }
 
   /// Update the [path], causing a new [useCase] to bet returned.

--- a/packages/widgetbook/test/src/state/widgetbook_state_test.dart
+++ b/packages/widgetbook/test/src/state/widgetbook_state_test.dart
@@ -31,7 +31,34 @@ void main() {
 
       test(
         'given a state, '
-        'when [updateQueryParam] is called with a reserved key, '
+        'when [updateQueryField] is called, '
+        'then only the field within the group is updated',
+        () {
+          final state = WidgetbookState(
+            queryParams: {
+              'knobs': '{foo:bar,qux:baz}',
+            },
+            root: WidgetbookRoot(
+              children: [],
+            ),
+          );
+
+          state.updateQueryField(
+            group: 'knobs',
+            field: 'qux',
+            value: 'widgetbook',
+          );
+
+          expect(
+            state.queryParams['knobs'],
+            '{foo:bar,qux:widgetbook}',
+          );
+        },
+      );
+
+      test(
+        'given a state, '
+        'when [updateQueryField] is called with a reserved key, '
         'then an $ArgumentError exception is thrown',
         () {
           final state = WidgetbookState(


### PR DESCRIPTION
This new method can edit a query field within a query group.
It can be used for bi-directional knob updates as follow:

```dart
import 'package:flutter/material.dart';
import 'package:widgetbook/widgetbook.dart';
import 'package:widgetbook_annotation/widgetbook_annotation.dart';

@UseCase(name: 'Default', type: CheckboxListTile)
Widget checkBoxTileUseCase(BuildContext context) {
  return CheckboxListTile(
    title: const Text('Title'),
    value: context.knobs.boolean(label: 'Checkbox Knob'),
    onChanged: (value) {
      WidgetbookState.of(context).updateQueryField(
        group: 'knobs',
        field: 'Checkbox Knob',
        value: '$value',
      );
    },
  );
}
```