### PR TITLE
feat: Notify users when selected language is changed

### DIFF
--- a/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
+++ b/packages/widgetbook/lib/src/addons/localization_addon/localization_addon.dart
@@ -8,6 +8,7 @@ class LocalizationAddon extends WidgetbookAddon<Locale> {
   LocalizationAddon({
     required this.locales,
     required this.localizationsDelegates,
+    this.onChanged,
     Locale? initialLocale,
   })  : assert(
           locales.isNotEmpty,
@@ -24,6 +25,7 @@ class LocalizationAddon extends WidgetbookAddon<Locale> {
 
   final List<Locale> locales;
   final List<LocalizationsDelegate<dynamic>> localizationsDelegates;
+  final void Function(Locale)? onChanged;
 
   @override
   List<Field> get fields {
@@ -33,6 +35,11 @@ class LocalizationAddon extends WidgetbookAddon<Locale> {
         values: locales,
         initialValue: initialSetting,
         labelBuilder: (locale) => locale.toLanguageTag(),
+        onChanged: (context, locale) {
+          if (onChanged != null && locale != null) {
+            onChanged!(locale);
+          }
+        },
       ),
     ];
   }


### PR DESCRIPTION
- Users may need to trigger events for example LocalizationBloc event to change the language of the project

This PR allows users to be notified when selected language is changed. So that, we can run custom logics such as triggering an event from LocalizationBloc.

Example usecase:
onChanged: (Locale locale) {
  context.read<LocalizationBloc>.add(LocalizationEventChangeLocale(locale));
}