### PR TITLE
docs: update sign-up link

### DIFF
--- a/docs/widgetbook-cloud/signup.mdx
+++ b/docs/widgetbook-cloud/signup.mdx
@@ -1,9 +1,6 @@
 # Sign-up
 
-To get started, follow the steps below:
-
-1. Sign up for Early Access to Widgetbook Cloud by visiting [widgetbook.io early access form](https://ic7614zmz3s.typeform.com/to/bqG82ECS#hubspot_utk=xxxxx&hubspot_page_name=xxxxx&hubspot_page_url=xxxxx).
-2. Congrats! You're on our waiting list now.
+Sign up for Early Access to Widgetbook Cloud by visiting [widgetbook.io](https://www.widgetbook.io/plans).
 
 **New to Widgetbook Cloud?**
 


### PR DESCRIPTION
You can now sign up for Widgetbook Cloud using this [link](https://www.widgetbook.io/plans).