### PR TITLE
fix: respect Double Slider Knob's `initialValue`

### DIFF
--- a/packages/widgetbook/lib/src/knobs/builders/double_knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/double_knobs_builder.dart
@@ -17,17 +17,30 @@ class DoubleKnobsBuilder {
     double? min,
     int? divisions,
   }) {
-    initialValue ??= max ?? min ?? 10;
-    return onKnobAdded(
-      DoubleSliderKnob(
-        label: label,
-        value: initialValue,
-        description: description,
-        min: min ?? initialValue - 10,
-        max: max ?? initialValue + 10,
-        divisions: divisions,
-      ),
-    )!;
+    if (initialValue == null) {
+      return onKnobAdded(
+        DoubleSliderKnob(
+          label: label,
+          value: initialValue,
+          description: description,
+          min: min!,
+          max: max!,
+          divisions: divisions,
+        ),
+      )!;
+    } else {
+      initialValue = max ?? min ?? 10;
+      return onKnobAdded(
+        DoubleSliderKnob(
+          label: label,
+          value: initialValue,
+          description: description,
+          min: min ?? initialValue - 10,
+          max: max ?? initialValue + 10,
+          divisions: divisions,
+        ),
+      )!;
+    }
   }
 
   /// Creates a textfield which users can type double values into. You can use

--- a/packages/widgetbook/lib/src/knobs/builders/double_knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/double_knobs_builder.dart
@@ -17,30 +17,16 @@ class DoubleKnobsBuilder {
     double? min,
     int? divisions,
   }) {
-    if (initialValue == null) {
-      return onKnobAdded(
-        DoubleSliderKnob(
-          label: label,
-          value: initialValue,
-          description: description,
-          min: min!,
-          max: max!,
-          divisions: divisions,
-        ),
-      )!;
-    } else {
-      initialValue = max ?? min ?? 10;
-      return onKnobAdded(
-        DoubleSliderKnob(
-          label: label,
-          value: initialValue,
-          description: description,
-          min: min ?? initialValue - 10,
-          max: max ?? initialValue + 10,
-          divisions: divisions,
-        ),
-      )!;
-    }
+    return onKnobAdded(
+      DoubleSliderKnob.nullable(
+        label: label,
+        value: initialValue,
+        description: description,
+        min: min ?? (initialValue == null ? 0 : initialValue - 10),
+        max: max ?? (initialValue == null ? 10 : initialValue + 10),
+        divisions: divisions,
+      ),
+    )!;
   }
 
   /// Creates a textfield which users can type double values into. You can use


### PR DESCRIPTION
*Added an explicit check if  the initialValue is null before applying the default value. If it's null, the provided null value will be respected; otherwise, the default logic will be applied.*

### List of issues which are fixed by the PR
*When using context.knobs.doubleOrNull.slider() with an initialValue: null, the initial value is set to a non-null value.*


### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
