### PR TITLE
ci: fix webp

### DIFF
--- a/.github/workflows/_package.yml
+++ b/.github/workflows/_package.yml
@@ -72,6 +72,7 @@ jobs:
         if: inputs.run_pana
         run: |
           dart pub global activate pana
+          sudo apt-get update
           sudo apt-get install webp # Needed for screenshots validation
 
       - name: Check Package Score


### PR DESCRIPTION
The following error was thrown while running `apt-get install webp`

```
The following additional packages will be installed:
  freeglut3
The following NEW packages will be installed:
  freeglut3 webp
0 upgraded, 2 newly installed, 0 to remove and 28 not upgraded.
Need to get 160 kB of archives.
After this operation, 632 kB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [142 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu jammy/universe amd64 freeglut3 amd64 2.8.1-6 [74.0 kB]
Ign:3 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 webp amd64 1.2.2-2ubuntu0.22.04.1
Ign:3 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 webp amd64 1.2.2-2ubuntu0.22.04.1
Ign:3 http://security.ubuntu.com/ubuntu jammy-updates/universe amd64 webp amd64 1.2.2-2ubuntu0.22.04.1
Err:3 mirror+file:/etc/apt/apt-mirrors.txt jammy-updates/universe amd64 webp amd64 1.2.2-2ubuntu0.22.04.1
  404  Not Found [IP: 40.81.13.82 [80](https://github.com/widgetbook/widgetbook/actions/runs/6207990623/job/16853713975#step:13:81)]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/universe/libw/libwebp/webp_1.2.2-2ubuntu0.22.04.1_amd64.deb  404  Not Found [IP: 40.[81](https://github.com/widgetbook/widgetbook/actions/runs/6207990623/job/16853713975#step:13:82).13.[82](https://github.com/widgetbook/widgetbook/actions/runs/6207990623/job/16853713975#step:13:83) 80]
Fetched 74.0 kB in 1s (73.9 kB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```