### PR TITLE
chore(cli): move `test` to `dev_dependencies`

### DIFF
--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -27,13 +27,13 @@ dependencies:
   path: ^1.8.2
   pub_updater: ^0.3.0 
   pubspec: ^2.3.0
-  test: ^1.12.1
   version: ^3.0.2
 
 dev_dependencies:
   build_runner: ^2.1.10
   build_version: ^2.1.1
   mocktail: ^1.0.0
+  test: ^1.12.1
   test_descriptor: ^2.0.0
 
 executables:


### PR DESCRIPTION
Package `test` ended up in `dependencies` not `dev_dependencies` for some reason.
Now we are putting it back to where it belongs.