### PR TITLE
refactor(cli): remove `--base-commit` option

### DIFF
--- a/docs/widgetbook-cli/overview.mdx
+++ b/docs/widgetbook-cli/overview.mdx
@@ -46,12 +46,11 @@ The CLI accepts the following arguments.
 | `--repository`   | ➖        | The name of the repository for which the Widgetbook is uploaded.|
 | `--actor`        | ➖        | The username of the actor which triggered the build.|
 | `--base-branch`  | ➖        | The name of the pull-request's base branch. |
-| `--base-commit`  | ➖        | The SHA hash of pull-request's base branch. Defaults to the last commit of `base-branch`, if `base-branch` is set. |
 | `--pr`           | ➖        | The number of the PR on which the CLI is running. |
 | `--github-token` | ➖        | The authentication token to post comments to the PR on which the CLI is running. |
 
-If `base-branch` or `base-commit` are omitted, a Widgetbook Build is created. 
-If `base-branch` is provided, a Widgetbook Build and a Widgetbook Review is created.
+If `base-branch` is omitted, a **Widgetbook Build** is created. 
+If `base-branch` is provided, a **Widgetbook Build** and a **Widgetbook Review** is created.
 
 ### Example
 

--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **BREAKING**: Remove `--git-provider` option from `publish` command. ([#913](https://github.com/widgetbook/widgetbook/pull/913))
+- **BREAKING**: Remove `--base-commit` option from `publish` command. ([#936](https://github.com/widgetbook/widgetbook/pull/936))
 
 ## 3.0.0-rc.3
 

--- a/packages/widgetbook_cli/README.md
+++ b/packages/widgetbook_cli/README.md
@@ -50,12 +50,11 @@ The CLI accepts the following arguments.
 | `--repository`   | ➖        | The name of the repository for which the Widgetbook is uploaded.|
 | `--actor`        | ➖        | The username of the actor which triggered the build.|
 | `--base-branch`  | ➖        | The name of the pull-request's base branch. |
-| `--base-commit`  | ➖        | The SHA hash of pull-request's base branch. Defaults to the last commit of `base-branch`, if `base-branch` is set. |
 | `--pr`           | ➖        | The number of the PR on which the CLI is running. |
 | `--github-token` | ➖        | The authentication token to post comments to the PR on which the CLI is running. |
 
-If `base-branch` or `base-commit` are omitted, a Widgetbook Build is created. 
-If `base-branch` is provided, a Widgetbook Build and a Widgetbook Review is created.
+If `base-branch` is omitted, a **Widgetbook Build** is created. 
+If `base-branch` is provided, a **Widgetbook Build** and a **Widgetbook Review** is created.
 
 ## Documentation
 

--- a/packages/widgetbook_cli/bin/commands/publish.dart
+++ b/packages/widgetbook_cli/bin/commands/publish.dart
@@ -91,10 +91,6 @@ class PublishCommand extends WidgetbookCommand {
             'The base branch of the pull-request. For example, main or master.',
       )
       ..addOption(
-        'base-commit',
-        help: 'The SHA hash of the commit of the base branch.',
-      )
-      ..addOption(
         'github-token',
         help: 'GitHub API token.',
       )
@@ -156,7 +152,6 @@ class PublishCommand extends WidgetbookCommand {
     final baseBranch = await getBaseBranch(
       repository: repository,
       branch: results['base-branch'] as String?,
-      sha: results['base-commit'] as String?,
     );
 
     final actor = results['actor'] as String? ?? context.userName;
@@ -222,7 +217,6 @@ class PublishCommand extends WidgetbookCommand {
   Future<Reference?> getBaseBranch({
     required Repository repository,
     required String? branch,
-    required String? sha,
   }) async {
     if (branch == null) {
       return null;

--- a/packages/widgetbook_cli/test/commands/publish_test.dart
+++ b/packages/widgetbook_cli/test/commands/publish_test.dart
@@ -114,7 +114,6 @@ void main() {
               final branch = await publishCommand.getBaseBranch(
                 repository: repository,
                 branch: 'a',
-                sha: null,
               );
               expect(branch, isNull);
             },
@@ -126,7 +125,6 @@ void main() {
               final branch = await publishCommand.getBaseBranch(
                 repository: repository,
                 branch: 'refs/heads/a',
-                sha: null,
               );
               expect(branch, isNull);
             },
@@ -138,7 +136,6 @@ void main() {
               final branch = await publishCommand.getBaseBranch(
                 repository: repository,
                 branch: 'c',
-                sha: null,
               );
               expect(branch, isNull);
             },
@@ -150,7 +147,6 @@ void main() {
               final branch = await publishCommand.getBaseBranch(
                 repository: repository,
                 branch: 'refs/remotes/c',
-                sha: null,
               );
               expect(branch, isNull);
             },
@@ -176,7 +172,6 @@ void main() {
                 final branch = await publishCommand.getBaseBranch(
                   repository: repository,
                   branch: 'refs/heads/c',
-                  sha: null,
                 );
                 expect(branch, equals(branchRefC));
               },
@@ -202,7 +197,6 @@ void main() {
               final branch = await publishCommand.getBaseBranch(
                 repository: repository,
                 branch: 'a',
-                sha: null,
               );
               expect(branch, equals(branchRefA));
             },
@@ -214,7 +208,6 @@ void main() {
               final branch = await publishCommand.getBaseBranch(
                 repository: repository,
                 branch: 'refs/heads/a',
-                sha: null,
               );
               expect(branch, equals(branchRefA));
             },
@@ -226,7 +219,6 @@ void main() {
               final branch = await publishCommand.getBaseBranch(
                 repository: repository,
                 branch: 'c',
-                sha: null,
               );
               expect(branch, equals(branchRefC));
             },
@@ -238,7 +230,6 @@ void main() {
               final branch = await publishCommand.getBaseBranch(
                 repository: repository,
                 branch: 'refs/remotes/c',
-                sha: null,
               );
               expect(branch, equals(branchRefC));
             },
@@ -714,7 +705,6 @@ void main() {
 
       when(() => argResults['path'] as String).thenReturn(tempDir.path);
       when(() => argResults['base-branch'] as String).thenReturn('main');
-      when(() => argResults['base-commit'] as String).thenReturn('base-commit');
       when(() => repository.user).thenAnswer((_) async => 'John Doe');
       when(() => repository.name).thenAnswer((_) async => 'widgetbook');
 


### PR DESCRIPTION
Following down the path of this option, it lead to nowhere.
Thus, it's going down until we add it properly (if needed).