### PR TITLE
chore: add `StatefulWidget` example

### DIFF
--- a/examples/full_example/lib/components/stepped_counter.dart
+++ b/examples/full_example/lib/components/stepped_counter.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+final counterKey = GlobalKey();
+
+@widgetbook.UseCase(
+  name: 'Default',
+  type: SteppedCounter,
+)
+Widget steppedCounterUseCase(BuildContext context) {
+  return SteppedCounter(
+    key: counterKey, // To preserve state
+    step: context.knobs.int.slider(
+      label: 'Step',
+      initialValue: 1,
+    ),
+  );
+}
+
+class SteppedCounter extends StatefulWidget {
+  const SteppedCounter({
+    super.key,
+    required this.step,
+  });
+
+  final int step;
+
+  @override
+  State<SteppedCounter> createState() => _SteppedCounterState();
+}
+
+class _SteppedCounterState extends State<SteppedCounter> {
+  int count = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Badge.count(
+      count: widget.step,
+      child: Card(
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.remove),
+              onPressed: () => setState(() => count -= widget.step),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(
+                '${count}',
+                style: Theme.of(context).textTheme.headlineMedium,
+              ),
+            ),
+            IconButton(
+              icon: const Icon(Icons.add),
+              onPressed: () => setState(() => count += widget.step),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/examples/full_example/lib/widgetbook.generator.directories.g.dart
+++ b/examples/full_example/lib/widgetbook.generator.directories.g.dart
@@ -12,7 +12,8 @@
 import 'package:full_example/components/container.dart' as _i2;
 import 'package:full_example/components/custom_card.dart' as _i3;
 import 'package:full_example/components/custom_text_field.dart' as _i4;
-import 'package:full_example/customs/custom_knob.dart' as _i5;
+import 'package:full_example/components/stepped_counter.dart' as _i5;
+import 'package:full_example/customs/custom_knob.dart' as _i6;
 import 'package:widgetbook/widgetbook.dart' as _i1;
 
 final directories = <_i1.WidgetbookNode>[
@@ -68,6 +69,13 @@ final directories = <_i1.WidgetbookNode>[
           ),
         ],
       ),
+      _i1.WidgetbookLeafComponent(
+        name: 'SteppedCounter',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Default',
+          builder: _i5.steppedCounterUseCase,
+        ),
+      ),
     ],
   ),
   _i1.WidgetbookFolder(
@@ -77,7 +85,7 @@ final directories = <_i1.WidgetbookNode>[
         name: 'RangeSlider',
         useCase: _i1.WidgetbookUseCase(
           name: 'CustomRangeSlider',
-          builder: _i5.rangeSlider,
+          builder: _i6.rangeSlider,
         ),
       )
     ],


### PR DESCRIPTION
An example of preserving `StatefulWidget` state as proposed in #788 