### PR TITLE
fix: use `MapMixin` instead of `MapBase`

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: use `MapMixin` instead of `MapBase` for `KnobsRegistry`. ([#903](https://github.com/widgetbook/widgetbook/pull/903))
+
 ## 3.3.0
 
 - **FEAT**: Add Builder Addon. ([#895](https://github.com/widgetbook/widgetbook/pull/895))

--- a/packages/widgetbook/lib/src/knobs/knobs_registry.dart
+++ b/packages/widgetbook/lib/src/knobs/knobs_registry.dart
@@ -5,7 +5,7 @@ import 'package:meta/meta.dart';
 
 import 'knob.dart';
 
-class KnobsRegistry extends ChangeNotifier with MapBase<String, Knob> {
+class KnobsRegistry extends ChangeNotifier with MapMixin<String, Knob> {
   KnobsRegistry({
     required this.onLock,
   });


### PR DESCRIPTION
`MapBase` can only be used as a mixin with Dart v3,
while `MapMixin` works with both Dart v2 and v3.
