### PR TITLE
refactor: replace knobs `value` with `initialValue`

### DIFF
--- a/docs/knobs/custom-knob.mdx
+++ b/docs/knobs/custom-knob.mdx
@@ -13,8 +13,8 @@ values.
 ## Creating a Custom Knob
 
 To create a custom knob, you must extend the `Knob` class from the `widgetbook` package.
-This class has a `label` and `value` property, both required. The `label` uniquely
-identifies the Knob, and the `value` holds the current value of the Knob.
+This class has a `label` and `initialValue` property. The `label` uniquely
+identifies the Knob, and the `initialValue` holds the initial value of the Knob.
 
 For our `RangeSlider`, we create a `RangeKnob` class that extends `Knob<RangeValues>`.
 `RangeValues` is a class in Flutter that holds two double values - start and end,
@@ -24,7 +24,7 @@ representing the range.
 class RangeKnob extends Knob<RangeValues> {
   RangeKnob({
     required super.label,
-    required super.value,
+    required super.initialValue,
   });
   //...
 }
@@ -43,11 +43,11 @@ The Knob class has several properties that can be overridden:
 List<Field> get fields => [
   DoubleInputField(
     name: 'min-$label',
-    initialValue: value.start,
+    initialValue: initialValue.start,
   ),
   DoubleInputField(
     name: 'max-$label',
-    initialValue: value.end,
+    initialValue: initialValue.end,
   ),
 ];
 
@@ -81,7 +81,7 @@ extension RangeKnobBuilder on KnobsBuilder {
       onKnobAdded(
         RangeKnob(
           label: label,
-          value: initialValue,
+          initialValue: initialValue,
         ),
       )!;
 }

--- a/examples/full_example/lib/customs/custom_knob.dart
+++ b/examples/full_example/lib/customs/custom_knob.dart
@@ -18,18 +18,18 @@ Widget rangeSlider(BuildContext context) {
 class RangeKnob extends Knob<RangeValues> {
   RangeKnob({
     required super.label,
-    required super.value,
+    required super.initialValue,
   });
 
   @override
   List<Field> get fields => [
         DoubleInputField(
           name: 'min-$label',
-          initialValue: value.start,
+          initialValue: initialValue.start,
         ),
         DoubleInputField(
           name: 'max-$label',
-          initialValue: value.end,
+          initialValue: initialValue.end,
         ),
       ];
 
@@ -50,7 +50,7 @@ extension RangeKnobBuilder on KnobsBuilder {
       onKnobAdded(
         RangeKnob(
           label: label,
-          value: initialValue,
+          initialValue: initialValue,
         ),
       )!;
 }

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **FEAT**: Add `q` query param for search. ([#950](https://github.com/widgetbook/widgetbook/pull/950))
 - **REFACTOR**: Deprecate `WidgetbookAddon`'s `initialSetting`. Should be replaced by a local field in relevant addons. ([#1023](https://github.com/widgetbook/widgetbook/pull/1023))
 - **REFACTOR**: Deprecate `Field.onChanged`. ([#1024](https://github.com/widgetbook/widgetbook/pull/1024))
+- **REFACTOR**: Deprecate `Knob.value` & `KnobsRegistry.updateValue` in favor of `Knob.initialValue`. ([#1025](https://github.com/widgetbook/widgetbook/pull/1025))
 
 ## 3.3.0
 

--- a/packages/widgetbook/lib/src/knobs/boolean_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/boolean_knob.dart
@@ -7,13 +7,13 @@ import 'knob.dart';
 class BooleanKnob extends Knob<bool?> {
   BooleanKnob({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
   });
 
   BooleanKnob.nullable({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
   }) : super(isNullable: true);
 
@@ -22,7 +22,7 @@ class BooleanKnob extends Knob<bool?> {
     return [
       BooleanField(
         name: label,
-        initialValue: value,
+        initialValue: initialValue,
       ),
     ];
   }

--- a/packages/widgetbook/lib/src/knobs/builders/double_knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/double_knobs_builder.dart
@@ -20,7 +20,7 @@ class DoubleKnobsBuilder {
     return onKnobAdded(
       DoubleSliderKnob(
         label: label,
-        value: initialValue,
+        initialValue: initialValue,
         description: description,
         min: min,
         max: max,
@@ -39,7 +39,7 @@ class DoubleKnobsBuilder {
     return onKnobAdded(
       DoubleInputKnob(
         label: label,
-        value: initialValue,
+        initialValue: initialValue,
         description: description,
       ),
     )!;
@@ -67,7 +67,7 @@ class DoubleOrNullKnobsBuilder {
     return onKnobAdded(
       DoubleSliderKnob.nullable(
         label: label,
-        value: initialValue,
+        initialValue: initialValue,
         description: description,
         min: min,
         max: max,
@@ -87,7 +87,7 @@ class DoubleOrNullKnobsBuilder {
     return onKnobAdded(
       DoubleInputKnob.nullable(
         label: label,
-        value: initialValue,
+        initialValue: initialValue,
         description: description,
       ),
     );

--- a/packages/widgetbook/lib/src/knobs/builders/int_knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/int_knobs_builder.dart
@@ -16,7 +16,7 @@ class IntKnobsBuilder {
     return onKnobAdded(
       IntInputKnob(
         label: label,
-        value: initialValue,
+        initialValue: initialValue,
         description: description,
       ),
     )!;
@@ -34,7 +34,7 @@ class IntKnobsBuilder {
     return onKnobAdded(
       IntSliderKnob(
         label: label,
-        value: initialValue,
+        initialValue: initialValue,
         description: description,
         min: min,
         max: max,
@@ -61,7 +61,7 @@ class IntOrNullKnobsBuilder {
     return onKnobAdded(
       IntInputKnob.nullable(
         label: label,
-        value: initialValue,
+        initialValue: initialValue,
         description: description,
       ),
     );
@@ -80,7 +80,7 @@ class IntOrNullKnobsBuilder {
     return onKnobAdded(
       IntSliderKnob.nullable(
         label: label,
-        value: initialValue,
+        initialValue: initialValue,
         description: description,
         min: min,
         max: max,

--- a/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
@@ -38,7 +38,7 @@ class KnobsBuilder {
       BooleanKnob(
         label: label,
         description: description,
-        value: initialValue,
+        initialValue: initialValue,
       ),
     )!;
   }
@@ -54,7 +54,7 @@ class KnobsBuilder {
       BooleanKnob.nullable(
         label: label,
         description: description,
-        value: initialValue,
+        initialValue: initialValue,
       ),
     );
   }
@@ -70,7 +70,7 @@ class KnobsBuilder {
     return onKnobAdded(
       ColorKnob(
         label: label,
-        value: initialValue,
+        initialValue: initialValue,
         initialColorSpace: initialColorSpace,
         description: description,
       ),
@@ -87,7 +87,7 @@ class KnobsBuilder {
     return onKnobAdded(
       StringKnob(
         label: label,
-        value: initialValue,
+        initialValue: initialValue,
         description: description,
         maxLines: maxLines,
       ),
@@ -105,7 +105,7 @@ class KnobsBuilder {
     return onKnobAdded(
       StringKnob.nullable(
         label: label,
-        value: initialValue,
+        initialValue: initialValue,
         description: description,
         maxLines: maxLines,
       ),
@@ -125,7 +125,7 @@ class KnobsBuilder {
     return onKnobAdded(
       ListKnob<T>(
         label: label,
-        value: initialOption ?? options.first,
+        initialValue: initialOption ?? options.first,
         description: description,
         options: options,
         labelBuilder: labelBuilder,
@@ -146,7 +146,7 @@ class KnobsBuilder {
     return onKnobAdded(
       ListKnob<T?>.nullable(
         label: label,
-        value: initialOption ?? options.first,
+        initialValue: initialOption ?? options.first,
         description: description,
         options: options,
         labelBuilder: labelBuilder,
@@ -163,7 +163,7 @@ class KnobsBuilder {
     return onKnobAdded(
       DurationKnob(
         label: label,
-        value: initialValue,
+        initialValue: initialValue,
         description: description,
       ),
     )!;
@@ -179,7 +179,7 @@ class KnobsBuilder {
     return onKnobAdded(
       DurationKnob.nullable(
         label: label,
-        value: initialValue,
+        initialValue: initialValue,
         description: description,
       ),
     );
@@ -196,7 +196,7 @@ class KnobsBuilder {
     return onKnobAdded(
       DateTimeKnob(
         label: label,
-        value: initialValue,
+        initialValue: initialValue,
         description: description,
         start: start,
         end: end,
@@ -216,7 +216,7 @@ class KnobsBuilder {
     return onKnobAdded(
       DateTimeKnob.nullable(
         label: label,
-        value: initialValue,
+        initialValue: initialValue,
         description: description,
         start: start,
         end: end,

--- a/packages/widgetbook/lib/src/knobs/color_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/color_knob.dart
@@ -9,7 +9,7 @@ import 'knob.dart';
 class ColorKnob extends Knob<Color> {
   ColorKnob({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
     this.initialColorSpace = ColorSpace.hex,
   });
@@ -21,7 +21,7 @@ class ColorKnob extends Knob<Color> {
     return [
       ColorField(
         name: label,
-        initialValue: value,
+        initialValue: initialValue,
         initialColorSpace: initialColorSpace,
       ),
     ];

--- a/packages/widgetbook/lib/src/knobs/date_time_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/date_time_knob.dart
@@ -7,7 +7,7 @@ import 'knob.dart';
 class DateTimeKnob extends Knob<DateTime?> {
   DateTimeKnob({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
     required this.start,
     required this.end,
@@ -15,7 +15,7 @@ class DateTimeKnob extends Knob<DateTime?> {
 
   DateTimeKnob.nullable({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
     required this.start,
     required this.end,
@@ -32,7 +32,7 @@ class DateTimeKnob extends Knob<DateTime?> {
     return [
       DateTimeField(
         name: label,
-        initialValue: value,
+        initialValue: initialValue,
         start: start,
         end: end,
       ),

--- a/packages/widgetbook/lib/src/knobs/double_input_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/double_input_knob.dart
@@ -7,13 +7,13 @@ import 'knob.dart';
 class DoubleInputKnob extends Knob<double?> {
   DoubleInputKnob({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
   });
 
   DoubleInputKnob.nullable({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
   }) : super(isNullable: true);
 
@@ -22,7 +22,7 @@ class DoubleInputKnob extends Knob<double?> {
     return [
       DoubleInputField(
         name: label,
-        initialValue: value,
+        initialValue: initialValue,
       ),
     ];
   }

--- a/packages/widgetbook/lib/src/knobs/double_slider_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/double_slider_knob.dart
@@ -7,7 +7,7 @@ import 'knob.dart';
 class DoubleSliderKnob extends Knob<double?> {
   DoubleSliderKnob({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
     this.max = 1,
     this.min = 0,
@@ -16,7 +16,7 @@ class DoubleSliderKnob extends Knob<double?> {
 
   DoubleSliderKnob.nullable({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
     this.max = 1,
     this.min = 0,
@@ -32,7 +32,7 @@ class DoubleSliderKnob extends Knob<double?> {
     return [
       DoubleSliderField(
         name: label,
-        initialValue: value,
+        initialValue: initialValue,
         min: min,
         max: max,
         divisions: divisions,

--- a/packages/widgetbook/lib/src/knobs/duration_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/duration_knob.dart
@@ -7,13 +7,13 @@ import 'knob.dart';
 class DurationKnob extends Knob<Duration?> {
   DurationKnob({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
   });
 
   DurationKnob.nullable({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
   }) : super(isNullable: true);
 
@@ -22,7 +22,7 @@ class DurationKnob extends Knob<Duration?> {
     return [
       DurationField(
         name: label,
-        initialValue: value,
+        initialValue: initialValue,
       ),
     ];
   }

--- a/packages/widgetbook/lib/src/knobs/int_input_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/int_input_knob.dart
@@ -7,13 +7,13 @@ import 'knob.dart';
 class IntInputKnob extends Knob<int?> {
   IntInputKnob({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
   });
 
   IntInputKnob.nullable({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
   }) : super(isNullable: true);
 
@@ -22,7 +22,7 @@ class IntInputKnob extends Knob<int?> {
     return [
       IntInputField(
         name: label,
-        initialValue: value,
+        initialValue: initialValue,
       ),
     ];
   }

--- a/packages/widgetbook/lib/src/knobs/int_slider_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/int_slider_knob.dart
@@ -7,7 +7,7 @@ import 'knob.dart';
 class IntSliderKnob extends Knob<int?> {
   IntSliderKnob({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
     this.max = 1,
     this.min = 0,
@@ -16,7 +16,7 @@ class IntSliderKnob extends Knob<int?> {
 
   IntSliderKnob.nullable({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
     this.max = 1,
     this.min = 0,
@@ -32,7 +32,7 @@ class IntSliderKnob extends Knob<int?> {
     return [
       IntSliderField(
         name: label,
-        initialValue: value,
+        initialValue: initialValue,
         min: min,
         max: max,
         divisions: divisions,

--- a/packages/widgetbook/lib/src/knobs/knob.dart
+++ b/packages/widgetbook/lib/src/knobs/knob.dart
@@ -11,15 +11,16 @@ abstract class Knob<T> extends FieldsComposable<T> {
   Knob({
     required this.label,
     this.description,
-    required this.value,
+    @Deprecated('Use initialValue instead.') T? value,
+    T? initialValue,
     this.isNullable = false,
     @Deprecated(
       'This parameter is not used anymore. '
       'It defaults to [value == null] instead of [false]',
     )
     this.isNull = false,
-  }) {
-    this.isNull = value == null;
+  }) : this.initialValue = (initialValue ?? value) as T {
+    this.isNull = this.initialValue == null;
   }
 
   /// The label that's put above a knob.
@@ -28,10 +29,17 @@ abstract class Knob<T> extends FieldsComposable<T> {
   /// The Description of what the user can put on the knob.
   final String? description;
 
-  /// The current value the knob is set to.
-  T value;
+  /// The initial value the knob is set to.
+  final T initialValue;
 
   final bool isNullable;
+
+  @Deprecated(
+    'Knobs are stateless. '
+    'They know about their value from [valueFromQueryGroup]. '
+    'You can use [initialValue] if you want to set a default value. ',
+  )
+  T? value;
 
   bool isNull;
 
@@ -70,7 +78,7 @@ abstract class Knob<T> extends FieldsComposable<T> {
   @override
   bool operator ==(Object other) {
     return other is Knob<T> &&
-        other.value == value &&
+        other.initialValue == initialValue &&
         other.label == label &&
         other.description == description;
   }

--- a/packages/widgetbook/lib/src/knobs/knobs_registry.dart
+++ b/packages/widgetbook/lib/src/knobs/knobs_registry.dart
@@ -37,15 +37,11 @@ class KnobsRegistry extends ChangeNotifier with MapMixin<String, Knob> {
     return knob.valueFromQueryGroup(queryGroup);
   }
 
-  /// Updates [Knob.value] using the [label] to find the [Knob].
-  void updateValue<T>(String label, T value) {
-    _registry.update(
-      label,
-      (knob) => knob..value = value,
-    );
-
-    notifyListeners();
-  }
+  @Deprecated(
+    'Knobs values can no longer be updated, '
+    'they rely on query groups.',
+  )
+  void updateValue<T>(String label, T value) {}
 
   /// Updates [Knob.isNull] using the [label] to find the [Knob].
   @internal

--- a/packages/widgetbook/lib/src/knobs/list_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/list_knob.dart
@@ -7,7 +7,7 @@ import 'knob.dart';
 class ListKnob<T> extends Knob<T?> {
   ListKnob({
     required super.label,
-    required super.value,
+    required super.initialValue,
     required this.options,
     super.description,
     this.labelBuilder,
@@ -15,7 +15,7 @@ class ListKnob<T> extends Knob<T?> {
 
   ListKnob.nullable({
     required super.label,
-    required super.value,
+    required super.initialValue,
     required this.options,
     super.description,
     this.labelBuilder,
@@ -30,7 +30,7 @@ class ListKnob<T> extends Knob<T?> {
       ListField<T>(
         name: label,
         values: options,
-        initialValue: value,
+        initialValue: initialValue,
         labelBuilder: labelBuilder ?? ListField.defaultLabelBuilder,
       ),
     ];

--- a/packages/widgetbook/lib/src/knobs/string_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/string_knob.dart
@@ -7,14 +7,14 @@ import 'knob.dart';
 class StringKnob extends Knob<String?> {
   StringKnob({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
     this.maxLines,
   });
 
   StringKnob.nullable({
     required super.label,
-    required super.value,
+    required super.initialValue,
     super.description,
     this.maxLines,
   }) : super(isNullable: true);
@@ -26,7 +26,7 @@ class StringKnob extends Knob<String?> {
     return [
       StringField(
         name: label,
-        initialValue: value,
+        initialValue: initialValue,
         maxLines: maxLines,
       ),
     ];

--- a/packages/widgetbook/test/src/integrations/widgetbook_cloud_integration_test.dart
+++ b/packages/widgetbook/test/src/integrations/widgetbook_cloud_integration_test.dart
@@ -70,7 +70,7 @@ void main() {
           final knobs = {
             'key': StringKnob(
               label: 'description',
-              value: 'Lorem ipsum',
+              initialValue: 'Lorem ipsum',
             ),
           };
 

--- a/packages/widgetbook/test/src/knobs/double_input_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/double_input_knob_test.dart
@@ -59,30 +59,30 @@ void main() {
     test('DoubleInputKnob.nullable constructor sets correct values', () {
       final knob = DoubleInputKnob.nullable(
         label: 'Test double',
-        value: 5.0,
+        initialValue: 5.0,
         description: 'A test double knob',
       );
 
       expect(knob.label, 'Test double');
-      expect(knob.value, 5.0);
+      expect(knob.initialValue, 5.0);
       expect(knob.description, 'A test double knob');
     });
 
     test('DoubleInputKnob.nullable constructor handles null value', () {
       final knob = DoubleInputKnob.nullable(
         label: 'Test double',
-        value: null,
+        initialValue: null,
         description: 'A test double knob with null value',
       );
 
       expect(knob.label, 'Test double');
-      expect(knob.value, null);
+      expect(knob.initialValue, null);
       expect(knob.description, 'A test double knob with null value');
     });
   });
 
   group('$KnobsBuilder', () {
-    double? mockOnKnobAdded<double>(Knob<double?> knob) => knob.value;
+    double? mockOnKnobAdded<double>(Knob<double?> knob) => knob.initialValue;
     final builder = KnobsBuilder(mockOnKnobAdded);
 
     test('doubleOrNull sets correct values', () {

--- a/packages/widgetbook/test/src/knobs/double_slider_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/double_slider_knob_test.dart
@@ -62,24 +62,24 @@ void main() {
     test('DoubleSliderKnob.nullable constructor sets correct values', () {
       final knob = DoubleSliderKnob.nullable(
         label: 'Test Int',
-        value: 5.0,
+        initialValue: 5.0,
         description: 'A test double knob',
       );
 
       expect(knob.label, 'Test Int');
-      expect(knob.value, 5.0);
+      expect(knob.initialValue, 5.0);
       expect(knob.description, 'A test double knob');
     });
 
     test('DoubleSliderKnob.nullable constructor handles null value', () {
       final knob = DoubleSliderKnob.nullable(
         label: 'Test double',
-        value: null,
+        initialValue: null,
         description: 'A test double knob with null value',
       );
 
       expect(knob.label, 'Test double');
-      expect(knob.value, null);
+      expect(knob.initialValue, null);
       expect(knob.description, 'A test double knob with null value');
     });
   });

--- a/packages/widgetbook/test/src/knobs/duration_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/duration_knob_test.dart
@@ -70,30 +70,32 @@ void main() {
     test('DurationKnob.nullable constructor sets correct values', () {
       final knob = DurationKnob.nullable(
         label: 'Test Duration',
-        value: const Duration(seconds: 5),
+        initialValue: const Duration(seconds: 5),
         description: 'A test duration knob',
       );
 
       expect(knob.label, 'Test Duration');
-      expect(knob.value, const Duration(seconds: 5));
+      expect(knob.initialValue, const Duration(seconds: 5));
       expect(knob.description, 'A test duration knob');
     });
 
     test('DurationKnob.nullable constructor handles null value', () {
       final knob = DurationKnob.nullable(
         label: 'Test Duration',
-        value: null,
+        initialValue: null,
         description: 'A test duration knob with null value',
       );
 
       expect(knob.label, 'Test Duration');
-      expect(knob.value, null);
+      expect(knob.initialValue, null);
       expect(knob.description, 'A test duration knob with null value');
     });
   });
 
   group('$KnobsBuilder', () {
-    Duration? mockOnKnobAdded<Duration>(Knob<Duration?> knob) => knob.value;
+    Duration? mockOnKnobAdded<Duration>(Knob<Duration?> knob) =>
+        knob.initialValue;
+
     final builder = KnobsBuilder(mockOnKnobAdded);
 
     test('durationOrNull sets correct values', () {

--- a/packages/widgetbook/test/src/knobs/int_input_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/int_input_knob_test.dart
@@ -65,30 +65,30 @@ void main() {
     test('IntKnob.nullable constructor sets correct values', () {
       final knob = IntInputKnob.nullable(
         label: 'Test Int',
-        value: 5,
+        initialValue: 5,
         description: 'A test int knob',
       );
 
       expect(knob.label, 'Test Int');
-      expect(knob.value, 5);
+      expect(knob.initialValue, 5);
       expect(knob.description, 'A test int knob');
     });
 
     test('IntKnob.nullable constructor handles null value', () {
       final knob = IntInputKnob.nullable(
         label: 'Test Int',
-        value: null,
+        initialValue: null,
         description: 'A test int knob with null value',
       );
 
       expect(knob.label, 'Test Int');
-      expect(knob.value, null);
+      expect(knob.initialValue, null);
       expect(knob.description, 'A test int knob with null value');
     });
   });
 
   group('$KnobsBuilder', () {
-    int? mockOnKnobAdded<int>(Knob<int?> knob) => knob.value;
+    int? mockOnKnobAdded<int>(Knob<int?> knob) => knob.initialValue;
     final builder = KnobsBuilder(mockOnKnobAdded);
 
     test('intOrNull sets correct values', () {

--- a/packages/widgetbook/test/src/knobs/int_slider_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/int_slider_knob_test.dart
@@ -61,24 +61,24 @@ void main() {
     test('IntSliderKnob.nullable constructor sets correct values', () {
       final knob = IntSliderKnob.nullable(
         label: 'Test Int',
-        value: 5,
+        initialValue: 5,
         description: 'A test int knob',
       );
 
       expect(knob.label, 'Test Int');
-      expect(knob.value, 5);
+      expect(knob.initialValue, 5);
       expect(knob.description, 'A test int knob');
     });
 
     test('IntSliderKnob.nullable constructor handles null value', () {
       final knob = IntSliderKnob.nullable(
         label: 'Test Int',
-        value: null,
+        initialValue: null,
         description: 'A test int knob with null value',
       );
 
       expect(knob.label, 'Test Int');
-      expect(knob.value, null);
+      expect(knob.initialValue, null);
       expect(knob.description, 'A test int knob with null value');
     });
   });

--- a/packages/widgetbook/test/src/state/widgetbook_state_test.dart
+++ b/packages/widgetbook/test/src/state/widgetbook_state_test.dart
@@ -122,11 +122,11 @@ void main() {
         () {
           final knob = StringKnob(
             label: 'Knob',
-            value: 'Widgetbook',
+            initialValue: 'Widgetbook',
           );
 
           final state = WidgetbookState(
-            queryParams: {'knobs': '{${knob.label}:${knob.value}}'},
+            queryParams: {'knobs': '{${knob.label}:${knob.initialValue}}'},
             root: WidgetbookRoot(
               children: [],
             ),
@@ -137,7 +137,7 @@ void main() {
             state.queryParams,
           );
 
-          expect(result, knob.value);
+          expect(result, knob.initialValue);
         },
       );
 
@@ -148,11 +148,11 @@ void main() {
         () {
           final knob = StringKnob.nullable(
             label: 'Knob',
-            value: 'Widgetbook',
+            initialValue: 'Widgetbook',
           );
 
           final state = WidgetbookState(
-            queryParams: {'knobs': '{${knob.label}:${knob.value}}'},
+            queryParams: {'knobs': '{${knob.label}:${knob.initialValue}}'},
             root: WidgetbookRoot(
               children: [],
             ),
@@ -168,34 +168,6 @@ void main() {
           );
 
           expect(result, isNull);
-        },
-      );
-
-      test(
-        'given a knob with a value, '
-        'when the knob value is updated, '
-        'then the new value is returned',
-        () {
-          final knob = StringKnob(
-            label: 'Knob',
-            value: 'Widgetbook',
-          );
-
-          final state = WidgetbookState(
-            queryParams: {'knobs': '{${knob.label}:${knob.value}}'},
-            root: WidgetbookRoot(
-              children: [],
-            ),
-          );
-
-          const newValue = 'Book of Widgets';
-          state.knobs
-            ..register(knob, state.queryParams)
-            ..updateValue(knob.label, newValue);
-
-          final result = state.knobs[knob.label]!.value;
-
-          expect(result, newValue);
         },
       );
 
@@ -233,13 +205,13 @@ void main() {
         () {
           final knob = StringKnob.nullable(
             label: 'Knob',
-            value: 'Widgetbook',
+            initialValue: 'Widgetbook',
           );
 
           final path = 'component/use-case';
 
           final state = WidgetbookState(
-            queryParams: {'knobs': '{${knob.label}:${knob.value}}'},
+            queryParams: {'knobs': '{${knob.label}:${knob.initialValue}}'},
             path: path,
             root: WidgetbookRoot(
               children: [],
@@ -248,12 +220,11 @@ void main() {
           state.knobs.register(knob, state.queryParams);
 
           const query = 'some widget';
-
           state.updateQuery(query);
 
-          expect(state.path, path);
           expect(state.query, query);
-          expect(state.knobs[knob.label]?.value, knob.value);
+          expect(state.path, path);
+          expect(state.knobs, {knob.label: knob});
         },
       );
 


### PR DESCRIPTION
The `Knob`'s `value` was only used as an `initialValue` for `Field`s. It has no other purposes. Even calls to `KnobRegistry.updateValue` were redundant due to the fact that `register` uses `Knob.valueFromQueryGroup` and not `Knob.value`.

To make things more clear, we will be deprecating `Knob.value` in favor of `Knob.initialValue`. In addition, `KnobRegistry.updateValue` is deprecated as well, and currently it's a no-op.