### PR TITLE
fix: use type-based default values for num fields

### DIFF
--- a/packages/widgetbook/lib/src/fields/num_input_field.dart
+++ b/packages/widgetbook/lib/src/fields/num_input_field.dart
@@ -22,8 +22,10 @@ class NumInputField<T extends num> extends Field<T> {
 
   @override
   Widget toWidget(BuildContext context, String label, T? currentValue) {
+    final defaultValue = (T == int ? 0 : 0.0) as T;
+
     return TextFormField(
-      initialValue: codec.toParam(currentValue ?? initialValue ?? (0 as T)),
+      initialValue: codec.toParam(currentValue ?? initialValue ?? defaultValue),
       keyboardType: TextInputType.number,
       inputFormatters: formatters,
       onChanged: (value) => updateField(

--- a/packages/widgetbook/lib/src/fields/num_slider_field.dart
+++ b/packages/widgetbook/lib/src/fields/num_slider_field.dart
@@ -22,6 +22,8 @@ class NumSliderField<T extends num> extends Field<T> {
 
   @override
   Widget toWidget(BuildContext context, String group, T? value) {
+    final defaultValue = (T == int ? 0 : 0.0) as T;
+
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
@@ -31,7 +33,7 @@ class NumSliderField<T extends num> extends Field<T> {
             value: (value ?? initialValue)?.toDouble() ?? 0,
             min: min.toDouble(),
             max: max.toDouble(),
-            label: codec.toParam(value ?? initialValue ?? (0 as T)),
+            label: codec.toParam(value ?? initialValue ?? defaultValue),
             divisions: divisions,
             onChanged: (value) {
               return updateField(
@@ -44,7 +46,7 @@ class NumSliderField<T extends num> extends Field<T> {
         ),
         Expanded(
           child: Text(
-            codec.toParam(value ?? initialValue!),
+            codec.toParam(value ?? initialValue ?? defaultValue),
             textAlign: TextAlign.end,
             maxLines: 1,
           ),


### PR DESCRIPTION
An assertion was thrown when a `DoubleXField` used `as` on `0` because `T` is `double` and `0` is `int`.