### PR TITLE
fix: add `DefaultTextStyle` to `ThemeAddon`s

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -23,6 +23,7 @@
 - **FIX**: Change `booleanOrNull` knobs's `initialValue` to null; to match other `orNull` knobs. ([#1026](https://github.com/widgetbook/widgetbook/pull/1026))
 - **REFACTOR**: Add default parameter value to `color` knobs's `initialValue`. ([#1039](https://github.com/widgetbook/widgetbook/pull/1039))
 - **FEAT**: Add mobile support. ([#1019](https://github.com/widgetbook/widgetbook/pull/1019))
+- **FIX**: Add `DefaultTextStyle` to `ThemeAddon`s. ([#1041](https://github.com/widgetbook/widgetbook/pull/1041))
 
 ## 3.3.0
 

--- a/packages/widgetbook/lib/src/addons/theme_addon/cupertino_theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/cupertino_theme_addon.dart
@@ -14,7 +14,10 @@ class CupertinoThemeAddon extends ThemeAddon<CupertinoThemeData> {
               data: theme,
               child: ColoredBox(
                 color: theme.scaffoldBackgroundColor,
-                child: child,
+                child: DefaultTextStyle(
+                  style: theme.textTheme.textStyle,
+                  child: child,
+                ),
               ),
             );
           },

--- a/packages/widgetbook/lib/src/addons/theme_addon/material_theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/material_theme_addon.dart
@@ -13,7 +13,10 @@ class MaterialThemeAddon extends ThemeAddon<ThemeData> {
               data: theme,
               child: ColoredBox(
                 color: theme.scaffoldBackgroundColor,
-                child: child,
+                child: DefaultTextStyle(
+                  style: theme.textTheme.bodyMedium!,
+                  child: child,
+                ),
               ),
             );
           },


### PR DESCRIPTION
In #789, `Scaffold` was replaced by `ColoredBox`, the `Scaffold` widget used to add the `DefaultTextStyle` widget to the tree, but after that change, the `DefaultTextStyle` should be added via the `ThemeAddon`s.