### PR TITLE
refactor(cli): check-in `version.dart`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 ## Removed when .gitignore is copied into .pubignore
 *.freezed.dart
 *.g.dart
-version.dart
 
 # Libraries should not include pubspec.lock,
 # per https://dart.dev/guides/libraries/private-files#pubspeclock.

--- a/packages/widgetbook_cli/bin/helpers/version.dart
+++ b/packages/widgetbook_cli/bin/helpers/version.dart
@@ -1,0 +1,2 @@
+// Generated code. Do not modify.
+const packageVersion = '3.0.0-rc.3';


### PR DESCRIPTION
To make the CLI easily usable directly from GitHub as a source, we are checking in the only generated file.