### PR TITLE
chore: add `avoid_renaming_method_parameters` lint rule

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -34,6 +34,7 @@ linter:
     - noop_primitive_operations
     - use_super_parameters
     - avoid_redundant_argument_values
+    - avoid_renaming_method_parameters
 
     # Types
     - unrelated_type_equality_checks

--- a/packages/widgetbook/lib/src/addons/grid_addon/grid_addon.dart
+++ b/packages/widgetbook/lib/src/addons/grid_addon/grid_addon.dart
@@ -24,15 +24,14 @@ class GridAddon extends WidgetbookAddon<int> {
   Widget buildUseCase(
     BuildContext context,
     Widget child,
-    int dimension, {
-    Key? key,
-  }) {
+    int setting,
+  ) {
     return Stack(
       children: [
         LayoutBuilder(
           builder: (context, constraints) {
             return CustomPaint(
-              painter: GridPainter(dimension),
+              painter: GridPainter(setting),
               size: Size(
                 constraints.maxWidth,
                 constraints.maxHeight,

--- a/packages/widgetbook/lib/src/addons/inspector_addon/inspector_addon.dart
+++ b/packages/widgetbook/lib/src/addons/inspector_addon/inspector_addon.dart
@@ -24,8 +24,12 @@ class InspectorAddon extends WidgetbookAddon<bool> {
   }
 
   @override
-  Widget buildUseCase(BuildContext context, Widget child, bool isEnabled) {
-    return isEnabled
+  Widget buildUseCase(
+    BuildContext context,
+    Widget child,
+    bool setting,
+  ) {
+    return setting
         ? Scaffold(
             backgroundColor: const Color(0xFF121515),
             body: Inspector(child: child),

--- a/packages/widgetbook/lib/src/addons/zoom_addon/zoom_addon.dart
+++ b/packages/widgetbook/lib/src/addons/zoom_addon/zoom_addon.dart
@@ -28,9 +28,13 @@ class ZoomAddon extends WidgetbookAddon<double> {
   }
 
   @override
-  Widget buildUseCase(BuildContext context, Widget child, double zoom) {
+  Widget buildUseCase(
+    BuildContext context,
+    Widget child,
+    double setting,
+  ) {
     return Transform.scale(
-      scale: zoom,
+      scale: setting,
       child: child,
     );
   }

--- a/packages/widgetbook/lib/src/fields/duration_field.dart
+++ b/packages/widgetbook/lib/src/fields/duration_field.dart
@@ -26,17 +26,20 @@ class DurationField extends Field<Duration> {
   static const defaultDuration = Duration.zero;
 
   @override
-  Widget toWidget(BuildContext context, String label, Duration? currentValue) {
+  Widget toWidget(
+    BuildContext context,
+    String group,
+    Duration? value,
+  ) {
     return TextFormField(
-      initialValue:
-          codec.toParam(currentValue ?? initialValue ?? defaultDuration),
+      initialValue: codec.toParam(value ?? initialValue ?? defaultDuration),
       keyboardType: TextInputType.number,
       decoration: const InputDecoration(
         suffix: Text('ms'),
       ),
       onChanged: (value) => updateField(
         context,
-        label,
+        group,
         codec.toValue(value) ?? initialValue ?? defaultDuration,
       ),
     );

--- a/packages/widgetbook/lib/src/fields/num_input_field.dart
+++ b/packages/widgetbook/lib/src/fields/num_input_field.dart
@@ -21,16 +21,16 @@ class NumInputField<T extends num> extends Field<T> {
   final List<TextInputFormatter>? formatters;
 
   @override
-  Widget toWidget(BuildContext context, String label, T? currentValue) {
+  Widget toWidget(BuildContext context, String group, T? value) {
     final defaultValue = (T == int ? 0 : 0.0) as T;
 
     return TextFormField(
-      initialValue: codec.toParam(currentValue ?? initialValue ?? defaultValue),
+      initialValue: codec.toParam(value ?? initialValue ?? defaultValue),
       keyboardType: TextInputType.number,
       inputFormatters: formatters,
       onChanged: (value) => updateField(
         context,
-        label,
+        group,
         codec.toValue(value) ?? initialValue!,
       ),
     );


### PR DESCRIPTION
Add [`avoid_renaming_method_parameters`](https://dart.dev/tools/linter-rules/avoid_renaming_method_parameters) rule.