### PR TITLE
refactor(cli): remove `PlatformWrapper`

### DIFF
--- a/packages/widgetbook_cli/bin/ci_parser/azure_parser.dart
+++ b/packages/widgetbook_cli/bin/ci_parser/azure_parser.dart
@@ -1,27 +1,25 @@
+import 'package:platform/platform.dart';
+
 import 'ci_parser.dart';
 
 class AzureParser extends CiParser {
   AzureParser({
     required super.argResults,
-    PlatformWrapper? platformWrapper,
-  }) : _platformWrapper = platformWrapper ?? PlatformWrapper();
+    this.platform = const LocalPlatform(),
+  });
 
-  final PlatformWrapper _platformWrapper;
-
-  PlatformWrapper get platformWrapper => _platformWrapper;
+  final Platform platform;
 
   @override
   String get vendor => 'Azure';
 
   @override
   Future<String?> getActor() async {
-    return _platformWrapper.environmentVariable(variable: 'Agent.Name');
+    return platform.environment['Agent.Name'];
   }
 
   @override
   Future<String?> getRepository() async {
-    return _platformWrapper.environmentVariable(
-      variable: 'Build.Repository.Name',
-    );
+    return platform.environment['Build.Repository.Name'];
   }
 }

--- a/packages/widgetbook_cli/bin/ci_parser/bitbucket_parser.dart
+++ b/packages/widgetbook_cli/bin/ci_parser/bitbucket_parser.dart
@@ -1,14 +1,14 @@
+import 'package:platform/platform.dart';
+
 import 'ci_parser.dart';
 
 class BitbucketParser extends CiParser {
   BitbucketParser({
     required super.argResults,
-    PlatformWrapper? platformWrapper,
-  }) : _platformWrapper = platformWrapper ?? PlatformWrapper();
+    this.platform = const LocalPlatform(),
+  });
 
-  final PlatformWrapper _platformWrapper;
-
-  PlatformWrapper get platformWrapper => _platformWrapper;
+  final Platform platform;
 
   @override
   String get vendor => 'Bitbucket';
@@ -17,15 +17,11 @@ class BitbucketParser extends CiParser {
   /// for scheduled builds, the uuid of the pipelines user.
   @override
   Future<String?> getActor() async {
-    return _platformWrapper.environmentVariable(
-      variable: 'BITBUCKET_STEP_TRIGGERER_UUID',
-    );
+    return platform.environment['BITBUCKET_STEP_TRIGGERER_UUID'];
   }
 
   @override
   Future<String?> getRepository() async {
-    return _platformWrapper.environmentVariable(
-      variable: 'BITBUCKET_REPO_FULL_NAME',
-    );
+    return platform.environment['BITBUCKET_REPO_FULL_NAME'];
   }
 }

--- a/packages/widgetbook_cli/bin/ci_parser/ci_parser.dart
+++ b/packages/widgetbook_cli/bin/ci_parser/ci_parser.dart
@@ -7,4 +7,3 @@ export 'github_parser.dart';
 export 'gitlab_parser.dart';
 export 'local_parser.dart';
 export 'parser.dart';
-export 'platform_wrapper.dart';

--- a/packages/widgetbook_cli/bin/ci_parser/ci_parser_runner.dart
+++ b/packages/widgetbook_cli/bin/ci_parser/ci_parser_runner.dart
@@ -1,4 +1,5 @@
 import 'package:args/args.dart';
+import 'package:platform/platform.dart';
 
 import '../git/git_dir.dart';
 import 'ci_parser.dart';
@@ -7,18 +8,14 @@ class CiParserRunner {
   CiParserRunner({
     required this.argResults,
     required this.gitDir,
+    this.platform = const LocalPlatform(),
     CiWrapper? ciWrapper,
-    PlatformWrapper? platformWrapper,
-  })  : _ciWrapper = ciWrapper ?? CiWrapper(),
-        _platformWrapper = platformWrapper ?? PlatformWrapper();
+  }) : _ciWrapper = ciWrapper ?? CiWrapper();
 
   final ArgResults argResults;
   final GitDir gitDir;
-
+  final Platform platform;
   final CiWrapper _ciWrapper;
-  final PlatformWrapper _platformWrapper;
-
-  PlatformWrapper get platformWrapper => _platformWrapper;
 
   CiParser? getParser() {
     if (!_ciWrapper.isCI()) {
@@ -31,31 +28,31 @@ class CiParserRunner {
     if (_ciWrapper.isGitLab()) {
       return GitLabParser(
         argResults: argResults,
-        platformWrapper: _platformWrapper,
+        platform: platform,
       );
     }
     if (_ciWrapper.isGithub()) {
       return GitHubParser(
         argResults: argResults,
-        platformWrapper: _platformWrapper,
+        platform: platform,
       );
     }
     if (_ciWrapper.isAzure()) {
       return AzureParser(
         argResults: argResults,
-        platformWrapper: _platformWrapper,
+        platform: platform,
       );
     }
     if (_ciWrapper.isBitBucket()) {
       return BitbucketParser(
         argResults: argResults,
-        platformWrapper: _platformWrapper,
+        platform: platform,
       );
     }
     if (_ciWrapper.isCodemagic()) {
       return CodemagicParser(
         argResults: argResults,
-        platformWrapper: _platformWrapper,
+        platform: platform,
       );
     }
 

--- a/packages/widgetbook_cli/bin/ci_parser/codemagic_parser.dart
+++ b/packages/widgetbook_cli/bin/ci_parser/codemagic_parser.dart
@@ -1,14 +1,14 @@
+import 'package:platform/platform.dart';
+
 import 'ci_parser.dart';
 
 class CodemagicParser extends CiParser {
   CodemagicParser({
     required super.argResults,
-    PlatformWrapper? platformWrapper,
-  }) : _platformWrapper = platformWrapper ?? PlatformWrapper();
+    this.platform = const LocalPlatform(),
+  });
 
-  final PlatformWrapper _platformWrapper;
-
-  PlatformWrapper get platformWrapper => _platformWrapper;
+  final Platform platform;
 
   @override
   String get vendor => 'Codemagic';
@@ -22,8 +22,6 @@ class CodemagicParser extends CiParser {
 
   @override
   Future<String?> getRepository() async {
-    return _platformWrapper.environmentVariable(
-      variable: 'CM_REPO_SLUG',
-    );
+    return platform.environment['CM_REPO_SLUG'];
   }
 }

--- a/packages/widgetbook_cli/bin/ci_parser/github_parser.dart
+++ b/packages/widgetbook_cli/bin/ci_parser/github_parser.dart
@@ -1,25 +1,25 @@
+import 'package:platform/platform.dart';
+
 import 'ci_parser.dart';
 
 class GitHubParser extends CiParser {
   GitHubParser({
     required super.argResults,
-    PlatformWrapper? platformWrapper,
-  }) : _platformWrapper = platformWrapper ?? PlatformWrapper();
+    this.platform = const LocalPlatform(),
+  });
 
-  final PlatformWrapper _platformWrapper;
-
-  PlatformWrapper get platformWrapper => _platformWrapper;
+  final Platform platform;
 
   @override
   String get vendor => 'GitHub';
 
   @override
   Future<String?> getActor() async {
-    return _platformWrapper.environmentVariable(variable: 'GITHUB_ACTOR');
+    return platform.environment['GITHUB_ACTOR'];
   }
 
   @override
   Future<String?> getRepository() async {
-    return _platformWrapper.environmentVariable(variable: 'GITHUB_REPOSITORY');
+    return platform.environment['GITHUB_REPOSITORY'];
   }
 }

--- a/packages/widgetbook_cli/bin/ci_parser/gitlab_parser.dart
+++ b/packages/widgetbook_cli/bin/ci_parser/gitlab_parser.dart
@@ -1,25 +1,25 @@
+import 'package:platform/platform.dart';
+
 import 'ci_parser.dart';
 
 class GitLabParser extends CiParser {
   GitLabParser({
     required super.argResults,
-    PlatformWrapper? platformWrapper,
-  }) : _platformWrapper = platformWrapper ?? PlatformWrapper();
+    this.platform = const LocalPlatform(),
+  });
 
-  final PlatformWrapper _platformWrapper;
-
-  PlatformWrapper get platformWrapper => _platformWrapper;
+  final Platform platform;
 
   @override
   String get vendor => 'GitLab';
 
   @override
   Future<String?> getActor() async {
-    return _platformWrapper.environmentVariable(variable: 'GITLAB_USER_NAME');
+    return platform.environment['GITLAB_USER_NAME'];
   }
 
   @override
   Future<String?> getRepository() async {
-    return _platformWrapper.environmentVariable(variable: 'CI_PROJECT_NAME');
+    return platform.environment['CI_PROJECT_NAME'];
   }
 }

--- a/packages/widgetbook_cli/bin/ci_parser/platform_wrapper.dart
+++ b/packages/widgetbook_cli/bin/ci_parser/platform_wrapper.dart
@@ -1,7 +1,0 @@
-import 'dart:io';
-
-class PlatformWrapper {
-  String? environmentVariable({required String variable}) {
-    return Platform.environment[variable];
-  }
-}

--- a/packages/widgetbook_cli/bin/commands/publish.dart
+++ b/packages/widgetbook_cli/bin/commands/publish.dart
@@ -26,6 +26,7 @@ import 'package:file/local.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 
 import '../api/widgetbook_http_client.dart';
 import '../ci_parser/ci_parser.dart';
@@ -45,20 +46,19 @@ class PublishCommand extends WidgetbookCommand {
   PublishCommand({
     super.logger,
     this.ciParserRunner,
+    this.platform = const LocalPlatform(),
     WidgetbookHttpClient? widgetbookHttpClient,
     WidgetbookZipEncoder? widgetbookZipEncoder,
     FileSystem? fileSystem,
     CiWrapper? ciWrapper,
     GitWrapper? gitWrapper,
     StdInWrapper? stdInWrapper,
-    PlatformWrapper? platformWrapper,
     UseCaseParser? useCaseParser,
   })  : _widgetbookHttpClient = widgetbookHttpClient ?? WidgetbookHttpClient(),
         _widgetbookZipEncoder = widgetbookZipEncoder ?? WidgetbookZipEncoder(),
         _ciWrapper = ciWrapper ?? CiWrapper(),
         _gitWrapper = gitWrapper ?? GitWrapper(),
         _stdInWrapper = stdInWrapper ?? StdInWrapper(),
-        _platformWrapper = platformWrapper ?? PlatformWrapper(),
         _useCaseParser = useCaseParser,
         _fileSystem = fileSystem ?? const LocalFileSystem() {
     progress = logger.progress('Publishing Widgetbook');
@@ -129,13 +129,13 @@ class PublishCommand extends WidgetbookCommand {
   final String name = 'publish';
 
   CiParserRunner? ciParserRunner;
+  final Platform platform;
   final WidgetbookHttpClient _widgetbookHttpClient;
   final WidgetbookZipEncoder _widgetbookZipEncoder;
   final FileSystem _fileSystem;
   final CiWrapper _ciWrapper;
   final GitWrapper _gitWrapper;
   final StdInWrapper _stdInWrapper;
-  final PlatformWrapper _platformWrapper;
   final UseCaseParser? _useCaseParser;
 
   late final Progress progress;
@@ -201,15 +201,13 @@ class PublishCommand extends WidgetbookCommand {
   @visibleForTesting
   String? gitProviderSha() {
     if (_ciWrapper.isGithub()) {
-      return _platformWrapper.environmentVariable(
-        variable: 'GITHUB_SHA',
-      );
+      return platform.environment['GITHUB_SHA'];
     }
+
     if (_ciWrapper.isCodemagic()) {
-      return _platformWrapper.environmentVariable(
-        variable: 'CM_COMMIT',
-      );
+      return platform.environment['CM_COMMIT'];
     }
+
     return null;
   }
 

--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   mason_logger: ^0.2.5
   meta: ^1.8.0
   path: ^1.8.2
+  platform: ^3.0.0
   pub_updater: ^0.3.0 
   version: ^3.0.2
 

--- a/packages/widgetbook_cli/test/ci_parser/azure_parser_test.dart
+++ b/packages/widgetbook_cli/test/ci_parser/azure_parser_test.dart
@@ -1,5 +1,6 @@
 import 'package:args/args.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import '../../bin/ci_parser/ci_parser.dart';
@@ -14,15 +15,15 @@ const actorEnvVariable = 'Agent.Name';
 void main() {
   late AzureParser sut;
   late ArgResults argResults;
-  late PlatformWrapper platformWrapper;
+  late Platform platform;
 
   setUp(() async {
     argResults = MockArgResults();
-    platformWrapper = MockPlatformWrapper();
+    platform = MockPlatform();
 
     sut = AzureParser(
       argResults: argResults,
-      platformWrapper: platformWrapper,
+      platform: platform,
     );
   });
 
@@ -34,9 +35,9 @@ void main() {
       },
     );
     test(
-      'expect instance of $PlatformWrapper',
+      'expect instance of $Platform',
       () async {
-        expect(sut.platformWrapper, equals(platformWrapper));
+        expect(sut.platform, equals(platform));
       },
     );
 
@@ -51,10 +52,10 @@ void main() {
       'can get a repository',
       () async {
         when(
-          () => platformWrapper.environmentVariable(
-            variable: repositoryEnvVariable,
-          ),
-        ).thenReturn(repositoryName);
+          () => platform.environment,
+        ).thenReturn({
+          repositoryEnvVariable: repositoryName,
+        });
 
         final repository = await sut.getRepository();
         expect(repository, equals(repositoryName));
@@ -64,10 +65,10 @@ void main() {
       'can get an actor',
       () async {
         when(
-          () => platformWrapper.environmentVariable(
-            variable: actorEnvVariable,
-          ),
-        ).thenReturn(actorName);
+          () => platform.environment,
+        ).thenReturn({
+          actorEnvVariable: actorName,
+        });
 
         final actor = await sut.getActor();
         expect(actor, equals(actorName));

--- a/packages/widgetbook_cli/test/ci_parser/bitbucket_parser_test.dart
+++ b/packages/widgetbook_cli/test/ci_parser/bitbucket_parser_test.dart
@@ -1,5 +1,6 @@
 import 'package:args/args.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import '../../bin/ci_parser/ci_parser.dart';
@@ -14,15 +15,15 @@ const actorEnvVariable = 'BITBUCKET_STEP_TRIGGERER_UUID';
 void main() {
   late BitbucketParser sut;
   late ArgResults argResults;
-  late PlatformWrapper platformWrapper;
+  late Platform platform;
 
   setUp(() async {
     argResults = MockArgResults();
-    platformWrapper = MockPlatformWrapper();
+    platform = MockPlatform();
 
     sut = BitbucketParser(
       argResults: argResults,
-      platformWrapper: platformWrapper,
+      platform: platform,
     );
   });
 
@@ -35,9 +36,9 @@ void main() {
     );
 
     test(
-      'expect instance of $PlatformWrapper',
+      'expect instance of $Platform',
       () async {
-        expect(sut.platformWrapper, equals(platformWrapper));
+        expect(sut.platform, equals(platform));
       },
     );
 
@@ -52,10 +53,11 @@ void main() {
       'can get a repository',
       () async {
         when(
-          () => platformWrapper.environmentVariable(
-            variable: repositoryEnvVariable,
-          ),
-        ).thenReturn(repositoryName);
+          () => platform.environment,
+        ).thenReturn({
+          repositoryEnvVariable: repositoryName,
+        });
+
         final repository = await sut.getRepository();
         expect(repository, equals(repositoryName));
       },
@@ -64,10 +66,11 @@ void main() {
       'can get an actor',
       () async {
         when(
-          () => platformWrapper.environmentVariable(
-            variable: actorEnvVariable,
-          ),
-        ).thenReturn(actorName);
+          () => platform.environment,
+        ).thenReturn({
+          actorEnvVariable: actorName,
+        });
+
         final actor = await sut.getActor();
         expect(actor, equals(actorName));
       },

--- a/packages/widgetbook_cli/test/ci_parser/ci_parser_runner_test.dart
+++ b/packages/widgetbook_cli/test/ci_parser/ci_parser_runner_test.dart
@@ -1,5 +1,6 @@
 import 'package:args/args.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import '../../bin/ci_parser/ci_parser.dart';
@@ -15,19 +16,19 @@ void main() {
   late ArgResults argResults;
   late GitDir gitDir;
   late CiWrapper ciWrapper;
-  late PlatformWrapper platformWrapper;
+  late Platform platform;
 
   setUp(() async {
     argResults = MockArgResults();
     gitDir = MockGitDir();
     ciWrapper = MockCiWrapper();
-    platformWrapper = MockPlatformWrapper();
+    platform = MockPlatform();
 
     sut = CiParserRunner(
       argResults: argResults,
       gitDir: gitDir,
       ciWrapper: ciWrapper,
-      platformWrapper: platformWrapper,
+      platform: platform,
     );
   });
 
@@ -76,18 +77,12 @@ void main() {
       () async {
         when(() => ciWrapper.isCI()).thenReturn(true);
         when(() => ciWrapper.isGitLab()).thenReturn(true);
-
         when(
-          () => platformWrapper.environmentVariable(
-            variable: 'CI_PROJECT_NAME',
-          ),
-        ).thenReturn(repositoryName);
-
-        when(
-          () => platformWrapper.environmentVariable(
-            variable: 'GITLAB_USER_NAME',
-          ),
-        ).thenReturn(actorName);
+          () => platform.environment,
+        ).thenReturn({
+          'CI_PROJECT_NAME': repositoryName,
+          'GITLAB_USER_NAME': actorName,
+        });
 
         final ciArgs = await sut.getParser()?.getCiArgs();
 
@@ -104,18 +99,12 @@ void main() {
         when(() => ciWrapper.isBitBucket()).thenReturn(false);
         when(() => ciWrapper.isGitLab()).thenReturn(false);
         when(() => ciWrapper.isAzure()).thenReturn(false);
-
         when(
-          () => platformWrapper.environmentVariable(
-            variable: 'GITHUB_REPOSITORY',
-          ),
-        ).thenReturn(repositoryName);
-
-        when(
-          () => platformWrapper.environmentVariable(
-            variable: 'GITHUB_ACTOR',
-          ),
-        ).thenReturn(actorName);
+          () => platform.environment,
+        ).thenReturn({
+          'GITHUB_REPOSITORY': repositoryName,
+          'GITHUB_ACTOR': actorName,
+        });
 
         final ciArgs = await sut.getParser()?.getCiArgs();
 
@@ -130,22 +119,15 @@ void main() {
       () async {
         when(() => ciWrapper.isCI()).thenReturn(true);
         when(() => ciWrapper.isAzure()).thenReturn(true);
-
         when(() => ciWrapper.isBitBucket()).thenReturn(false);
         when(() => ciWrapper.isGitLab()).thenReturn(false);
         when(() => ciWrapper.isGithub()).thenReturn(false);
-
         when(
-          () => platformWrapper.environmentVariable(
-            variable: 'Build.Repository.Name',
-          ),
-        ).thenReturn(repositoryName);
-
-        when(
-          () => platformWrapper.environmentVariable(
-            variable: 'Agent.Name',
-          ),
-        ).thenReturn(actorName);
+          () => platform.environment,
+        ).thenReturn({
+          'Build.Repository.Name': repositoryName,
+          'Agent.Name': actorName,
+        });
 
         final ciArgs = await sut.getParser()?.getCiArgs();
 
@@ -160,22 +142,15 @@ void main() {
       () async {
         when(() => ciWrapper.isCI()).thenReturn(true);
         when(() => ciWrapper.isBitBucket()).thenReturn(true);
-
         when(() => ciWrapper.isAzure()).thenReturn(false);
         when(() => ciWrapper.isGitLab()).thenReturn(false);
         when(() => ciWrapper.isGithub()).thenReturn(false);
-
         when(
-          () => platformWrapper.environmentVariable(
-            variable: 'BITBUCKET_REPO_FULL_NAME',
-          ),
-        ).thenReturn(repositoryName);
-
-        when(
-          () => platformWrapper.environmentVariable(
-            variable: 'BITBUCKET_STEP_TRIGGERER_UUID',
-          ),
-        ).thenReturn(actorName);
+          () => platform.environment,
+        ).thenReturn({
+          'BITBUCKET_REPO_FULL_NAME': repositoryName,
+          'BITBUCKET_STEP_TRIGGERER_UUID': actorName,
+        });
 
         final ciArgs = await sut.getParser()?.getCiArgs();
 

--- a/packages/widgetbook_cli/test/ci_parser/github_parser_test.dart
+++ b/packages/widgetbook_cli/test/ci_parser/github_parser_test.dart
@@ -1,5 +1,6 @@
 import 'package:args/args.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import '../../bin/ci_parser/ci_parser.dart';
@@ -14,15 +15,15 @@ const actorEnvVariable = 'GITHUB_ACTOR';
 void main() {
   late GitHubParser sut;
   late ArgResults argResults;
-  late PlatformWrapper platformWrapper;
+  late Platform platform;
 
   setUp(() async {
     argResults = MockArgResults();
-    platformWrapper = MockPlatformWrapper();
+    platform = MockPlatform();
 
     sut = GitHubParser(
       argResults: argResults,
-      platformWrapper: platformWrapper,
+      platform: platform,
     );
   });
 
@@ -35,9 +36,9 @@ void main() {
     );
 
     test(
-      'expect instance of $PlatformWrapper',
+      'expect instance of $Platform',
       () async {
-        expect(sut.platformWrapper, equals(platformWrapper));
+        expect(sut.platform, equals(platform));
       },
     );
 
@@ -52,10 +53,11 @@ void main() {
       'can get a repository',
       () async {
         when(
-          () => platformWrapper.environmentVariable(
-            variable: repositoryEnvVariable,
-          ),
-        ).thenReturn(repositoryName);
+          () => platform.environment,
+        ).thenReturn({
+          repositoryEnvVariable: repositoryName,
+        });
+
         final repository = await sut.getRepository();
         expect(repository, equals(repositoryName));
       },
@@ -64,10 +66,11 @@ void main() {
       'can get an actor',
       () async {
         when(
-          () => platformWrapper.environmentVariable(
-            variable: actorEnvVariable,
-          ),
-        ).thenReturn(actorName);
+          () => platform.environment,
+        ).thenReturn({
+          actorEnvVariable: actorName,
+        });
+
         final actor = await sut.getActor();
         expect(actor, equals(actorName));
       },

--- a/packages/widgetbook_cli/test/ci_parser/gitlab_parser_test.dart
+++ b/packages/widgetbook_cli/test/ci_parser/gitlab_parser_test.dart
@@ -1,5 +1,6 @@
 import 'package:args/args.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import '../../bin/ci_parser/ci_parser.dart';
@@ -14,15 +15,15 @@ const actorEnvVariable = 'GITLAB_USER_NAME';
 void main() {
   late GitLabParser sut;
   late ArgResults argResults;
-  late PlatformWrapper platformWrapper;
+  late Platform platform;
 
   setUp(() async {
     argResults = MockArgResults();
-    platformWrapper = MockPlatformWrapper();
+    platform = MockPlatform();
 
     sut = GitLabParser(
       argResults: argResults,
-      platformWrapper: platformWrapper,
+      platform: platform,
     );
   });
 
@@ -45,10 +46,11 @@ void main() {
       'can get a repository',
       () async {
         when(
-          () => platformWrapper.environmentVariable(
-            variable: repositoryEnvVariable,
-          ),
-        ).thenReturn(repositoryName);
+          () => platform.environment,
+        ).thenReturn({
+          repositoryEnvVariable: repositoryName,
+        });
+
         final repository = await sut.getRepository();
         expect(repository, equals(repositoryName));
       },
@@ -57,10 +59,11 @@ void main() {
       'can get an actor',
       () async {
         when(
-          () => platformWrapper.environmentVariable(
-            variable: actorEnvVariable,
-          ),
-        ).thenReturn(actorName);
+          () => platform.environment,
+        ).thenReturn({
+          actorEnvVariable: actorName,
+        });
+
         final actor = await sut.getActor();
         expect(actor, equals(actorName));
       },

--- a/packages/widgetbook_cli/test/mocks/command_mocks.dart
+++ b/packages/widgetbook_cli/test/mocks/command_mocks.dart
@@ -4,6 +4,7 @@ import 'package:args/args.dart';
 import 'package:file/local.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:platform/platform.dart';
 import 'package:pub_updater/pub_updater.dart';
 
 import '../../bin/api/widgetbook_http_client.dart';
@@ -42,6 +43,6 @@ class MockCiWrapper extends Mock implements CiWrapper {}
 
 class MockStdInWrapper extends Mock implements StdInWrapper {}
 
-class MockPlatformWrapper extends Mock implements PlatformWrapper {}
+class MockPlatform extends Mock implements Platform {}
 
 class MockUseCaseParser extends Mock implements UseCaseParser {}


### PR DESCRIPTION
Use [`platform`](https://pub.dev/packages/platform) package to mock `dart:io`'s `Platform` instead of using `PlatformWrapper`.