### PR TITLE
docs: fix contribution links

### DIFF
--- a/docs/contribution/get-started.mdx
+++ b/docs/contribution/get-started.mdx
@@ -74,4 +74,4 @@ Here's a step-by-step guide to get you started:
    GitHub Discussions.
 
 5. **Contribution Workflow**: Now that you are ready, let's dive into how to
-   send a good PR. Check out [Contribution Workflow](/contribute/workflow).
+   send a good PR. Check out [Contribution Workflow](/contribution/workflow).

--- a/docs/contribution/ways-to-contribute.mdx
+++ b/docs/contribution/ways-to-contribute.mdx
@@ -34,7 +34,7 @@ large. Here are some ways you can make a difference:
 
 5. **Providing Examples:** Share practical use-cases or scenarios. Examples
    often act as starting points and provide clarity on the application of
-   certain features. Check out [Adding Examples](/contribute/adding-example) doc
+   certain features. Check out [Adding Examples](/contribution/adding-example) doc
    page for more information.
 
    _Example_: Creating an example showcasing how to use Widgetbook for managing

--- a/docs/contribution/workflow.mdx
+++ b/docs/contribution/workflow.mdx
@@ -112,6 +112,6 @@ detailed walkthrough of the process:
   issues.
 
 <Info>
-	Check out [Adding Examples](/contribute/adding-example) doc page for more
+	Check out [Adding Examples](/contribution/adding-example) doc page for more
 	information.
 </Info>


### PR DESCRIPTION
This PR fixes a small handful of broken links in the contribution documentation.

### List of issues which are fixed by the PR
I am guilty, there is no issue for this. I just noticed these while following the contribution docs.

### Screenshots
N/A

### Checklist

- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
