### PR TITLE
refactor(cli): remove `build_version`

### DIFF
--- a/packages/widgetbook_cli/bin/commands/upgrade.dart
+++ b/packages/widgetbook_cli/bin/commands/upgrade.dart
@@ -6,7 +6,7 @@ import 'package:pub_updater/pub_updater.dart';
 
 import '../core/cli_command.dart';
 import '../core/context.dart';
-import '../helpers/metadata.dart';
+import '../metadata.dart';
 
 class UpgradeCommand extends CliVoidCommand {
   UpgradeCommand({
@@ -45,7 +45,10 @@ class UpgradeCommand extends CliVoidCommand {
     final updateProgress = logger.progress('Upgrading to latest version');
 
     try {
-      final latestVersion = await pubUpdater.getLatestVersion(packageName);
+      final latestVersion = await pubUpdater.getLatestVersion(
+        packageName,
+      );
+
       await pubUpdater.update(
         packageName: packageName,
       );

--- a/packages/widgetbook_cli/bin/core/cli_runner.dart
+++ b/packages/widgetbook_cli/bin/core/cli_runner.dart
@@ -8,6 +8,7 @@ import 'package:pub_updater/pub_updater.dart';
 import '../commands/publish.dart';
 import '../commands/upgrade.dart';
 import '../helpers/helpers.dart';
+import '../metadata.dart';
 import 'context.dart';
 
 class CliRunner extends CommandRunner<int> {
@@ -17,7 +18,7 @@ class CliRunner extends CommandRunner<int> {
     PubUpdater? pubUpdater,
   })  : _logger = logger ?? Logger(),
         _pubUpdater = pubUpdater ?? PubUpdater(),
-        super(executableName, packageDescription) {
+        super(cliName, cliDescription) {
     argParser.addFlag(
       'version',
       negatable: false,
@@ -131,9 +132,10 @@ class CliRunner extends CommandRunner<int> {
       );
 
       _logger.info(
-        '\n${lightYellow.wrap('Update available!')} ${lightCyan.wrap(packageVersion)} \u2192 ${lightCyan.wrap(latestVersion)}\n'
+        '\n${lightYellow.wrap('Update available!')} '
+        '${lightCyan.wrap(packageVersion)} \u2192 ${lightCyan.wrap(latestVersion)}\n'
         '${lightYellow.wrap('Changelog:')} $changelogLink\n'
-        'Run ${cyan.wrap('$executableName update')} to update',
+        'Run ${cyan.wrap('${cliName} update')} to update',
       );
     } catch (_) {}
   }

--- a/packages/widgetbook_cli/bin/helpers/helpers.dart
+++ b/packages/widgetbook_cli/bin/helpers/helpers.dart
@@ -1,3 +1,2 @@
 export 'exceptions.dart';
-export 'metadata.dart';
 export 'zip_encoder.dart';

--- a/packages/widgetbook_cli/bin/helpers/metadata.dart
+++ b/packages/widgetbook_cli/bin/helpers/metadata.dart
@@ -1,5 +1,0 @@
-export 'version.dart';
-
-const executableName = 'widgetbook';
-const packageName = 'widgetbook_cli';
-const packageDescription = 'Widgetbook CLI';

--- a/packages/widgetbook_cli/bin/helpers/version.dart
+++ b/packages/widgetbook_cli/bin/helpers/version.dart
@@ -1,2 +1,0 @@
-// Generated code. Do not modify.
-const packageVersion = '3.0.0-rc.3';

--- a/packages/widgetbook_cli/bin/metadata.dart
+++ b/packages/widgetbook_cli/bin/metadata.dart
@@ -1,0 +1,11 @@
+/// The name of the CLI executable to be show in help menu
+const cliName = 'widgetbook';
+
+/// The description shown in the help menu
+const cliDescription = 'Widgetbook CLI';
+
+/// The name as in pubspec.yaml
+const packageName = 'widgetbook_cli';
+
+/// The version as in pubspec.yaml
+const packageVersion = '3.0.0-rc.3';

--- a/packages/widgetbook_cli/build.yaml
+++ b/packages/widgetbook_cli/build.yaml
@@ -1,6 +1,0 @@
-targets:
-  $default:
-    builders:
-      build_version:
-        options:
-          output: bin/helpers/version.dart

--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -31,8 +31,6 @@ dependencies:
   version: ^3.0.2
 
 dev_dependencies:
-  build_runner: ^2.1.10
-  build_version: ^2.1.1
   mocktail: ^1.0.0
   test: ^1.12.1
 

--- a/packages/widgetbook_cli/test/commands/upgrade_test.dart
+++ b/packages/widgetbook_cli/test/commands/upgrade_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 
 import '../../bin/core/cli_runner.dart';
 import '../../bin/core/context.dart';
-import '../../bin/helpers/metadata.dart';
+import '../../bin/metadata.dart';
 import '../utils/mocks.dart';
 
 void main() {
@@ -96,7 +96,11 @@ void main() {
       expect(result, equals(ExitCode.success.code));
       verify(() => logger.progress('Checking for updates')).called(1);
       verify(() => logger.progress('Upgrading to latest version')).called(1);
-      verify(() => pubUpdater.update(packageName: packageName)).called(1);
+      verify(
+        () => pubUpdater.update(
+          packageName: packageName,
+        ),
+      ).called(1);
     });
 
     test('does not update when already on latest version', () async {

--- a/packages/widgetbook_cli/test/core/cli_runner_test.dart
+++ b/packages/widgetbook_cli/test/core/cli_runner_test.dart
@@ -6,7 +6,7 @@ import 'package:pub_updater/pub_updater.dart';
 import 'package:test/test.dart';
 
 import '../../bin/core/cli_runner.dart';
-import '../../bin/helpers/helpers.dart';
+import '../../bin/metadata.dart';
 import '../utils/mocks.dart';
 import '../utils/utils.dart';
 
@@ -37,10 +37,10 @@ final changelogLink = lightCyan.wrap(
   ),
 );
 
-final updateMessage =
-    '\n${lightYellow.wrap('Update available!')} ${lightCyan.wrap(packageVersion)} \u2192 ${lightCyan.wrap(latestVersion)}\n'
+final updateMessage = '\n${lightYellow.wrap('Update available!')} '
+    '${lightCyan.wrap(packageVersion)} \u2192 ${lightCyan.wrap(latestVersion)}\n'
     '${lightYellow.wrap('Changelog:')} $changelogLink\n'
-    'Run ${cyan.wrap('$executableName update')} to update';
+    'Run ${cyan.wrap('${cliName} update')} to update';
 
 void main() {
   group('$CliRunner', () {

--- a/packages/widgetbook_cli/test/metadata_test.dart
+++ b/packages/widgetbook_cli/test/metadata_test.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../bin/metadata.dart';
+
+void main() {
+  final file = File('pubspec.yaml');
+  final lines = file.readAsLinesSync();
+
+  String getYamlValue(String key) {
+    final line = lines.firstWhere((x) => x.contains(key));
+    return line.split(':').last.trim();
+  }
+
+  group('metadata', () {
+    test('valid version', () {
+      final pubVersion = getYamlValue('version');
+
+      expect(
+        packageVersion,
+        equals(pubVersion),
+      );
+    });
+
+    test('valid name', () {
+      final pubName = getYamlValue('name');
+
+      expect(
+        packageName,
+        equals(pubName),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Manually update `packageVersion` instead of using code generation.
A test was added to make sure that the version is always up to date with `pubspec.yaml`.