### PR TITLE
refactor: deprecate `Field.onChanged`

### DIFF
--- a/docs/knobs/custom-knob.mdx
+++ b/docs/knobs/custom-knob.mdx
@@ -42,28 +42,16 @@ The Knob class has several properties that can be overridden:
 @override
 List<Field> get fields => [
   DoubleInputField(
-    group: 'knobs',
     name: 'min-$label',
     initialValue: value.start,
-    onChanged: (context, value) {
-      //...
-    },
   ),
   DoubleInputField(
-    group: 'knobs',
     name: 'max-$label',
     initialValue: value.end,
-    onChanged: (context, value) {
-      //...
-    },
   ),
 ];
 
 ```
-
-Each `DoubleInputField` also has an `onChanged` callback that's triggered when the field's
-value is changed. Inside this callback, we update the knob value using
-`WidgetbookState.of(context).updateKnobValue()` method.
 
 - `valueFromQueryGroup`: This property is used to parse the value of the knob from a query
   string.

--- a/examples/full_example/lib/customs/custom_knob.dart
+++ b/examples/full_example/lib/customs/custom_knob.dart
@@ -26,32 +26,10 @@ class RangeKnob extends Knob<RangeValues> {
         DoubleInputField(
           name: 'min-$label',
           initialValue: value.start,
-          onChanged: (context, value) {
-            if (value == null) return;
-
-            final state = WidgetbookState.of(context);
-            final endValue = (state.knobs[label]!.value as RangeValues).end;
-
-            state.knobs.updateValue<RangeValues>(
-              label,
-              RangeValues(value, endValue),
-            );
-          },
         ),
         DoubleInputField(
           name: 'max-$label',
           initialValue: value.end,
-          onChanged: (context, value) {
-            if (value == null) return;
-
-            final state = WidgetbookState.of(context);
-            final startValue = (state.knobs[label]!.value as RangeValues).start;
-
-            state.knobs.updateValue<RangeValues>(
-              label,
-              RangeValues(startValue, value),
-            );
-          },
         ),
       ];
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **FEAT**: Add Accessibility Addon. ([#1020](https://github.com/widgetbook/widgetbook/pull/1020))
 - **FEAT**: Add `q` query param for search. ([#950](https://github.com/widgetbook/widgetbook/pull/950))
 - **REFACTOR**: Deprecate `WidgetbookAddon`'s `initialSetting`. Should be replaced by a local field in relevant addons. ([#1023](https://github.com/widgetbook/widgetbook/pull/1023))
+- **REFACTOR**: Deprecate `Field.onChanged`. ([#1024](https://github.com/widgetbook/widgetbook/pull/1024))
 
 ## 3.3.0
 

--- a/packages/widgetbook/lib/src/fields/boolean_field.dart
+++ b/packages/widgetbook/lib/src/fields/boolean_field.dart
@@ -9,7 +9,7 @@ class BooleanField extends Field<bool> {
   BooleanField({
     required super.name,
     super.initialValue = true,
-    super.onChanged,
+    @deprecated super.onChanged,
   }) : super(
           type: FieldType.boolean,
           codec: FieldCodec(

--- a/packages/widgetbook/lib/src/fields/color_field/color_field.dart
+++ b/packages/widgetbook/lib/src/fields/color_field/color_field.dart
@@ -15,7 +15,7 @@ class ColorField extends Field<Color> {
     required super.name,
     super.initialValue = defaultColor,
     this.initialColorSpace = ColorSpace.hex,
-    super.onChanged,
+    @deprecated super.onChanged,
   }) : super(
           type: FieldType.color,
           codec: FieldCodec(

--- a/packages/widgetbook/lib/src/fields/date_time_field.dart
+++ b/packages/widgetbook/lib/src/fields/date_time_field.dart
@@ -19,7 +19,7 @@ class DateTimeField extends Field<DateTime> {
   DateTimeField({
     required super.name,
     required super.initialValue,
-    super.onChanged,
+    @deprecated super.onChanged,
     required this.start,
     required this.end,
   }) : super(

--- a/packages/widgetbook/lib/src/fields/double_input_field.dart
+++ b/packages/widgetbook/lib/src/fields/double_input_field.dart
@@ -9,7 +9,7 @@ class DoubleInputField extends NumInputField<double> {
   DoubleInputField({
     required super.name,
     super.initialValue = 0,
-    super.onChanged,
+    @deprecated super.onChanged,
   }) : super(
           type: FieldType.doubleInput,
         );

--- a/packages/widgetbook/lib/src/fields/double_slider_field.dart
+++ b/packages/widgetbook/lib/src/fields/double_slider_field.dart
@@ -13,7 +13,7 @@ class DoubleSliderField extends NumSliderField<double> {
     required super.min,
     required super.max,
     this.divisions,
-    super.onChanged,
+    @deprecated super.onChanged,
   }) : super(
           type: FieldType.doubleSlider,
           codec: FieldCodec(

--- a/packages/widgetbook/lib/src/fields/duration_field.dart
+++ b/packages/widgetbook/lib/src/fields/duration_field.dart
@@ -8,7 +8,7 @@ class DurationField extends Field<Duration> {
   DurationField({
     required super.name,
     super.initialValue = defaultDuration,
-    super.onChanged,
+    @deprecated super.onChanged,
   }) : super(
           type: FieldType.duration,
           codec: FieldCodec(

--- a/packages/widgetbook/lib/src/fields/field.dart
+++ b/packages/widgetbook/lib/src/fields/field.dart
@@ -28,7 +28,7 @@ abstract class Field<T> {
     required this.type,
     required this.initialValue,
     required this.codec,
-    this.onChanged,
+    @deprecated this.onChanged,
   });
 
   /// Name of this inside the query group.
@@ -47,6 +47,7 @@ abstract class Field<T> {
   /// Callback for when [Field]'s value changed through:
   /// 1. [WidgetbookState.queryParams], used for deep linking.
   /// 2. [Field]'s widget from the side panel.
+  @Deprecated('Fields should not be aware of their context')
   final void Function(BuildContext context, T? value)? onChanged;
 
   /// Extracts the value from [groupMap],
@@ -68,8 +69,6 @@ abstract class Field<T> {
   Widget toWidget(BuildContext context, String group, T? value);
 
   void updateField(BuildContext context, String group, T value) {
-    onChanged?.call(context, value);
-
     WidgetbookState.of(context).updateQueryField(
       group: group,
       field: name,

--- a/packages/widgetbook/lib/src/fields/int_input_field.dart
+++ b/packages/widgetbook/lib/src/fields/int_input_field.dart
@@ -6,7 +6,7 @@ class IntInputField extends NumInputField<int> {
   IntInputField({
     required super.name,
     super.initialValue = 0,
-    super.onChanged,
+    @deprecated super.onChanged,
   }) : super(
           type: FieldType.intInput,
         );

--- a/packages/widgetbook/lib/src/fields/int_slider_field.dart
+++ b/packages/widgetbook/lib/src/fields/int_slider_field.dart
@@ -7,7 +7,7 @@ class IntSliderField extends NumSliderField<int> {
   IntSliderField({
     required super.name,
     super.initialValue = 0,
-    super.onChanged,
+    @deprecated super.onChanged,
     required super.min,
     required super.max,
     this.divisions,

--- a/packages/widgetbook/lib/src/fields/list_field.dart
+++ b/packages/widgetbook/lib/src/fields/list_field.dart
@@ -14,7 +14,7 @@ class ListField<T> extends Field<T> {
     required this.values,
     required super.initialValue,
     this.labelBuilder = defaultLabelBuilder,
-    super.onChanged,
+    @deprecated super.onChanged,
   }) : super(
           type: FieldType.list,
           codec: FieldCodec(

--- a/packages/widgetbook/lib/src/fields/num_input_field.dart
+++ b/packages/widgetbook/lib/src/fields/num_input_field.dart
@@ -8,7 +8,7 @@ class NumInputField<T extends num> extends Field<T> {
   NumInputField({
     required super.name,
     super.initialValue,
-    super.onChanged,
+    @deprecated super.onChanged,
     required super.type,
     this.formatters,
   }) : super(

--- a/packages/widgetbook/lib/src/fields/num_slider_field.dart
+++ b/packages/widgetbook/lib/src/fields/num_slider_field.dart
@@ -7,7 +7,7 @@ class NumSliderField<T extends num> extends Field<T> {
     required super.name,
     this.divisions,
     super.initialValue,
-    super.onChanged,
+    @deprecated super.onChanged,
     required this.min,
     required this.max,
     required super.codec,

--- a/packages/widgetbook/lib/src/fields/string_field.dart
+++ b/packages/widgetbook/lib/src/fields/string_field.dart
@@ -10,7 +10,7 @@ class StringField extends Field<String> {
     required super.name,
     super.initialValue = '',
     this.maxLines,
-    super.onChanged,
+    @deprecated super.onChanged,
   }) : super(
           type: FieldType.string,
           codec: FieldCodec(

--- a/packages/widgetbook/lib/src/knobs/boolean_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/boolean_knob.dart
@@ -1,7 +1,6 @@
 import 'package:meta/meta.dart';
 
 import '../fields/fields.dart';
-import '../state/state.dart';
 import 'knob.dart';
 
 @internal
@@ -24,10 +23,6 @@ class BooleanKnob extends Knob<bool?> {
       BooleanField(
         name: label,
         initialValue: value,
-        onChanged: (context, value) {
-          if (value == null) return;
-          WidgetbookState.of(context).knobs.updateValue(label, value);
-        },
       ),
     ];
   }

--- a/packages/widgetbook/lib/src/knobs/color_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/color_knob.dart
@@ -3,7 +3,6 @@ import 'dart:ui';
 import 'package:meta/meta.dart';
 
 import '../fields/fields.dart';
-import '../state/state.dart';
 import 'knob.dart';
 
 @internal
@@ -24,10 +23,6 @@ class ColorKnob extends Knob<Color> {
         name: label,
         initialValue: value,
         initialColorSpace: initialColorSpace,
-        onChanged: (context, value) {
-          if (value == null) return;
-          WidgetbookState.of(context).knobs.updateValue(label, value);
-        },
       ),
     ];
   }

--- a/packages/widgetbook/lib/src/knobs/date_time_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/date_time_knob.dart
@@ -1,7 +1,6 @@
 import 'package:meta/meta.dart';
 
 import '../fields/fields.dart';
-import '../state/state.dart';
 import 'knob.dart';
 
 @internal
@@ -36,10 +35,6 @@ class DateTimeKnob extends Knob<DateTime?> {
         initialValue: value,
         start: start,
         end: end,
-        onChanged: (context, value) {
-          if (value == null) return;
-          WidgetbookState.of(context).knobs.updateValue(label, value);
-        },
       ),
     ];
   }

--- a/packages/widgetbook/lib/src/knobs/double_input_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/double_input_knob.dart
@@ -1,7 +1,6 @@
 import 'package:meta/meta.dart';
 
 import '../fields/fields.dart';
-import '../state/widgetbook_state.dart';
 import 'knob.dart';
 
 @internal
@@ -24,10 +23,6 @@ class DoubleInputKnob extends Knob<double?> {
       DoubleInputField(
         name: label,
         initialValue: value,
-        onChanged: (context, value) {
-          if (value == null) return;
-          WidgetbookState.of(context).knobs.updateValue(label, value);
-        },
       ),
     ];
   }

--- a/packages/widgetbook/lib/src/knobs/double_slider_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/double_slider_knob.dart
@@ -1,7 +1,6 @@
 import 'package:meta/meta.dart';
 
 import '../fields/fields.dart';
-import '../state/state.dart';
 import 'knob.dart';
 
 @internal
@@ -37,10 +36,6 @@ class DoubleSliderKnob extends Knob<double?> {
         min: min,
         max: max,
         divisions: divisions,
-        onChanged: (context, value) {
-          if (value == null) return;
-          WidgetbookState.of(context).knobs.updateValue(label, value);
-        },
       ),
     ];
   }

--- a/packages/widgetbook/lib/src/knobs/duration_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/duration_knob.dart
@@ -1,7 +1,6 @@
 import 'package:meta/meta.dart';
 
 import '../fields/fields.dart';
-import '../state/state.dart';
 import 'knob.dart';
 
 @internal
@@ -24,10 +23,6 @@ class DurationKnob extends Knob<Duration?> {
       DurationField(
         name: label,
         initialValue: value,
-        onChanged: (context, value) {
-          if (value == null) return;
-          WidgetbookState.of(context).knobs.updateValue(label, value);
-        },
       ),
     ];
   }

--- a/packages/widgetbook/lib/src/knobs/int_input_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/int_input_knob.dart
@@ -1,7 +1,6 @@
 import 'package:meta/meta.dart';
 
 import '../fields/fields.dart';
-import '../state/widgetbook_state.dart';
 import 'knob.dart';
 
 @internal
@@ -24,10 +23,6 @@ class IntInputKnob extends Knob<int?> {
       IntInputField(
         name: label,
         initialValue: value,
-        onChanged: (context, value) {
-          if (value == null) return;
-          WidgetbookState.of(context).knobs.updateValue(label, value);
-        },
       ),
     ];
   }

--- a/packages/widgetbook/lib/src/knobs/int_slider_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/int_slider_knob.dart
@@ -1,7 +1,6 @@
 import 'package:meta/meta.dart';
 
 import '../fields/fields.dart';
-import '../state/state.dart';
 import 'knob.dart';
 
 @internal
@@ -37,10 +36,6 @@ class IntSliderKnob extends Knob<int?> {
         min: min,
         max: max,
         divisions: divisions,
-        onChanged: (context, value) {
-          if (value == null) return;
-          WidgetbookState.of(context).knobs.updateValue(label, value);
-        },
       ),
     ];
   }

--- a/packages/widgetbook/lib/src/knobs/list_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/list_knob.dart
@@ -1,7 +1,6 @@
 import 'package:meta/meta.dart';
 
 import '../fields/fields.dart';
-import '../state/state.dart';
 import 'knob.dart';
 
 @internal
@@ -33,10 +32,6 @@ class ListKnob<T> extends Knob<T?> {
         values: options,
         initialValue: value,
         labelBuilder: labelBuilder ?? ListField.defaultLabelBuilder,
-        onChanged: (context, value) {
-          if (value == null) return;
-          WidgetbookState.of(context).knobs.updateValue<T>(label, value);
-        },
       ),
     ];
   }

--- a/packages/widgetbook/lib/src/knobs/string_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/string_knob.dart
@@ -1,7 +1,6 @@
 import 'package:meta/meta.dart';
 
 import '../fields/fields.dart';
-import '../state/state.dart';
 import 'knob.dart';
 
 @internal
@@ -29,10 +28,6 @@ class StringKnob extends Knob<String?> {
         name: label,
         initialValue: value,
         maxLines: maxLines,
-        onChanged: (context, value) {
-          if (value == null) return;
-          WidgetbookState.of(context).knobs.updateValue(label, value);
-        },
       ),
     ];
   }

--- a/packages/widgetbook/test/src/fields/field_test.dart
+++ b/packages/widgetbook/test/src/fields/field_test.dart
@@ -15,12 +15,6 @@ class MockField extends Field<bool> {
 
   final Fn3Mock<Widget, BuildContext, String, bool?> toWidgetMock = Fn3Mock();
   final FnMock<Map<String, dynamic>> toJsonMock = FnMock();
-  final VoidFn2Mock<BuildContext, bool?> onChangeMock = VoidFn2Mock();
-
-  @override
-  void Function(BuildContext context, bool? value)? get onChanged {
-    return onChangeMock.call;
-  }
 
   @override
   Widget toWidget(
@@ -128,10 +122,6 @@ void main() {
               state.queryParams[group],
             ),
           );
-
-          verify(
-            () => field.onChangeMock(any(), true),
-          ).called(1);
 
           expect(result, equals(true));
         },


### PR DESCRIPTION
The `onChanged` property of `Field` allow users to implement anti-patterns that will not work with Widgetbook Cloud. This is because Widgetbook Cloud is implemented in React and the way it renders these `Field`s is using the JSON shared from `Field.toFullJson`, which cannot decode non-primitive types like `onChanged`.

To prevent this kind of anti-pattern, `onChanged` is deprecated to warn about future removals.