### PR TITLE
fix: change `booleanOrNull`'s `initialValue` to null

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -18,6 +18,7 @@
 - **REFACTOR**: Deprecate `WidgetbookAddon`'s `initialSetting`. Should be replaced by a local field in relevant addons. ([#1023](https://github.com/widgetbook/widgetbook/pull/1023))
 - **REFACTOR**: Deprecate `Field.onChanged`. ([#1024](https://github.com/widgetbook/widgetbook/pull/1024))
 - **REFACTOR**: Deprecate `Knob.value` & `KnobsRegistry.updateValue` in favor of `Knob.initialValue`. ([#1025](https://github.com/widgetbook/widgetbook/pull/1025))
+- **FIX**: Change `booleanOrNull` knobs's `initialValue` to null; to match other `orNull` knobs. ([#1026](https://github.com/widgetbook/widgetbook/pull/1026))
 
 ## 3.3.0
 

--- a/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
@@ -48,7 +48,7 @@ class KnobsBuilder {
   bool? booleanOrNull({
     required String label,
     String? description,
-    bool? initialValue = false,
+    bool? initialValue,
   }) {
     return onKnobAdded(
       BooleanKnob.nullable(

--- a/packages/widgetbook/test/src/knobs/boolean_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/boolean_knob_test.dart
@@ -44,6 +44,7 @@ void main() {
               context.knobs
                   .booleanOrNull(
                     label: 'Knob',
+                    initialValue: false,
                   )
                   .toString(),
             ),
@@ -68,6 +69,7 @@ void main() {
               context.knobs
                   .booleanOrNull(
                     label: 'Knob',
+                    initialValue: false,
                   )
                   .toString(),
             ),


### PR DESCRIPTION
Match other `orNull` knobs' `initialValue`.