### PR TITLE
feat(cli): send versions with requests

### DIFF
--- a/packages/widgetbook_cli/lib/src/api/api.dart
+++ b/packages/widgetbook_cli/lib/src/api/api.dart
@@ -3,4 +3,5 @@ export 'models/build_response.dart';
 export 'models/review_request.dart';
 export 'models/review_response.dart';
 export 'models/upload_task.dart';
+export 'models/versions_metadata.dart';
 export 'widgetbook_http_client.dart';

--- a/packages/widgetbook_cli/lib/src/api/models/versions_metadata.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/versions_metadata.dart
@@ -1,0 +1,25 @@
+class VersionsMetadata {
+  VersionsMetadata({
+    required this.flutter,
+    required this.widgetbook,
+    required this.cli,
+    required this.generator,
+    required this.annotation,
+  });
+
+  final String? flutter;
+  final String? widgetbook;
+  final String cli;
+  final String? generator;
+  final String? annotation;
+
+  Map<String, String> toHeaders() {
+    return {
+      'x-widgetbook_cli-version': cli,
+      if (flutter != null) 'x-flutter-version': flutter!,
+      if (widgetbook != null) 'x-widgetbook-version': widgetbook!,
+      if (generator != null) 'x-widgetbook_generator-version': generator!,
+      if (annotation != null) 'x-widgetbook_annotation-version': annotation!,
+    };
+  }
+}

--- a/packages/widgetbook_cli/lib/src/api/widgetbook_http_client.dart
+++ b/packages/widgetbook_cli/lib/src/api/widgetbook_http_client.dart
@@ -6,6 +6,7 @@ import 'models/build_request.dart';
 import 'models/build_response.dart';
 import 'models/review_request.dart';
 import 'models/review_response.dart';
+import 'models/versions_metadata.dart';
 
 /// HTTP client to connect to the Widgetbook Cloud backend
 class WidgetbookHttpClient {
@@ -24,6 +25,7 @@ class WidgetbookHttpClient {
 
   /// Sends review data to the Widgetbook Cloud backend.
   Future<ReviewResponse> uploadReview(
+    VersionsMetadata? versions,
     ReviewRequest request,
   ) async {
     if (request.useCases.isEmpty) {
@@ -36,6 +38,9 @@ class WidgetbookHttpClient {
       final response = await client.post<Map<String, dynamic>>(
         '/reviews',
         data: request.toJson(),
+        options: Options(
+          headers: versions?.toHeaders(),
+        ),
       );
 
       return ReviewResponse.fromJson(response.data!);
@@ -52,6 +57,7 @@ class WidgetbookHttpClient {
 
   /// Uploads the build .zip file to the Widgetbook Cloud backend.
   Future<BuildResponse> uploadBuild(
+    VersionsMetadata? versions,
     BuildRequest request,
   ) async {
     try {
@@ -59,6 +65,9 @@ class WidgetbookHttpClient {
       final response = await client.post<Map<String, dynamic>>(
         '/builds/deploy',
         data: formData,
+        options: Options(
+          headers: versions?.toHeaders(),
+        ),
       );
 
       return BuildResponse.fromJson(response.data!);

--- a/packages/widgetbook_cli/lib/src/commands/publish.dart
+++ b/packages/widgetbook_cli/lib/src/commands/publish.dart
@@ -137,7 +137,15 @@ class PublishCommand extends CliCommand<PublishArgs> {
         throw ExitedByUser();
       }
 
+      progress.update('Getting versions');
+
       final versions = await getVersions(args);
+      logger.info('\nThe following versions are used: ');
+      logger.info('  Flutter    : ${versions?.flutter ?? '-'}');
+      logger.info('  Widgetbook : ${versions?.widgetbook ?? '-'}');
+      logger.info('  Annotation : ${versions?.annotation ?? '-'}');
+      logger.info('  Generator  : ${versions?.generator ?? '-'}');
+
       final buildResponse = await publishBuild(
         args: args,
         versions: versions,
@@ -359,8 +367,8 @@ class PublishCommand extends CliCommand<PublishArgs> {
         cli: packageVersion,
         flutter: await getFlutterVersion(),
         widgetbook: getPackageVersion(packages, 'widgetbook'),
-        generator: getPackageVersion(packages, 'widgetbook_generator'),
         annotation: getPackageVersion(packages, 'widgetbook_annotation'),
+        generator: getPackageVersion(packages, 'widgetbook_generator'),
       );
     } catch (_) {
       return null;
@@ -376,7 +384,7 @@ class PublishCommand extends CliCommand<PublishArgs> {
   }
 
   String? getPackageVersion(YamlMap packages, String name) {
-    final package = packages['widgetbook'] as YamlMap?;
+    final package = packages[name] as YamlMap?;
     return package?['version']?.toString();
   }
 }

--- a/packages/widgetbook_cli/lib/src/commands/publish_args.dart
+++ b/packages/widgetbook_cli/lib/src/commands/publish_args.dart
@@ -22,6 +22,8 @@ class PublishArgs {
   final String repository;
   final Reference? baseBranch;
 
+  bool get hasReview => baseBranch != null;
+
   @override
   bool operator ==(covariant PublishArgs other) {
     if (identical(this, other)) return true;

--- a/packages/widgetbook_cli/lib/src/git/git.dart
+++ b/packages/widgetbook_cli/lib/src/git/git.dart
@@ -1,4 +1,3 @@
 export 'diff_header.dart';
-export 'git_process_manager.dart';
 export 'reference.dart';
 export 'repository.dart';

--- a/packages/widgetbook_cli/lib/src/git/repository.dart
+++ b/packages/widgetbook_cli/lib/src/git/repository.dart
@@ -5,8 +5,8 @@ import 'package:collection/collection.dart';
 import 'package:path/path.dart' as path;
 import 'package:process/process.dart';
 
+import '../utils/executable_manager.dart';
 import 'diff_header.dart';
-import 'git_process_manager.dart';
 import 'reference.dart';
 
 /// Class representation of a git repository.

--- a/packages/widgetbook_cli/lib/src/utils/executable_manager.dart
+++ b/packages/widgetbook_cli/lib/src/utils/executable_manager.dart
@@ -3,14 +3,29 @@ import 'dart:io';
 
 import 'package:process/process.dart';
 
-/// Similar to [run] but for `git`.
-extension GitProcessManager on ProcessManager {
-  static const executable = 'git';
+extension ExecutableManager on ProcessManager {
+  /// Runs `flutter` with the given [args].
+  Future<String> runFlutter(List<String> args) {
+    return _exec('flutter', args);
+  }
 
   /// Runs `git` with the given [args] inside the [workingDirectory].
   /// If [workingDirectory] is `null` the current working directory is used.
-  /// Throws a [ProcessException] if the exit code is not `0`.
   Future<String> runGit(
+    List<String> args, {
+    String? workingDirectory,
+  }) {
+    return _exec(
+      'git',
+      args,
+      workingDirectory: workingDirectory,
+    );
+  }
+
+  /// Executes [ProcessManager.run] on a given [executable].
+  /// Throws a [ProcessException] if the exit code is not `0`.
+  Future<String> _exec(
+    String executable,
     List<String> args, {
     String? workingDirectory,
   }) async {

--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -27,8 +27,9 @@ dependencies:
   path: ^1.8.2
   platform: ^3.0.0
   process: ^5.0.0
-  pub_updater: ^0.4.0 
+  pub_updater: ^0.4.0
   version: ^3.0.2
+  yaml: ^3.1.2
 
 dev_dependencies:
   mocktail: ^1.0.0

--- a/packages/widgetbook_cli/test/src/commands/publish_test.dart
+++ b/packages/widgetbook_cli/test/src/commands/publish_test.dart
@@ -17,6 +17,8 @@ class FakeBuildRequest extends Fake implements BuildRequest {}
 
 class FakeReviewRequest extends Fake implements ReviewRequest {}
 
+class FakeVersionsMetadata extends Fake implements VersionsMetadata {}
+
 void main() {
   const buildResponse = BuildResponse(
     project: 'projectId',
@@ -33,6 +35,8 @@ void main() {
   );
 
   group('$PublishCommand', () {
+    final versions = FakeVersionsMetadata();
+
     late Logger logger;
     late Repository repository;
     late WidgetbookHttpClient client;
@@ -46,6 +50,7 @@ void main() {
     late ZipEncoder zipEncoder;
 
     setUp(() async {
+      registerFallbackValue(versions);
       registerFallbackValue(FakeFile());
       registerFallbackValue(FakeBuildRequest());
       registerFallbackValue(FakeReviewRequest());
@@ -389,7 +394,10 @@ void main() {
         ).thenReturn(directory);
 
         expectLater(
-          () => command.publishBuild(args),
+          () => command.publishBuild(
+            args: args,
+            versions: versions,
+          ),
           throwsA(const TypeMatcher<UnableToCreateZipFileException>()),
         );
       },
@@ -416,7 +424,10 @@ void main() {
         when(() => zipEncoder.zip(any())).thenAnswer((_) async => null);
 
         expectLater(
-          () => command.publishBuild(args),
+          () => command.publishBuild(
+            args: args,
+            versions: versions,
+          ),
           throwsA(const TypeMatcher<UnableToCreateZipFileException>()),
         );
       },
@@ -452,7 +463,10 @@ void main() {
       when(() => zipEncoder.zip(any())).thenAnswer((_) async => file);
 
       when(
-        () => client.uploadBuild(any<BuildRequest>()),
+        () => client.uploadBuild(
+          any<VersionsMetadata>(),
+          any<BuildRequest>(),
+        ),
       ).thenAnswer(
         (_) async => buildResponse,
       );
@@ -498,7 +512,10 @@ void main() {
       when(() => zipEncoder.zip(any())).thenAnswer((_) async => file);
 
       when(
-        () => client.uploadBuild(any<BuildRequest>()),
+        () => client.uploadBuild(
+          any<VersionsMetadata>(),
+          any<BuildRequest>(),
+        ),
       ).thenAnswer(
         (_) async => buildResponse,
       );
@@ -530,7 +547,10 @@ void main() {
       ]);
 
       when(
-        () => client.uploadReview(any<ReviewRequest>()),
+        () => client.uploadReview(
+          any<VersionsMetadata>(),
+          any<ReviewRequest>(),
+        ),
       ).thenAnswer(
         (_) async => reviewResponse,
       );


### PR DESCRIPTION
The following versions are being sent to Widgetbook Cloud when a review or build is published:
1. Flutter version
1. `widgetbook` version
1. `widgetbook_cli` version
1. `widgetbook_annotation` version
1. `widgetbook_generator` version

The versions are used to toggle features on/off depending on compatibility.