### PR TITLE
refactor(cli): split `publish` method

### DIFF
--- a/packages/widgetbook_cli/bin/review/use_cases/use_case_parser.dart
+++ b/packages/widgetbook_cli/bin/review/use_cases/use_case_parser.dart
@@ -77,55 +77,50 @@ class UseCaseParser extends GeneratorParser<ChangedUseCase> {
 
   @override
   Future<List<ChangedUseCase>> parse() async {
-    // TODO we should be able to remove this
-    if (fileSystem.isDirectorySync(generatedFolderPath)) {
-      // TODO we should do this first
-      if (!await GitDir.isGitDir(projectPath)) {
-        return [];
-      }
-
-      final files =
-          getFilesFromGeneratedFolder(fileExtension: '.usecase.widgetbook.json')
-              .toList();
-
-      // TODO use getItemsFromFiles instead!
-      final useCases = _getUseCasesFromFiles(files).toList();
-
-      final gitDir = await GitDir.fromExisting(
-        projectPath,
-        allowSubdirectory: true,
-      );
-
-      final fileDiffs = await gitDir.diff(
-        base: baseBranch,
-      );
-
-      final changedUseCases = <ChangedUseCase>[];
-
-      // TODO this is inefficient
-      for (final useCase in useCases) {
-        for (final diff in fileDiffs) {
-          if (_hasChanged(usecase: useCase, diff: diff)) {
-            changedUseCases.add(
-              ChangedUseCase(
-                name: useCase.useCaseName,
-                componentName: useCase.componentName,
-                componentDefinitionPath: useCase.componentDefinitionPath,
-                // TODO works for now, but on a file level we can't really say
-                // if a single use-case was added or not
-                // for this, we require AT LEAST line-diff functionality
-                modification: diff.modification,
-                designLink: useCase.designLink,
-              ),
-            );
-            break;
-          }
-        }
-      }
-
-      return changedUseCases;
+    // TODO we should do this first
+    if (!await GitDir.isGitDir(projectPath)) {
+      return [];
     }
 
-    return [];
+    final files = getFilesFromGeneratedFolder(
+      fileExtension: '.usecase.widgetbook.json',
+    ).toList();
+
+    // TODO use getItemsFromFiles instead!
+    final useCases = _getUseCasesFromFiles(files).toList();
+
+    final gitDir = await GitDir.fromExisting(
+      projectPath,
+      allowSubdirectory: true,
+    );
+
+    final fileDiffs = await gitDir.diff(
+      base: baseBranch,
+    );
+
+    final changedUseCases = <ChangedUseCase>[];
+
+    // TODO this is inefficient
+    for (final useCase in useCases) {
+      for (final diff in fileDiffs) {
+        if (_hasChanged(usecase: useCase, diff: diff)) {
+          changedUseCases.add(
+            ChangedUseCase(
+              name: useCase.useCaseName,
+              componentName: useCase.componentName,
+              componentDefinitionPath: useCase.componentDefinitionPath,
+              // TODO works for now, but on a file level we can't really say
+              // if a single use-case was added or not
+              // for this, we require AT LEAST line-diff functionality
+              modification: diff.modification,
+              designLink: useCase.designLink,
+            ),
+          );
+          break;
+        }
+      }
+    }
+
+    return changedUseCases;
   }
 }

--- a/packages/widgetbook_cli/test/commands/publish_test.dart
+++ b/packages/widgetbook_cli/test/commands/publish_test.dart
@@ -613,7 +613,7 @@ void main() {
 
     test(
         'throws a $ExitedByUser when user decides not to '
-        'proceed with un-commited changes', () async {
+        'proceed with un-committed changes', () async {
       final publishCommand = PublishCommand(
         logger: logger,
         gitWrapper: gitWrapper,
@@ -668,18 +668,6 @@ void main() {
     });
 
     test(
-      'throws $DirectoryNotFoundException when web folder is not found',
-      () {
-        final fileSystem = MemoryFileSystem.test();
-
-        expect(
-          () => publishCommand.getZipFile(fileSystem.directory('/web')),
-          throwsA(const TypeMatcher<DirectoryNotFoundException>()),
-        );
-      },
-    );
-
-    test(
       'throws $UnableToCreateZipFileException when zip file could '
       'not be create for upload',
       () {
@@ -694,25 +682,9 @@ void main() {
         )..testArgResults = argResults;
 
         expect(
-          () => command.publishBuilds(
-            args: TestData.args,
-            gitDir: gitDir,
-            getZipFile: (fileSystem) => null,
-          ),
+          () => command.publish(TestData.args),
           throwsA(const TypeMatcher<UnableToCreateZipFileException>()),
         );
-      },
-    );
-
-    test(
-      'delete zip',
-      () {
-        final fileSystem = MemoryFileSystem.test();
-        final file = fileSystem.file('web.zip')..createSync();
-
-        expect(file.existsSync(), isTrue);
-        publishCommand.deleteZip(file);
-        expect(file.existsSync(), isFalse);
       },
     );
 


### PR DESCRIPTION
The old `publishBuilds` method was a big function that did a lot of logic, so it has been renamed to `publish` and split into two methods, `publishBuild` and `publishReview`, for better maintainability.