### PR TITLE
refactor(cli): remove `--git-provider` option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,6 @@
                 "--api-key", "abc",
                 "--repository", "test-repo",
                 "--actor", "jenshor",
-                "--git-provider", "CLI",
                 "--base-branch", "main"
             ]
         },

--- a/docs/widgetbook-cli/overview.mdx
+++ b/docs/widgetbook-cli/overview.mdx
@@ -45,7 +45,6 @@ The CLI accepts the following arguments.
 | `--commit`       | ➖        | The SHA hash of the commit for which the Widgetbook is uploaded. Defaults to the last commit of the current git branch. |
 | `--repository`   | ➖        | The name of the repository for which the Widgetbook is uploaded.|
 | `--actor`        | ➖        | The username of the actor which triggered the build.|
-| `--git-provider` | ➖        | The name of the Git provider. Allowed values: `GitHub`, `GitLab`, `BitBucket`, `Azure`, `Local`. Defaults to `Local` |
 | `--base-branch`  | ➖        | The name of the pull-request's base branch. |
 | `--base-commit`  | ➖        | The SHA hash of pull-request's base branch. Defaults to the last commit of `base-branch`, if `base-branch` is set. |
 | `--pr`           | ➖        | The number of the PR on which the CLI is running. |

--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **BREAKING**: Remove `--git-provider` option from `publish` command. ([#913](https://github.com/widgetbook/widgetbook/pull/913))
+
 ## 3.0.0-rc.3
 
 - **REFACTOR**: :recycle: improved error handling. [#831](https://github.com/widgetbook/widgetbook/pull/831)

--- a/packages/widgetbook_cli/README.md
+++ b/packages/widgetbook_cli/README.md
@@ -49,7 +49,6 @@ The CLI accepts the following arguments.
 | `--commit`       | ➖        | The SHA hash of the commit for which the Widgetbook is uploaded. Defaults to the last commit of the current git branch. |
 | `--repository`   | ➖        | The name of the repository for which the Widgetbook is uploaded.|
 | `--actor`        | ➖        | The username of the actor which triggered the build.|
-| `--git-provider` | ➖        | The name of the Git provider. Allowed values: `GitHub`, `GitLab`, `BitBucket`, `Azure`, `Local`. Defaults to `Local` |
 | `--base-branch`  | ➖        | The name of the pull-request's base branch. |
 | `--base-commit`  | ➖        | The SHA hash of pull-request's base branch. Defaults to the last commit of `base-branch`, if `base-branch` is set. |
 | `--pr`           | ➖        | The number of the PR on which the CLI is running. |

--- a/packages/widgetbook_cli/bin/commands/publish.dart
+++ b/packages/widgetbook_cli/bin/commands/publish.dart
@@ -91,18 +91,6 @@ class PublishCommand extends WidgetbookCommand {
         help: 'The username of the actor which triggered the build.',
       )
       ..addOption(
-        'git-provider',
-        help: 'The name of the Git provider.',
-        defaultsTo: 'Local',
-        allowed: [
-          'GitHub',
-          'GitLab',
-          'BitBucket',
-          'Azure',
-          'Local',
-        ],
-      )
-      ..addOption(
         'base-branch',
         help:
             'The base branch of the pull-request. For example, main or master.',
@@ -223,7 +211,6 @@ class PublishCommand extends WidgetbookCommand {
     final commit =
         results['commit'] as String? ?? gitProviderSha() ?? currentBranch.sha;
 
-    final gitProvider = results['git-provider'] as String;
     final gitHubToken = results['github-token'] as String?;
     final prNumber = results['pr'] as String?;
 
@@ -249,7 +236,6 @@ class PublishCommand extends WidgetbookCommand {
       apiKey: apiKey,
       branch: branch,
       commit: commit,
-      gitProvider: gitProvider,
       path: path,
       vendor: ciArgs.vendor,
       actor: actor,

--- a/packages/widgetbook_cli/bin/models/publish_args.dart
+++ b/packages/widgetbook_cli/bin/models/publish_args.dart
@@ -3,7 +3,6 @@ class PublishArgs {
     required this.apiKey,
     required this.branch,
     required this.commit,
-    required this.gitProvider,
     required this.path,
     required this.vendor,
     required this.actor,
@@ -17,7 +16,6 @@ class PublishArgs {
   final String apiKey;
   final String branch;
   final String commit;
-  final String gitProvider;
   final String path;
   final String vendor;
   final String actor;
@@ -37,7 +35,6 @@ class PublishArgs {
     return other.apiKey == apiKey &&
         other.branch == branch &&
         other.commit == commit &&
-        other.gitProvider == gitProvider &&
         other.path == path &&
         other.vendor == vendor &&
         other.actor == actor &&
@@ -53,7 +50,6 @@ class PublishArgs {
     return apiKey.hashCode ^
         branch.hashCode ^
         commit.hashCode ^
-        gitProvider.hashCode ^
         path.hashCode ^
         vendor.hashCode ^
         actor.hashCode ^

--- a/packages/widgetbook_cli/test/commands/publish_test.dart
+++ b/packages/widgetbook_cli/test/commands/publish_test.dart
@@ -35,7 +35,6 @@ class FakeDirectory extends Fake implements Directory {}
 
 void main() {
   const apiKey = 'Api-Key';
-  const gitProvider = 'Local';
   const path = 'path';
   const branch = 'branch';
   const commit = 'commit';
@@ -76,7 +75,6 @@ void main() {
       )..testArgResults = argResults;
 
       when(() => argResults['api-key'] as String).thenReturn(apiKey);
-      when(() => argResults['git-provider'] as String).thenReturn(gitProvider);
 
       registerFallbackValue(FakeFile());
       registerFallbackValue(FakeCreateBuildRequest());
@@ -496,8 +494,6 @@ void main() {
             when(() => argResults['path'] as String).thenReturn(path);
             when(() => argResults['api-key'] as String).thenReturn(apiKey);
             when(() => argResults['commit'] as String).thenReturn(commit);
-            when(() => argResults['git-provider'] as String)
-                .thenReturn(gitProvider);
 
             // Setup mocks for getArgumentsFromCi
             when(() => ciParserRunner.getParser()).thenReturn(ciParser);
@@ -522,7 +518,6 @@ void main() {
                   apiKey: apiKey,
                   branch: branch,
                   commit: commit,
-                  gitProvider: gitProvider,
                   vendor: vendor,
                   actor: actor,
                   repository: repository,
@@ -547,7 +542,6 @@ void main() {
                   apiKey: apiKey,
                   branch: branchReference.reference,
                   commit: commit,
-                  gitProvider: gitProvider,
                   vendor: vendor,
                   actor: actor,
                   repository: repository,

--- a/packages/widgetbook_cli/test/helpers/test_data.dart
+++ b/packages/widgetbook_cli/test/helpers/test_data.dart
@@ -18,7 +18,6 @@ class TestData {
     apiKey: 'apiKey',
     branch: 'branch',
     commit: 'commit',
-    gitProvider: 'gitProvider',
     gitHubToken: 'gitHubToken',
     prNumber: 'prNumber',
     baseBranch: 'baseBranch',


### PR DESCRIPTION
The `--git-provider` option was redundant as only GitHub was supported as a provider, and passing different values have no effect.