### PR TITLE
docs: fix contribution URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ ensure a smooth and fruitful collaboration.
 ## Table of Contents
 
 - [Ways to Contribute](https://docs.widgetbook.io/contribution/ways-to-contribute)
-- [Getting Started](https://docs.widgetbook.io/contribution/getting-started)
+- [Getting Started](https://docs.widgetbook.io/contribution/get-started)
 - [Contribution Workflow](https://docs.widgetbook.io/contribution/contribution-workflow)
 - [Adding an Example](https://docs.widgetbook.io/contribution/adding-example)
 - [PR Title Conventions](https://docs.widgetbook.io/contribution//pr-conventions)

--- a/docs/contribution/get-started.mdx
+++ b/docs/contribution/get-started.mdx
@@ -16,7 +16,7 @@ Here's a step-by-step guide to get you started:
 
    _Tip:_ Regularly sync your fork with the main repository to stay updated with
    the latest changes. This helps in avoiding merge conflicts later on. Check
-   out [Synchronize Your Fork](/contribute/sync-your-fork).
+   out [Synchronize Your Fork](/contribution/sync-your-fork).
 
 2. **Clone Your Fork:** With your fork ready, clone it to your local machine to
    start development. Replace `<YOUR_USERNAME>` with your actual GitHub

--- a/docs/contribution/workflow.mdx
+++ b/docs/contribution/workflow.mdx
@@ -11,7 +11,7 @@ detailed walkthrough of the process:
 - Before starting any new work, ensure you have the latest updates from the main
   project.
 - Synchronize your fork with the main repository. If you're unsure, refer to the
-  section on [Synchronizing Your Fork](/contribute/sync-your-fork).
+  section on [Synchronizing Your Fork](/contribution/sync-your-fork).
 
 ### 2. Create a Branch
 


### PR DESCRIPTION
Fixed Getting started URL and Synchronize Your Fork URL

*Updated 2 URLs in th docs and read me files since the original ones were navigating to 404.*

### 2 wrong urls were fixed

### Checklist

- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing.
