### PR TITLE
fix(cli): send `useCaseName` in `ChangedUseCase`

### DIFF
--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Send correct use-case name in reviews. ([#998](https://github.com/widgetbook/widgetbook/pull/998))
+
 ## 3.0.0-rc.5
 
 - **BREAKING**: Remove `--github-token` & `--pr` options from `publish` command. You can now use our [GitHub App](https://docs.widgetbook.io/widgetbook-cloud/integrating-github) instead. ([#982](https://github.com/widgetbook/widgetbook/pull/982))

--- a/packages/widgetbook_cli/lib/src/models/changed_use_case.dart
+++ b/packages/widgetbook_cli/lib/src/models/changed_use_case.dart
@@ -20,8 +20,12 @@ class ChangedUseCase extends UseCaseMetadata {
 
   Map<String, dynamic> toJson() {
     return {
+      'name': useCaseName,
+      'componentName': componentName,
+      'componentDefinitionPath': componentDefinitionPath,
+      'componentImportStatement': componentImportStatement,
       'modification': modification.name,
-      ...super.toJson(),
+      'designLink': designLink,
     };
   }
 }

--- a/packages/widgetbook_cli/lib/src/models/use_case_metadata.dart
+++ b/packages/widgetbook_cli/lib/src/models/use_case_metadata.dart
@@ -49,17 +49,4 @@ class UseCaseMetadata {
           map['designLink'] != null ? map['designLink'] as String : null,
     );
   }
-
-  Map<String, dynamic> toJson() {
-    return {
-      'name': name,
-      'useCaseName': useCaseName,
-      'componentName': componentName,
-      'importStatement': importStatement,
-      'componentImportStatement': componentImportStatement,
-      'componentDefinitionPath': componentDefinitionPath,
-      'useCaseDefinitionPath': useCaseDefinitionPath,
-      'designLink': designLink,
-    };
-  }
 }


### PR DESCRIPTION
In #992, the `name` property was messed up with `useCaseName`. So the use-case function name was sent instead of the actual use-case name.