### PR TITLE
refactor: add `args` to `setup`

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **EXPERIMENTAL**: Change `Arg.value` to be positional parameter instead of named one. ([#1077](https://github.com/widgetbook/widgetbook/pull/1077))
 - **EXPERIMENTAL**: Allow overriding `Arg.name`. ([#1078](https://github.com/widgetbook/widgetbook/pull/1078))
 - **EXPERIMENTAL**: Support custom args via `MetaWithArgs`. ([#1080](https://github.com/widgetbook/widgetbook/pull/1080))
+- **EXPERIMENTAL**: Add `args` parameter to `Story.setup`. ([#1081](https://github.com/widgetbook/widgetbook/pull/1081))
 
 ## 3.6.0
 

--- a/packages/widgetbook/lib/src/next/story.dart
+++ b/packages/widgetbook/lib/src/next/story.dart
@@ -3,7 +3,12 @@ import 'package:flutter/material.dart';
 import '../navigation/nodes/nodes.dart' as v3;
 import 'args/story_args.dart';
 
-typedef SetupBuilder = Widget Function(BuildContext context, Widget story);
+typedef SetupBuilder<TArgs> = Widget Function(
+  BuildContext context,
+  Widget story,
+  TArgs args,
+);
+
 typedef ArgsBuilder<TWidget extends Widget, TArgs extends StoryArgs<TWidget>>
     = TWidget Function(BuildContext context, TArgs args);
 
@@ -21,12 +26,13 @@ abstract class Story<TWidget extends Widget, TArgs extends StoryArgs<TWidget>>
         );
 
   final TArgs args;
-  final SetupBuilder setup;
+  final SetupBuilder<TArgs> setup;
   final ArgsBuilder<TWidget, TArgs> argsBuilder;
 
   static Widget defaultSetup(
     BuildContext context,
     Widget story,
+    dynamic args,
   ) {
     return story;
   }
@@ -34,7 +40,7 @@ abstract class Story<TWidget extends Widget, TArgs extends StoryArgs<TWidget>>
   @override
   Widget build(BuildContext context) {
     final story = argsBuilder(context, args);
-    return setup(context, story);
+    return setup(context, story, args);
   }
 
   @override

--- a/sandbox/lib/next/types_table.stories.dart
+++ b/sandbox/lib/next/types_table.stories.dart
@@ -10,12 +10,12 @@ final meta = Meta<TypesTable>();
 
 final $Default = TypesTableStory(
   name: 'Default',
-  setup: (context, child) {
+  setup: (context, child, args) {
     return Container(
       decoration: BoxDecoration(
         border: Border.all(
           color: Colors.red,
-          width: 6,
+          width: args.decimal.resolve(context),
         ),
       ),
       child: child,


### PR DESCRIPTION
Allowing access to `args` in `setup` method can be beneficial for cases that the setup method is used to inject a `Provider` that needs those `args`. 