### PR TITLE
docs: fix getting started example

### DIFF
--- a/docs/getting-started/components.mdx
+++ b/docs/getting-started/components.mdx
@@ -59,6 +59,9 @@ approach or generator approach
         children: [
           Container(
             color: Colors.green,
+            child: const SizedBox.square(
+              dimension: 100,
+            ),
           ),
         ],
       );


### PR DESCRIPTION
Improve green container example by adding a SizedBox child. Without a child nothing shows up when running widgetbook.

*Replace this paragraph with a description of what this PR is changing or adding, and why.*

### List of issues which are fixed by the PR
- running widgetbook from the exmaple, nothing shows up 

### Screenshots
<img width="944" alt="image" src="https://github.com/widgetbook/widgetbook/assets/3084607/8b550e27-278d-4e16-83d0-dc92b5fe962f">
<img width="944" alt="image" src="https://github.com/widgetbook/widgetbook/assets/3084607/e956085f-01c6-4b0c-ae08-4a15b6dbc7d3">


### Checklist

- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing. 

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
