### PR TITLE
feat: add `setup` to `Story`

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **REFACTOR**: Use const named constructors for `Widgetbook`, instead of static methods. ([#1066](https://github.com/widgetbook/widgetbook/pull/1066))
+- **EXPERIMENTAL**: Add `setup` to `Story`. ([#1069](https://github.com/widgetbook/widgetbook/pull/1069))
 
 ## 3.5.0
 

--- a/packages/widgetbook/lib/src/next/story.dart
+++ b/packages/widgetbook/lib/src/next/story.dart
@@ -5,12 +5,15 @@ import '../navigation/nodes/nodes.dart' as v3;
 import '../state/state.dart';
 import 'args/story_args.dart';
 
+typedef StoryBuilder = Widget Function(BuildContext context, Widget story);
+
 @optionalTypeArgs
 class Story<TWidget> extends v3.WidgetbookUseCase {
   Story({
     required super.name,
     required this.args,
     super.designLink,
+    this.setup,
   }) : super(
           builder: (context) {
             final state = WidgetbookState.of(context);
@@ -18,11 +21,14 @@ class Story<TWidget> extends v3.WidgetbookUseCase {
               state.queryParams['args'],
             );
 
-            return args.build(context, groupMap);
+            final story = args.build(context, groupMap);
+
+            return setup != null ? setup(context, story) : story;
           },
         );
 
   final StoryArgs<TWidget> args;
+  final StoryBuilder? setup;
 
   @override
   Story<TWidget> copyWith({

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **EXPERIMENTAL**: Add `setup` to `Story`. ([#1069](https://github.com/widgetbook/widgetbook/pull/1069))
+
 ## 3.4.0
 
 - **EXPERIMENTAL**: Add support for [SAM Architecture](https://docs.widgetbook.io/next/sam). ([#1064](https://github.com/widgetbook/widgetbook/pull/1064))

--- a/packages/widgetbook_generator/lib/src/next/story_class_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/story_class_builder.dart
@@ -46,6 +46,12 @@ class StoryClassBuilder {
                         ? null
                         : refer('${type.displayName}Args?'),
                 ),
+                Parameter(
+                  (b) => b
+                    ..name = 'setup'
+                    ..named = true
+                    ..toSuper = true,
+                ),
               ]);
 
               if (!isPrimitiveArgs) {

--- a/sandbox/lib/next/types_table.stories.dart
+++ b/sandbox/lib/next/types_table.stories.dart
@@ -10,6 +10,17 @@ final meta = Meta<TypesTable>();
 
 final $Default = TypesTableStory(
   name: 'Default',
+  setup: (context, child) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: Colors.red,
+          width: 6,
+        ),
+      ),
+      child: child,
+    );
+  },
   args: TypesTableArgs(
     duration: Arg.fixed(Duration.zero), // constant arg (not shown in UI)
     person: const PersonArg(


### PR DESCRIPTION
The `setup` parameter is used to wrap stories with some widgets before they get rendered. This could be useful for mocking.