### PR TITLE
feat: add int knob

### DIFF
--- a/docs/knobs/overview.mdx
+++ b/docs/knobs/overview.mdx
@@ -82,3 +82,5 @@ Widgetbook's UI:
 | listOrNull          | `T?`      |
 | duration            | `Duration`|
 | durationOrNull      | `Duration?`|
+| intbuilder          | `int`     |
+| intOrNull           | `int?`    |

--- a/packages/widgetbook/lib/src/fields/field_type.dart
+++ b/packages/widgetbook/lib/src/fields/field_type.dart
@@ -6,4 +6,5 @@ enum FieldType {
   list,
   string,
   duration,
+  int,
 }

--- a/packages/widgetbook/lib/src/fields/fields.dart
+++ b/packages/widgetbook/lib/src/fields/fields.dart
@@ -7,5 +7,6 @@ export 'field.dart';
 export 'field_codec.dart';
 export 'field_type.dart';
 export 'fields_composable.dart';
+export 'int_field.dart';
 export 'list_field.dart';
 export 'string_field.dart';

--- a/packages/widgetbook/lib/src/fields/int_field.dart
+++ b/packages/widgetbook/lib/src/fields/int_field.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'field.dart';
+import 'field_codec.dart';
+import 'field_type.dart';
+
+class IntField extends Field<int> {
+  IntField({
+    required super.name,
+    super.initialValue = 0,
+    super.onChanged,
+  }) : super(
+          type: FieldType.int,
+          codec: FieldCodec<int>(
+            toParam: (value) => value.toString(),
+            toValue: (param) => int.tryParse(param ?? ''),
+          ),
+        );
+
+  @override
+  Widget toWidget(BuildContext context, String label, int? currentValue) {
+    return TextFormField(
+      initialValue: codec.toParam(currentValue ?? initialValue ?? 0),
+      keyboardType: TextInputType.number,
+      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+      onChanged: (value) => updateField(
+        context,
+        label,
+        codec.toValue(value) ?? initialValue ?? 0,
+      ),
+    );
+  }
+}

--- a/packages/widgetbook/lib/src/knobs/builders/int_knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/int_knobs_builder.dart
@@ -1,0 +1,47 @@
+import '../int_knob.dart';
+import 'knobs_builder.dart';
+
+class IntKnobsBuilder {
+  IntKnobsBuilder(this.onKnobAdded);
+
+  final KnobAdded onKnobAdded;
+
+  /// Creates a textfield which users can type integer values into.
+  int input({
+    required String label,
+    String? description,
+    int initialValue = 0,
+  }) {
+    return onKnobAdded(
+      IntKnob(
+        label: label,
+        value: initialValue,
+        description: description,
+      ),
+    )!;
+  }
+}
+
+class IntOrNullKnobsBuilder {
+  IntOrNullKnobsBuilder(
+    KnobAdded onKnobAdded,
+  ) : this.onKnobAdded = onKnobAdded;
+
+  final KnobAdded onKnobAdded;
+
+  /// Creates a textfield which users can type integer values into.
+  /// Can optionally hold a null value.
+  int? input({
+    required String label,
+    String? description,
+    int? initialValue,
+  }) {
+    return onKnobAdded(
+      IntKnob.nullable(
+        label: label,
+        value: initialValue,
+        description: description,
+      ),
+    );
+  }
+}

--- a/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
@@ -8,6 +8,7 @@ import '../knob.dart';
 import '../list_knob.dart';
 import '../string_knob.dart';
 import 'double_knobs_builder.dart';
+import 'int_knobs_builder.dart';
 
 typedef KnobAdded = T? Function<T>(Knob<T?> knob);
 
@@ -15,11 +16,15 @@ class KnobsBuilder {
   KnobsBuilder(
     this.onKnobAdded,
   )   : this.double = DoubleKnobsBuilder(onKnobAdded),
-        this.doubleOrNull = DoubleOrNullKnobsBuilder(onKnobAdded);
+        this.doubleOrNull = DoubleOrNullKnobsBuilder(onKnobAdded),
+        this.intbuilder = IntKnobsBuilder(onKnobAdded),
+        this.intOrNull = IntOrNullKnobsBuilder(onKnobAdded);
 
   final KnobAdded onKnobAdded;
   final DoubleKnobsBuilder double;
   final DoubleOrNullKnobsBuilder doubleOrNull;
+  final IntKnobsBuilder intbuilder;
+  final IntOrNullKnobsBuilder intOrNull;
 
   /// Creates a checkbox that can be toggled on and off
   bool boolean({

--- a/packages/widgetbook/lib/src/knobs/int_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/int_knob.dart
@@ -1,0 +1,39 @@
+import 'package:meta/meta.dart';
+
+import '../fields/fields.dart';
+import '../state/widgetbook_state.dart';
+import 'knob.dart';
+
+@internal
+class IntKnob extends Knob<int?> {
+  IntKnob({
+    required super.label,
+    required super.value,
+    super.description,
+  });
+
+  IntKnob.nullable({
+    required super.label,
+    required super.value,
+    super.description,
+  }) : super(isNullable: true);
+
+  @override
+  List<Field> get fields {
+    return [
+      IntField(
+        name: label,
+        initialValue: value,
+        onChanged: (context, value) {
+          if (value == null) return;
+          WidgetbookState.of(context).knobs.updateValue(label, value);
+        },
+      ),
+    ];
+  }
+
+  @override
+  int? valueFromQueryGroup(Map<String, String> group) {
+    return valueOf(label, group);
+  }
+}

--- a/packages/widgetbook/lib/src/knobs/knobs.dart
+++ b/packages/widgetbook/lib/src/knobs/knobs.dart
@@ -6,6 +6,7 @@ export 'color_knob.dart';
 export 'double_input_knob.dart';
 export 'double_slider_knob.dart';
 export 'duration_knob.dart';
+export 'int_knob.dart';
 export 'knob.dart';
 export 'knobs_registry.dart';
 export 'list_knob.dart';

--- a/packages/widgetbook/test/src/fields/int_field_test.dart
+++ b/packages/widgetbook/test/src/fields/int_field_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+void main() {
+  group('$IntField', () {
+    final field = IntField(
+      name: 'int_field',
+      initialValue: 5,
+    );
+
+    test(
+      'given a value, '
+      'when [codec.toParam] is called, '
+      'then it returns the value as a string',
+      () {
+        final result = field.codec.toParam(7);
+        expect(result, equals('7'));
+      },
+    );
+
+    test(
+      'given a string param, '
+      'when [codec.toValue] is called, '
+      'then it returns the actual value',
+      () {
+        final result = field.codec.toValue('7');
+        expect(result, equals(7));
+      },
+    );
+
+    testWidgets(
+      'given a state that has no field value, '
+      'then [toWidget] builds the initial value',
+      (tester) async {
+        await tester.pumpWidget(
+          Builder(
+            builder: (context) {
+              return MaterialApp(
+                home: Material(
+                  child: field.toWidget(
+                    context,
+                    'int_field',
+                    null,
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+
+        expect(find.text('5'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'given a state that has a field value, '
+      'then [toWidget] builds that value',
+      (tester) async {
+        await tester.pumpWidget(
+          Builder(
+            builder: (context) {
+              return MaterialApp(
+                home: Material(
+                  child: field.toWidget(
+                    context,
+                    'int_field',
+                    7,
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+
+        expect(find.text('7'), findsOneWidget);
+      },
+    );
+  });
+}

--- a/packages/widgetbook/test/src/knobs/int_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/int_knob_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/src/knobs/knobs.dart';
+
+import '../../helper/helper.dart';
+
+void main() {
+  group(
+    '$IntKnob',
+    () {
+      testWidgets(
+        'given an initial value, '
+        'then the value should be displayed',
+        (tester) async {
+          const initialValue = 5;
+
+          await tester.pumpKnob(
+            (context) => Text(
+              context.knobs.intbuilder
+                  .input(
+                    label: 'IntKnob',
+                    initialValue: initialValue,
+                  )
+                  .toString(),
+            ),
+          );
+
+          expect(find.text('$initialValue'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'when field is updated, '
+        'then the value should be updated',
+        (tester) async {
+          const initialValue = 5;
+          const updatedValue = 10;
+
+          await tester.pumpKnob(
+            (context) => Text(
+              context.knobs.intbuilder
+                  .input(
+                    label: 'IntKnob',
+                    initialValue: initialValue,
+                  )
+                  .toString(),
+            ),
+          );
+
+          await tester.findAndEnter(
+            find.byType(TextField),
+            updatedValue.toString(),
+          );
+
+          expect(
+            find.text('${updatedValue}'),
+            findsOneWidget,
+          );
+        },
+      );
+    },
+  );
+
+  group('${IntKnob.nullable}', () {
+    test('IntKnob.nullable constructor sets correct values', () {
+      final knob = IntKnob.nullable(
+        label: 'Test Int',
+        value: 5,
+        description: 'A test int knob',
+      );
+
+      expect(knob.label, 'Test Int');
+      expect(knob.value, 5);
+      expect(knob.description, 'A test int knob');
+    });
+
+    test('IntKnob.nullable constructor handles null value', () {
+      final knob = IntKnob.nullable(
+        label: 'Test Int',
+        value: null,
+        description: 'A test int knob with null value',
+      );
+
+      expect(knob.label, 'Test Int');
+      expect(knob.value, null);
+      expect(knob.description, 'A test int knob with null value');
+    });
+  });
+
+  group('$KnobsBuilder', () {
+    int? mockOnKnobAdded<int>(Knob<int?> knob) => knob.value;
+    final builder = KnobsBuilder(mockOnKnobAdded);
+
+    test('intOrNull sets correct values', () {
+      final intValue = builder.intOrNull.input(
+        label: 'Test Int',
+        initialValue: 10,
+        description: 'A test int',
+      );
+
+      expect(intValue, 10);
+    });
+
+    test('intOrNull handles null initialValue', () {
+      final intValue = builder.intOrNull.input(
+        label: 'Test Int',
+        description: 'A test int with null value',
+      );
+
+      expect(intValue, null);
+    });
+  });
+}


### PR DESCRIPTION
Add int number knob.

IntField have been written to prevent decimals by setting the input formatter to `FilteringTextInputFormatter.digitsOnly`

### List of issues which are fixed by the PR
#430

### Screenshots

https://github.com/widgetbook/widgetbook/assets/31275429/7db112ae-ee4e-444e-9030-658029f25945



### Checklist

- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
