### PR TITLE
feat: support custom args

### DIFF
--- a/docs/next/sam.mdx
+++ b/docs/next/sam.mdx
@@ -164,6 +164,8 @@ final $Default = CoolButtonStory(
 );
 ```
 
+### Args vs Knobs
+
 If you were using Widgetbook 3 knobs, here is a mapping of the knobs to the new args:
 
 | Type       | Knob            | Arg            |
@@ -179,6 +181,32 @@ If you were using Widgetbook 3 knobs, here is a mapping of the knobs to the new 
 | `Color`    | `color`         | `ColorArg`     |
 | `T`        | `list`          | `SingleArg<T>` |
 | `Enum`     | `list`          | `EnumArg<T>`   |
+
+### Custom Args
+
+Args usually match the Widget's constructor, but in some cases users want to customize that.
+
+```dart
+// 1. Define the custom args class
+class CustomInputs {
+  CustomInputs({
+    required this.number,
+  });
+
+  final int number;
+}
+
+// 2. Use `MetaWithArgs` instead of `Meta`
+final meta = MetaWithArgs<CoolWidget, CustomInputs>();
+
+final $Default = CoolWidgetStory(
+  name: 'Default',
+  // 3. Specify how to convert the args (CustomInputsArgs) to a widget (CoolWidget)
+  argsBuilder: (context, args) => CoolWidget(
+    text: args.number.resolve(context).toString(),
+  ),
+);
+```
 
 ## Modes
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **EXPERIMENTAL**: Add `BuilderArg`. ([#1079](https://github.com/widgetbook/widgetbook/pull/1079))
 - **EXPERIMENTAL**: Change `Arg.value` to be positional parameter instead of named one. ([#1077](https://github.com/widgetbook/widgetbook/pull/1077))
 - **EXPERIMENTAL**: Allow overriding `Arg.name`. ([#1078](https://github.com/widgetbook/widgetbook/pull/1078))
+- **EXPERIMENTAL**: Support custom args via `MetaWithArgs`. ([#1080](https://github.com/widgetbook/widgetbook/pull/1080))
 
 ## 3.6.0
 

--- a/packages/widgetbook/lib/src/navigation/nodes/widgetbook_use_case.dart
+++ b/packages/widgetbook/lib/src/navigation/nodes/widgetbook_use_case.dart
@@ -44,6 +44,10 @@ class WidgetbookUseCase extends WidgetbookNode {
   final WidgetBuilder builder;
   final String? designLink;
 
+  Widget build(BuildContext context) {
+    return builder(context);
+  }
+
   @override
   WidgetbookUseCase copyWith({
     String? name,

--- a/packages/widgetbook/lib/src/next/args/arg.dart
+++ b/packages/widgetbook/lib/src/next/args/arg.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 
 import '../../fields/fields.dart';
 import '../../settings/settings.dart';
+import '../../state/state.dart';
 import '../experimental_badge.dart';
 import 'const_arg.dart';
 
@@ -47,6 +48,12 @@ abstract class Arg<T> extends FieldsComposable<T> {
 
   @override
   String get groupName => 'args';
+
+  T resolve(BuildContext context) {
+    final state = WidgetbookState.of(context);
+    final queryGroup = FieldCodec.decodeQueryGroup(state.queryParams['args']);
+    return valueFromQueryGroup(queryGroup);
+  }
 
   @override
   Widget buildFields(BuildContext context) {

--- a/packages/widgetbook/lib/src/next/args/builder_arg.dart
+++ b/packages/widgetbook/lib/src/next/args/builder_arg.dart
@@ -11,5 +11,6 @@ class BuilderArg<T> extends ConstArg<T> {
 
   final ArgBuilder<T> builder;
 
+  @override
   T resolve(BuildContext context) => builder(context);
 }

--- a/packages/widgetbook/lib/src/next/args/story_args.dart
+++ b/packages/widgetbook/lib/src/next/args/story_args.dart
@@ -1,7 +1,4 @@
-import 'package:flutter/widgets.dart';
-
 import 'arg.dart';
-import 'builder_arg.dart';
 import 'const_arg.dart';
 
 abstract class StoryArgs<T> {
@@ -11,24 +8,5 @@ abstract class StoryArgs<T> {
 
   List<Arg> get nonConstList {
     return list.where((arg) => arg is! ConstArg).toList();
-  }
-
-  /// Builds the story with this.
-  /// If a [group] is given, the values are taken from the group.
-  /// Otherwise, the default values are used.
-  Widget build(BuildContext context, [Map<String, String>? group]);
-
-  TArg resolve<TArg>(
-    Arg<TArg> arg,
-    BuildContext context, [
-    Map<String, String>? group,
-  ]) {
-    if (arg is BuilderArg<TArg>) {
-      return arg.resolve(context);
-    } else if (group != null) {
-      return arg.valueFromQueryGroup(group);
-    } else {
-      return arg.value;
-    }
   }
 }

--- a/packages/widgetbook/lib/src/next/component.dart
+++ b/packages/widgetbook/lib/src/next/component.dart
@@ -1,8 +1,12 @@
+import 'package:flutter/widgets.dart';
+
 import '../navigation/nodes/nodes.dart' as v3;
+import 'args/story_args.dart';
 import 'meta.dart';
 import 'story.dart';
 
-class Component<T> extends v3.WidgetbookComponent {
+class Component<TWidget extends Widget, TArgs extends StoryArgs<TWidget>>
+    extends v3.WidgetbookComponent {
   Component({
     required this.meta,
     required this.stories,
@@ -11,6 +15,6 @@ class Component<T> extends v3.WidgetbookComponent {
           useCases: stories,
         );
 
-  final Meta<T> meta;
-  final List<Story<T>> stories;
+  final Meta<TWidget> meta;
+  final List<Story<TWidget, TArgs>> stories;
 }

--- a/packages/widgetbook/lib/src/next/meta.dart
+++ b/packages/widgetbook/lib/src/next/meta.dart
@@ -3,7 +3,7 @@ import 'args/story_args.dart';
 class Meta<T> {
   const Meta({
     String? name,
-  }) : name = name ?? '${T}';
+  }) : name = name ?? '$T';
 
   final String name;
 }

--- a/packages/widgetbook/lib/src/next/meta.dart
+++ b/packages/widgetbook/lib/src/next/meta.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/material.dart';
-
 import 'args/story_args.dart';
 
 class Meta<T> {
@@ -10,17 +8,7 @@ class Meta<T> {
   final String name;
 }
 
-typedef ArgsBuilder<TWidget> = TWidget Function(
-  BuildContext context,
-  StoryArgs<TWidget> args,
-);
-
 /// Same as [Meta] but for custom [StoryArgs].
 class MetaWithArgs<TWidget, TArgs> extends Meta<TWidget> {
-  const MetaWithArgs({
-    super.name,
-    required this.argsBuilder,
-  });
-
-  final ArgsBuilder<TWidget> argsBuilder;
+  const MetaWithArgs({super.name});
 }

--- a/packages/widgetbook/lib/src/next/meta.dart
+++ b/packages/widgetbook/lib/src/next/meta.dart
@@ -1,7 +1,26 @@
+import 'package:flutter/material.dart';
+
+import 'args/story_args.dart';
+
 class Meta<T> {
-  Meta({
+  const Meta({
     String? name,
-  }) : name = name == null ? T.toString() : name;
+  }) : name = name ?? '${T}';
 
   final String name;
+}
+
+typedef ArgsBuilder<TWidget> = TWidget Function(
+  BuildContext context,
+  StoryArgs<TWidget> args,
+);
+
+/// Same as [Meta] but for custom [StoryArgs].
+class MetaWithArgs<TWidget, TArgs> extends Meta<TWidget> {
+  const MetaWithArgs({
+    super.name,
+    required this.argsBuilder,
+  });
+
+  final ArgsBuilder<TWidget> argsBuilder;
 }

--- a/packages/widgetbook/lib/src/next/scenario.dart
+++ b/packages/widgetbook/lib/src/next/scenario.dart
@@ -23,7 +23,7 @@ class Scenario<TWidget extends Widget, TArgs extends StoryArgs<TWidget>>
 
   Widget build(BuildContext context) {
     final effectiveArgs = args ?? story.args;
-    final effectiveStory = story.buildWith(context, effectiveArgs);
+    final effectiveStory = story.argsBuilder(context, effectiveArgs);
 
     return modes == null || modes!.isEmpty
         ? effectiveStory

--- a/packages/widgetbook/lib/src/next/scenario.dart
+++ b/packages/widgetbook/lib/src/next/scenario.dart
@@ -5,7 +5,8 @@ import 'addons/base/mode.dart';
 import 'args/story_args.dart';
 import 'story.dart';
 
-class Scenario<T> extends StatelessWidget {
+class Scenario<TWidget extends Widget, TArgs extends StoryArgs<TWidget>>
+    extends StatelessWidget {
   const Scenario({
     super.key,
     required this.name,
@@ -17,12 +18,12 @@ class Scenario<T> extends StatelessWidget {
   final String name;
   // ignore: strict_raw_type
   final List<Mode>? modes;
-  final StoryArgs<T>? args;
-  final Story<T> story;
+  final TArgs? args;
+  final Story<TWidget, TArgs> story;
 
   Widget build(BuildContext context) {
     final effectiveArgs = args ?? story.args;
-    final effectiveStory = effectiveArgs.build(context);
+    final effectiveStory = story.buildWith(context, effectiveArgs);
 
     return modes == null || modes!.isEmpty
         ? effectiveStory

--- a/packages/widgetbook/lib/src/next/story.dart
+++ b/packages/widgetbook/lib/src/next/story.dart
@@ -1,37 +1,42 @@
 import 'package:flutter/material.dart';
 
-import '../fields/fields.dart';
 import '../navigation/nodes/nodes.dart' as v3;
-import '../state/state.dart';
 import 'args/story_args.dart';
 
 typedef StoryBuilder = Widget Function(BuildContext context, Widget story);
 
 @optionalTypeArgs
-class Story<TWidget> extends v3.WidgetbookUseCase {
+abstract class Story<TWidget extends Widget, TArgs extends StoryArgs<TWidget>>
+    extends v3.WidgetbookUseCase {
   Story({
     required super.name,
     required this.args,
     super.designLink,
-    this.setup,
+    this.setup = defaultSetup,
   }) : super(
-          builder: (context) {
-            final state = WidgetbookState.of(context);
-            final groupMap = FieldCodec.decodeQueryGroup(
-              state.queryParams['args'],
-            );
-
-            final story = args.build(context, groupMap);
-
-            return setup != null ? setup(context, story) : story;
-          },
+          builder: (context) => const SizedBox.shrink(), // TODO: remove
         );
 
-  final StoryArgs<TWidget> args;
-  final StoryBuilder? setup;
+  final TArgs args;
+  final StoryBuilder setup;
+
+  static Widget defaultSetup(
+    BuildContext context,
+    Widget story,
+  ) {
+    return story;
+  }
 
   @override
-  Story<TWidget> copyWith({
+  Widget build(BuildContext context) {
+    final story = buildWith(context, args);
+    return setup(context, story);
+  }
+
+  TWidget buildWith(BuildContext context, TArgs args);
+
+  @override
+  Story<TWidget, TArgs> copyWith({
     String? name,
     List<v3.WidgetbookNode>? children,
   }) {

--- a/packages/widgetbook/lib/src/next/story.dart
+++ b/packages/widgetbook/lib/src/next/story.dart
@@ -3,22 +3,26 @@ import 'package:flutter/material.dart';
 import '../navigation/nodes/nodes.dart' as v3;
 import 'args/story_args.dart';
 
-typedef StoryBuilder = Widget Function(BuildContext context, Widget story);
+typedef SetupBuilder = Widget Function(BuildContext context, Widget story);
+typedef ArgsBuilder<TWidget extends Widget, TArgs extends StoryArgs<TWidget>>
+    = TWidget Function(BuildContext context, TArgs args);
 
 @optionalTypeArgs
 abstract class Story<TWidget extends Widget, TArgs extends StoryArgs<TWidget>>
     extends v3.WidgetbookUseCase {
   Story({
     required super.name,
-    required this.args,
     super.designLink,
     this.setup = defaultSetup,
+    required this.args,
+    required this.argsBuilder,
   }) : super(
           builder: (context) => const SizedBox.shrink(), // TODO: remove
         );
 
   final TArgs args;
-  final StoryBuilder setup;
+  final SetupBuilder setup;
+  final ArgsBuilder<TWidget, TArgs> argsBuilder;
 
   static Widget defaultSetup(
     BuildContext context,
@@ -29,11 +33,9 @@ abstract class Story<TWidget extends Widget, TArgs extends StoryArgs<TWidget>>
 
   @override
   Widget build(BuildContext context) {
-    final story = buildWith(context, args);
+    final story = argsBuilder(context, args);
     return setup(context, story);
   }
-
-  TWidget buildWith(BuildContext context, TArgs args);
 
   @override
   Story<TWidget, TArgs> copyWith({

--- a/packages/widgetbook/lib/src/workbench/workbench.dart
+++ b/packages/widgetbook/lib/src/workbench/workbench.dart
@@ -46,7 +46,7 @@ class Workbench extends StatelessWidget {
                   builder: (context) {
                     return WidgetbookState.of(context)
                             .useCase
-                            ?.builder(context) ??
+                            ?.build(context) ??
                         const SizedBox.shrink();
                   },
                 ),

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **EXPERIMENTAL**: Support `BuilderArg`. ([#1079](https://github.com/widgetbook/widgetbook/pull/1079))
 - **EXPERIMENTAL**: Support positional `Arg.value` parameter. ([#1077](https://github.com/widgetbook/widgetbook/pull/1077))
 - **EXPERIMENTAL**: Set `Arg.name` via `init` instead of constructor. ([#1078](https://github.com/widgetbook/widgetbook/pull/1078))
+- **EXPERIMENTAL**: Support custom args via `MetaWithArgs`. ([#1080](https://github.com/widgetbook/widgetbook/pull/1080))
 
 ## 3.5.0
 

--- a/packages/widgetbook_generator/lib/src/next/args_class_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/args_class_builder.dart
@@ -7,44 +7,30 @@ import 'arg_builder.dart';
 import 'extensions.dart';
 
 class ArgsClassBuilder {
-  ArgsClassBuilder(this.type);
+  ArgsClassBuilder(this.widgetType, this.argsType);
 
-  final DartType type;
+  final DartType widgetType;
+  final DartType argsType;
 
   Iterable<ParameterElement> get params {
-    return (type.element as ClassElement)
+    return (argsType.element as ClassElement)
         .constructors
         .first
         .parameters
         .whereNot((param) => param.name == 'key');
   }
 
-  InvokeExpression instantiate(
-    Expression Function(ParameterElement) assigner,
-  ) {
-    return InvokeExpression.newOf(
-      refer(type.displayName),
-      params //
-          .where((param) => param.isPositional)
-          .map(assigner)
-          .toList(),
-      params //
-          .where((param) => param.isNamed)
-          .lastBy((param) => param.name)
-          .map(
-            (_, param) => MapEntry(
-              param.name,
-              assigner(param),
-            ),
-          ),
-    );
-  }
-
   Class build() {
     return Class(
       (b) => b
-        ..name = '${type.displayName}Args'
-        ..extend = refer('StoryArgs<${type.displayName}>')
+        ..name = '${argsType.displayName}Args'
+        ..extend = TypeReference(
+          (b) => b
+            ..symbol = 'StoryArgs'
+            ..types.addAll([
+              refer(widgetType.displayName),
+            ]),
+        )
         ..fields.addAll(
           params.map(
             (param) => ArgBuilder(param).buildField(),
@@ -94,49 +80,20 @@ class ArgsClassBuilder {
               ),
           ),
         ])
-        ..methods.addAll(
-          [
-            Method(
-              (b) => b
-                ..name = 'list'
-                ..type = MethodType.getter
-                ..returns = refer('List<Arg>')
-                ..annotations.add(refer('override'))
-                ..lambda = true
-                ..body = literalList(
-                  params.map(
-                    (param) => refer(param.name),
-                  ),
-                ).code,
-            ),
-            Method(
-              (b) => b
-                ..name = 'build'
-                ..annotations.add(refer('override'))
-                ..returns = refer('Widget')
-                ..requiredParameters.add(
-                  Parameter(
-                    (b) => b
-                      ..name = 'context'
-                      ..type = refer('BuildContext'),
-                  ),
-                )
-                ..optionalParameters.add(
-                  Parameter(
-                    (b) => b
-                      ..name = 'group'
-                      ..type = refer('Map<String, String>?'),
-                  ),
-                )
-                ..body = instantiate(
-                  (param) => refer('resolve').call([
-                    refer(param.name),
-                    refer('context'),
-                    refer('group'),
-                  ]),
-                ).returned.statement,
-            ),
-          ],
+        ..methods.add(
+          Method(
+            (b) => b
+              ..name = 'list'
+              ..type = MethodType.getter
+              ..returns = refer('List<Arg>')
+              ..annotations.add(refer('override'))
+              ..lambda = true
+              ..body = literalList(
+                params.map(
+                  (param) => refer(param.name),
+                ),
+              ).code,
+          ),
         ),
     );
   }

--- a/packages/widgetbook_generator/lib/src/next/component_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/component_builder.dart
@@ -6,18 +6,27 @@ import 'extensions.dart';
 
 class ComponentBuilder {
   ComponentBuilder(
-    this.type,
+    this.widgetType,
+    this.argsType,
     this.stories,
   );
 
-  final DartType type;
+  final DartType widgetType;
+  final DartType argsType;
   final List<TopLevelVariableElement> stories;
 
   Code build() {
-    return declareFinal('${type.displayName}Component')
+    return declareFinal('${widgetType.displayName}Component')
         .assign(
           InvokeExpression.newOf(
-            refer('Component<${type.displayName}>'),
+            TypeReference(
+              (b) => b
+                ..symbol = 'Component'
+                ..types.addAll([
+                  refer(widgetType.displayName),
+                  refer('${argsType.displayName}Args'),
+                ]),
+            ),
             [],
             {
               'meta': refer('meta'),

--- a/packages/widgetbook_generator/lib/src/next/components_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/components_builder.dart
@@ -50,7 +50,7 @@ class ComponentsBuilder implements Builder {
             ),
           )
           .toList(),
-      refer('Component<dynamic>', 'package:widgetbook/next.dart'),
+      refer('Component', 'package:widgetbook/next.dart'),
     );
 
     final outputLibrary = Library(

--- a/packages/widgetbook_generator/lib/src/next/scenario_typedef_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/scenario_typedef_builder.dart
@@ -4,15 +4,23 @@ import 'package:code_builder/code_builder.dart';
 import 'extensions.dart';
 
 class ScenarioTypedefBuilder {
-  ScenarioTypedefBuilder(this.type);
+  ScenarioTypedefBuilder(this.widgetType, this.argsType);
 
-  final DartType type;
+  final DartType widgetType;
+  final DartType argsType;
 
   TypeDef build() {
     return TypeDef(
       (b) => b
-        ..name = '${type.displayName}Scenario'
-        ..definition = refer('Scenario<${type.displayName}>'),
+        ..name = '${widgetType.displayName}Scenario'
+        ..definition = TypeReference(
+          (b) => b
+            ..symbol = 'Scenario'
+            ..types.addAll([
+              refer(widgetType.displayName),
+              refer('${argsType.displayName}Args'),
+            ]),
+        ),
     );
   }
 }

--- a/packages/widgetbook_generator/lib/src/next/story_generator.dart
+++ b/packages/widgetbook_generator/lib/src/next/story_generator.dart
@@ -24,18 +24,18 @@ class StoryGenerator extends Generator {
         .whereType<TopLevelVariableElement>()
         .firstWhere((element) => element.name == 'meta');
 
-    final widgetType = (metaVariable.type as InterfaceType) //
-        .typeArguments
-        .first;
+    final metaType = metaVariable.type as InterfaceType;
+    final widgetType = metaType.typeArguments.first;
+    final argsType = metaType.typeArguments.last;
 
     final genLib = Library(
       (b) => b
         ..body.addAll(
           [
-            ComponentBuilder(widgetType, storiesVariables).build(),
-            ScenarioTypedefBuilder(widgetType).build(),
-            StoryClassBuilder(widgetType).build(),
-            ArgsClassBuilder(widgetType).build(),
+            ComponentBuilder(widgetType, argsType, storiesVariables).build(),
+            ScenarioTypedefBuilder(widgetType, argsType).build(),
+            StoryClassBuilder(widgetType, argsType).build(),
+            ArgsClassBuilder(widgetType, argsType).build(),
           ],
         ),
     );

--- a/sandbox/lib/next/label_badge.dart
+++ b/sandbox/lib/next/label_badge.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class LabelBadge extends StatelessWidget {
+  const LabelBadge({
+    super.key,
+    required this.text,
+  });
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Badge(
+      label: Text(text),
+    );
+  }
+}

--- a/sandbox/lib/next/label_badge.stories.dart
+++ b/sandbox/lib/next/label_badge.stories.dart
@@ -1,23 +1,18 @@
-import 'package:flutter/widgets.dart';
 import 'package:widgetbook/next.dart';
 
 import 'label_badge.dart';
 
 part 'label_badge.stories.book.dart';
 
-final meta = MetaWithArgs<LabelBadge, NumericBadgeInput>(
-  argsBuilder: (context, args) {
-    final typedArgs = args as NumericBadgeInputArgs;
-    return LabelBadge(
-      text: typedArgs.number.resolve(context).toString(),
-    );
-  },
-);
+final meta = MetaWithArgs<LabelBadge, NumericBadgeInput>();
 
 final $Default = LabelBadgeStory(
   name: 'Default',
   args: NumericBadgeInputArgs(
     number: const IntArg(1),
+  ),
+  argsBuilder: (context, args) => LabelBadge(
+    text: args.number.resolve(context).toString(),
   ),
 );
 

--- a/sandbox/lib/next/label_badge.stories.dart
+++ b/sandbox/lib/next/label_badge.stories.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/widgets.dart';
+import 'package:widgetbook/next.dart';
+
+import 'label_badge.dart';
+
+part 'label_badge.stories.book.dart';
+
+final meta = MetaWithArgs<LabelBadge, NumericBadgeInput>(
+  argsBuilder: (context, args) {
+    final typedArgs = args as NumericBadgeInputArgs;
+    return LabelBadge(
+      text: typedArgs.number.resolve(context).toString(),
+    );
+  },
+);
+
+final $Default = LabelBadgeStory(
+  name: 'Default',
+  args: NumericBadgeInputArgs(
+    number: const IntArg(1),
+  ),
+);
+
+class NumericBadgeInput {
+  NumericBadgeInput({
+    required this.number,
+  });
+
+  final int number;
+}


### PR DESCRIPTION
Args usually match the Widget's constructor, but in some cases users want to customize that.

```dart
// 1. Define the custom args class
class CustomInputs {
  CustomInputs({
    required this.number,
  });

  final int number;
}

// 2. Use `MetaWithArgs` instead of `Meta`
final meta = MetaWithArgs<CoolWidget, CustomInputs>();

final $Default = CoolWidgetStory(
  name: 'Default',
  // 3. Specify how to convert the args (CustomInputsArgs) to a widget (CoolWidget)
  argsBuilder: (context, args) => CoolWidget(
    text: args.number.resolve(context).toString(),
  ),
);
```