### PR TITLE
fix(cli): include added/deleted files in review

### DIFF
--- a/packages/widgetbook_cli/lib/src/commands/publish.dart
+++ b/packages/widgetbook_cli/lib/src/commands/publish.dart
@@ -279,7 +279,7 @@ class PublishCommand extends CliCommand<PublishArgs> {
     final useCases = await useCaseReader.read(args.path);
     final diffs = await context.repository.diff(args.baseBranch!.fullName);
 
-    final changeUseCases = await useCaseReader.compare(
+    final changeUseCases = useCaseReader.compare(
       useCases: useCases,
       diffs: diffs,
     );

--- a/packages/widgetbook_cli/lib/src/utils/use_case_reader.dart
+++ b/packages/widgetbook_cli/lib/src/utils/use_case_reader.dart
@@ -25,7 +25,7 @@ class UseCaseReader {
     final files = await fileSystem
         .directory(generatedDir)
         .list(recursive: true)
-        .takeWhile((entity) => entity.path.endsWith('.usecase.widgetbook.json'))
+        .where((entity) => entity.path.endsWith('.usecase.widgetbook.json'))
         .cast<File>();
 
     return files
@@ -45,12 +45,12 @@ class UseCaseReader {
 
     for (final useCase in useCases) {
       for (final diff in diffs) {
-        final hasChanged = _hasChanged(
+        final isChanged = hasChanged(
           useCase: useCase,
           diff: diff,
         );
 
-        if (hasChanged) {
+        if (isChanged) {
           changedUseCases.add(
             ChangedUseCase(
               name: useCase.useCaseName,
@@ -71,23 +71,23 @@ class UseCaseReader {
     return changedUseCases;
   }
 
-  bool _hasChanged({
+  bool hasChanged({
     required UseCaseMetadata useCase,
     required DiffHeader diff,
   }) {
-    if (diff.ref == null || diff.base == null) {
-      return false;
-    }
-
-    return _comparePaths(useCase.componentDefinitionPath, diff.ref!) ||
-        _comparePaths(useCase.useCaseDefinitionPath, diff.ref!) ||
-        _comparePaths(useCase.componentDefinitionPath, diff.base!) ||
-        _comparePaths(useCase.useCaseDefinitionPath, diff.base!);
+    return comparePaths(useCase.componentDefinitionPath, diff.ref) ||
+        comparePaths(useCase.useCaseDefinitionPath, diff.ref) ||
+        comparePaths(useCase.componentDefinitionPath, diff.base) ||
+        comparePaths(useCase.useCaseDefinitionPath, diff.base);
   }
 
-  /// Returns true if [a] and [b] are equal or
+  /// Returns true if [filePath] and [diffPath] are equal or
   /// if one of them is a sub-path of the other.
-  bool _comparePaths(String a, String b) {
-    return a == b || a.endsWith(b) || b.endsWith(a);
+  bool comparePaths(String filePath, String? diffPath) {
+    if (diffPath == null) return false;
+
+    return filePath == diffPath ||
+        filePath.endsWith(diffPath) ||
+        diffPath.endsWith(filePath);
   }
 }


### PR DESCRIPTION
`UseCaseReader.compare` was not working properly because of:
1. Files were filtered using `takeWhile` instead of `where`.
1. `hasChanged` always returned `false` for added and deleted files because their `base`/`ref` are null.