### PR TITLE
ci: remove `MELOS_FILTERS`

### DIFF
--- a/.github/workflows/_package.yml
+++ b/.github/workflows/_package.yml
@@ -39,25 +39,14 @@ jobs:
       - name: Install Melos
         run: flutter pub global activate melos
 
-      - name: Build Melos Workspace
+      - name: Bootstrap Workspace
         working-directory: ${{ github.workspace }}
-        run: |
-          flutter pub get
-          melos --version # Needed to build melos executable
+        run: flutter pub get
 
-      - name: Create `MELOS_FILTERS`
+      - name: Bootstrap Package
         run: |
           PACKAGE_NAME=$(head -1 pubspec.yaml | cut -c7-)
-          FILTERS="--scope=$PACKAGE_NAME --include-dependencies"
-
-          # This variable is used to apply filters to melos scripts
-          echo "MELOS_FILTERS=$FILTERS" >> $GITHUB_ENV
-
-      - name: Install Dependencies
-        run: melos bootstrap $MELOS_FILTERS
-
-      - name: Generate Files
-        run: melos generate
+          melos bootstrap --scope=$PACKAGE_NAME --include-dependencies
 
       - name: Check Formatting
         run: dart format --set-exit-if-changed .
@@ -109,25 +98,14 @@ jobs:
       - name: Install Melos
         run: flutter pub global activate melos
 
-      - name: Build Melos Workspace
+      - name: Bootstrap Workspace
         working-directory: ${{ github.workspace }}
-        run: |
-          flutter pub get
-          melos --version # Needed to build melos executable
+        run: flutter pub get
 
-      - name: Create `MELOS_FILTERS`
+      - name: Bootstrap Package
         run: |
           PACKAGE_NAME=$(head -1 pubspec.yaml | cut -c7-)
-          FILTERS="--scope=$PACKAGE_NAME --include-dependencies"
-
-          # This variable is used to apply filters to melos scripts
-          echo "MELOS_FILTERS=$FILTERS" >> $GITHUB_ENV
-
-      - name: Install Dependencies
-        run: melos bootstrap $MELOS_FILTERS
-
-      - name: Generate Files
-        run: melos generate
+          melos bootstrap --scope=$PACKAGE_NAME --include-dependencies
 
       - name: Publish
         run: dart pub publish --force

--- a/.github/workflows/_upload.yml
+++ b/.github/workflows/_upload.yml
@@ -28,10 +28,10 @@ jobs:
         run: flutter pub global activate melos
 
       - name: Get packages
-        run: melos bootstrap
+        run: melos bootstrap --scope=sandbox --include-dependencies
 
       - name: Run build runner
-        run: melos generate
+        run: dart run build_runner build -d
 
       - name: Build Website
         run: flutter build web -t lib/widgetbook.dart

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get packages 
         run: melos bootstrap
 
-      - name: Get packages 
+      - name: Generate Files  
         run: melos generate
 
       - name: Generate diff

--- a/melos.yaml
+++ b/melos.yaml
@@ -16,5 +16,5 @@ scripts:
     description: Run flutter test with coverage and generates coverage report
 
   generate:
-    run: melos exec $MELOS_FILTERS -c 1 --depends-on="build_runner" -- "dart pub run build_runner build --delete-conflicting-outputs"
+    run: melos exec -c 1 --depends-on="build_runner" -- "dart run build_runner build -d"
     description: Build all generated files.


### PR DESCRIPTION
Packages no longer require code generation, so `MELOS_FILTER` is no longer needed.
Code generation steps were optimized for faster run time.