### PR TITLE
feat: add `WidgetbookLeafComponent`

### DIFF
--- a/examples/full_example/lib/widgetbook.generator.directories.g.dart
+++ b/examples/full_example/lib/widgetbook.generator.directories.g.dart
@@ -73,14 +73,12 @@ final directories = <_i1.WidgetbookNode>[
   _i1.WidgetbookFolder(
     name: 'material',
     children: [
-      _i1.WidgetbookComponent(
+      _i1.WidgetbookLeafComponent(
         name: 'RangeSlider',
-        useCases: [
-          _i1.WidgetbookUseCase(
-            name: 'CustomRangeSlider',
-            builder: _i5.rangeSlider,
-          )
-        ],
+        useCase: _i1.WidgetbookUseCase(
+          name: 'CustomRangeSlider',
+          builder: _i5.rangeSlider,
+        ),
       )
     ],
   ),

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **FEAT**: Introduce `WidgetbookLeafComponent` navigation node for components with a single use-case. ([#1015](https://github.com/widgetbook/widgetbook/pull/1015))
 - **FIX**: use `MapMixin` instead of `MapBase` for `KnobsRegistry`. ([#903](https://github.com/widgetbook/widgetbook/pull/903))
 - **FEAT**: Add `designLink` to `WidgetbookUseCase`. ([#926](https://github.com/widgetbook/widgetbook/pull/926))
 - **FEAT**: Add light theme support. ([#919](https://github.com/widgetbook/widgetbook/pull/919))

--- a/packages/widgetbook/lib/src/navigation/icons/resolve_icon.dart
+++ b/packages/widgetbook/lib/src/navigation/icons/resolve_icon.dart
@@ -13,6 +13,7 @@ Widget resolveIcon(WidgetbookNode node) {
     case WidgetbookFolder:
       return const Icon(Icons.folder, size: 16);
     case WidgetbookComponent:
+    case WidgetbookLeafComponent:
       return const ComponentIcon();
     case WidgetbookUseCase:
       return const UseCaseIcon();

--- a/packages/widgetbook/lib/src/navigation/nodes/nodes.dart
+++ b/packages/widgetbook/lib/src/navigation/nodes/nodes.dart
@@ -1,6 +1,7 @@
 export 'widgetbook_category.dart';
 export 'widgetbook_component.dart';
 export 'widgetbook_folder.dart';
+export 'widgetbook_leaf_component.dart';
 export 'widgetbook_node.dart';
 export 'widgetbook_package.dart';
 export 'widgetbook_root.dart';

--- a/packages/widgetbook/lib/src/navigation/nodes/widgetbook_leaf_component.dart
+++ b/packages/widgetbook/lib/src/navigation/nodes/widgetbook_leaf_component.dart
@@ -1,0 +1,23 @@
+import 'widgetbook_component.dart';
+import 'widgetbook_node.dart';
+import 'widgetbook_use_case.dart';
+
+/// A [WidgetbookComponent] with a single [WidgetbookUseCase].
+class WidgetbookLeafComponent extends WidgetbookNode {
+  WidgetbookLeafComponent({
+    required super.name,
+    required this.useCase,
+  }) : super(
+          children: [useCase],
+        );
+
+  final WidgetbookUseCase useCase;
+
+  @override
+  WidgetbookLeafComponent copyWith({
+    String? name,
+    List<WidgetbookNode>? children,
+  }) {
+    return this;
+  }
+}

--- a/packages/widgetbook/lib/src/navigation/nodes/widgetbook_node.dart
+++ b/packages/widgetbook/lib/src/navigation/nodes/widgetbook_node.dart
@@ -8,7 +8,8 @@ import 'nodes.dart';
 /// 3. [WidgetbookCategory]
 /// 4. [WidgetbookFolder]
 /// 5. [WidgetbookComponent]
-/// 6. [WidgetbookUseCase]
+/// 6. [WidgetbookLeafComponent]
+/// 7. [WidgetbookUseCase]
 abstract class WidgetbookNode {
   WidgetbookNode({
     required this.name,

--- a/packages/widgetbook/lib/src/navigation/widgets/navigation_tree_node.dart
+++ b/packages/widgetbook/lib/src/navigation/widgets/navigation_tree_node.dart
@@ -42,11 +42,18 @@ class _NavigationTreeNodeState extends State<NavigationTreeNode> {
           isExpanded: isExpanded,
           isSelected: widget.node.path == widget.selectedNode?.path,
           onTap: () {
+            // Redirect click to the use-case of the leaf component, so that
+            // when it's clicked, the route is updated to the use-case.
+            final targetNode = widget.node is WidgetbookLeafComponent
+                ? (widget.node as WidgetbookLeafComponent).useCase
+                : widget.node;
+
             setState(() => isExpanded = !isExpanded);
-            widget.onNodeSelected?.call(widget.node);
+            widget.onNodeSelected?.call(targetNode);
           },
         ),
-        if (widget.node.children != null)
+        if (widget.node.children != null &&
+            widget.node is! WidgetbookLeafComponent)
           ClipRect(
             child: AnimatedSlide(
               duration: animationDuration,

--- a/packages/widgetbook/lib/src/navigation/widgets/navigation_tree_tile.dart
+++ b/packages/widgetbook/lib/src/navigation/widgets/navigation_tree_tile.dart
@@ -44,7 +44,7 @@ class NavigationTreeTile extends StatelessWidget {
             ),
             SizedBox(
               width: indentation,
-              child: node.isLeaf
+              child: node.isLeaf || node is WidgetbookLeafComponent
                   ? null
                   : ExpanderIcon(
                       isExpanded: isExpanded,

--- a/packages/widgetbook/test/src/navigation/widgets/navigation_tree_item_test.dart
+++ b/packages/widgetbook/test/src/navigation/widgets/navigation_tree_item_test.dart
@@ -69,6 +69,26 @@ void main() {
           );
         },
       );
+
+      testWidgets(
+        'when node is $WidgetbookLeafComponent, '
+        'then $ExpanderIcon is not rendered',
+        (tester) async {
+          await tester.pumpWidgetWithMaterialApp(
+            NavigationTreeTile(
+              node: WidgetbookLeafComponent(
+                name: 'Leaf',
+                useCase: node,
+              ),
+            ),
+          );
+
+          expect(
+            find.byType(ExpanderIcon),
+            findsNothing,
+          );
+        },
+      );
     },
   );
 }

--- a/packages/widgetbook/test/src/navigation/widgets/navigation_tree_node_test.dart
+++ b/packages/widgetbook/test/src/navigation/widgets/navigation_tree_node_test.dart
@@ -50,6 +50,33 @@ void main() {
           verify(() => onValueChanged.call(node)).called(1);
         },
       );
+
+      testWidgets(
+        'when a $WidgetbookLeafComponent is tapped, '
+        'then the onNodeSelected callback is called with the child use-case',
+        (tester) async {
+          final useCase = WidgetbookUseCase(
+            name: 'UseCase Node',
+            builder: (context) => Container(),
+          );
+
+          final onValueChanged = VoidFn1Mock<WidgetbookNode>();
+
+          await tester.pumpWidgetWithMaterialApp(
+            NavigationTreeNode(
+              node: WidgetbookLeafComponent(
+                name: 'Leaf',
+                useCase: useCase,
+              ),
+              onNodeSelected: onValueChanged.call,
+            ),
+          );
+
+          await tester.tap(find.byType(NavigationTreeTile).first);
+
+          verify(() => onValueChanged.call(useCase)).called(1);
+        },
+      );
     },
   );
 }

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **FEAT**: Add `designLink` to `WidgetbookUseCase`. ([#926](https://github.com/widgetbook/widgetbook/pull/926))
 - **FEAT**: Support custom `path` for `@UseCase`. ([#988](https://github.com/widgetbook/widgetbook/pull/988))
+- **FEAT**: Support `WidgetbookLeafComponent` navigation node for components with a single use-case. ([#1015](https://github.com/widgetbook/widgetbook/pull/1015))
 
 ## 3.2.0
 

--- a/packages/widgetbook_generator/lib/src/code/widgetbook_instance.dart
+++ b/packages/widgetbook_generator/lib/src/code/widgetbook_instance.dart
@@ -6,6 +6,7 @@ import 'refer.dart';
 import 'widgetbook_category_instance.dart';
 import 'widgetbook_component_instance.dart';
 import 'widgetbook_folder_instance.dart';
+import 'widgetbook_leaf_component_instance.dart';
 import 'widgetbook_use_case_instance.dart';
 
 class WidgetbookInstance extends InvokeExpression {
@@ -32,7 +33,14 @@ class WidgetbookInstance extends InvokeExpression {
         );
 
     if (isComponentNode) {
-      return WidgetbookComponentInstance(node: node as TreeNode<String>);
+      final componentNode = node as TreeNode<String>;
+      return node.children.length == 1
+          ? WidgetbookLeafComponentInstance(
+              node: componentNode,
+            )
+          : WidgetbookComponentInstance(
+              node: componentNode,
+            );
     }
 
     final name = (node as TreeNode<String>).data;

--- a/packages/widgetbook_generator/lib/src/code/widgetbook_leaf_component_instance.dart
+++ b/packages/widgetbook_generator/lib/src/code/widgetbook_leaf_component_instance.dart
@@ -1,0 +1,21 @@
+import 'package:code_builder/code_builder.dart';
+
+import '../models/use_case_metadata.dart';
+import '../tree/tree_node.dart';
+import 'widgetbook_instance.dart';
+import 'widgetbook_use_case_instance.dart';
+
+/// [InvokeExpression] for [WidgetbookLeafComponent]
+class WidgetbookLeafComponentInstance extends WidgetbookInstance {
+  WidgetbookLeafComponentInstance({
+    required TreeNode<String> node,
+  }) : super(
+          type: 'WidgetbookLeafComponent',
+          args: {
+            'name': literalString(node.data),
+            'useCase': WidgetbookUseCaseInstance(
+              useCase: node.children.values.first.data as UseCaseMetadata,
+            ),
+          },
+        );
+}

--- a/packages/widgetbook_generator/lib/widgetbook_generator.dart
+++ b/packages/widgetbook_generator/lib/widgetbook_generator.dart
@@ -4,6 +4,7 @@ export 'src/code/widgetbook_category_instance.dart';
 export 'src/code/widgetbook_component_instance.dart';
 export 'src/code/widgetbook_folder_instance.dart';
 export 'src/code/widgetbook_instance.dart';
+export 'src/code/widgetbook_leaf_component_instance.dart';
 export 'src/code/widgetbook_use_case_instance.dart';
 export 'src/models/element_metadata.dart';
 export 'src/models/use_case_metadata.dart';

--- a/packages/widgetbook_generator/test/src/code/widgetbook_folder_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code/widgetbook_folder_instance_test.dart
@@ -41,14 +41,12 @@ void main() {
           WidgetbookFolder(
             name: 'root',
             children: [
-              WidgetbookComponent(
+              WidgetbookLeafComponent(
                 name: 'Component',
-                useCases: [
-                  WidgetbookUseCase(
-                    name: 'Default',
-                    builder: defaultUseCase,
-                  )
-                ],
+                useCase: WidgetbookUseCase(
+                  name: 'Default',
+                  builder: defaultUseCase,
+                ),
               ),
               WidgetbookFolder(
                 name: 'Folder1',

--- a/packages/widgetbook_generator/test/src/code/widgetbook_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code/widgetbook_instance_test.dart
@@ -18,10 +18,28 @@ void main() {
       );
     });
 
-    test('fromNode (Component)', () {
+    test('fromNode (Component) - leaf', () {
       final actual = WidgetbookInstance.fromNode(
         TreeNode<String>('Component', {
           'Default': TreeNode<UseCaseMetadata>(
+            MockUseCaseMetadata(),
+          ),
+        }),
+      );
+
+      expect(
+        actual.runtimeType,
+        WidgetbookLeafComponentInstance,
+      );
+    });
+
+    test('fromNode (Component)', () {
+      final actual = WidgetbookInstance.fromNode(
+        TreeNode<String>('Component', {
+          'First': TreeNode<UseCaseMetadata>(
+            MockUseCaseMetadata(),
+          ),
+          'Second': TreeNode<UseCaseMetadata>(
             MockUseCaseMetadata(),
           ),
         }),

--- a/packages/widgetbook_generator/test/src/code/widgetbook_leaf_component_instance_test.dart
+++ b/packages/widgetbook_generator/test/src/code/widgetbook_leaf_component_instance_test.dart
@@ -1,0 +1,32 @@
+import 'package:test/test.dart';
+import 'package:widgetbook_generator/widgetbook_generator.dart';
+
+import '../../helpers/code.dart';
+import '../../helpers/mock_use_case_metadata.dart';
+
+void main() {
+  group('$WidgetbookLeafComponentInstance', () {
+    test('with use case', () {
+      final actual = WidgetbookLeafComponentInstance(
+        node: TreeNode<String>('LeafComponent', {
+          'Default': TreeNode<UseCaseMetadata>(
+            MockUseCaseMetadata(),
+          ),
+        }),
+      );
+
+      expectExpression(
+        actual,
+        '''
+          WidgetbookLeafComponent(
+            name: 'LeafComponent',
+            useCase: WidgetbookUseCase(
+              name: 'Default',
+              builder: defaultUseCase,
+            ),
+          )
+        ''',
+      );
+    });
+  });
+}


### PR DESCRIPTION
The new `WidgetbookLeafComponent` is a more compact version of `WidgetbookComponent` for the cases when the component only have a single use-case. This makes the navigation tree much more cleaner.

<img width="368" alt="Before" src="https://github.com/widgetbook/widgetbook/assets/41103290/78b40a70-b8cf-43f8-a39f-6e6cb81b694a">
<img width="368" alt="After" src="https://github.com/widgetbook/widgetbook/assets/41103290/77a07f54-ea6d-4fe4-a09e-ba9ffc2d0cac">
