### PR TITLE
fix: enable `InspectorAddon` on release builds

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **FIX**: Enable `InspectorAddon` on release builds. ([#1087](https://github.com/widgetbook/widgetbook/pull/1087))
 - **EXPERIMENTAL**: Add `EnumArg`. ([#1073](https://github.com/widgetbook/widgetbook/pull/1073))
 - **EXPERIMENTAL**: Add `SingleArg`. ([#1075](https://github.com/widgetbook/widgetbook/pull/1075))
 - **EXPERIMENTAL**: Add `BuilderArg`. ([#1079](https://github.com/widgetbook/widgetbook/pull/1079))

--- a/packages/widgetbook/lib/src/addons/inspector_addon/inspector_addon.dart
+++ b/packages/widgetbook/lib/src/addons/inspector_addon/inspector_addon.dart
@@ -34,7 +34,10 @@ class InspectorAddon extends WidgetbookAddon<bool> {
     return setting
         ? Scaffold(
             backgroundColor: const Color(0xFF121515),
-            body: Inspector(child: child),
+            body: Inspector(
+              child: child,
+              isEnabled: enabled,
+            ),
           )
         : child;
   }

--- a/packages/widgetbook/lib/src/addons/inspector_addon/inspector_addon.dart
+++ b/packages/widgetbook/lib/src/addons/inspector_addon/inspector_addon.dart
@@ -36,7 +36,7 @@ class InspectorAddon extends WidgetbookAddon<bool> {
             backgroundColor: const Color(0xFF121515),
             body: Inspector(
               child: child,
-              isEnabled: enabled,
+              isEnabled: setting,
             ),
           )
         : child;

--- a/packages/widgetbook/lib/src/addons/inspector_addon/inspector_addon.dart
+++ b/packages/widgetbook/lib/src/addons/inspector_addon/inspector_addon.dart
@@ -31,9 +31,14 @@ class InspectorAddon extends WidgetbookAddon<bool> {
     Widget child,
     bool setting,
   ) {
-    return Inspector(
-              isEnabled: setting,
+    return setting
+        ? Scaffold(
+            backgroundColor: const Color(0xFF121515),
+            body: Inspector(
               child: child,
-            );
+              isEnabled: setting,
+            ),
+          )
+        : child;
   }
 }

--- a/packages/widgetbook/lib/src/addons/inspector_addon/inspector_addon.dart
+++ b/packages/widgetbook/lib/src/addons/inspector_addon/inspector_addon.dart
@@ -31,14 +31,14 @@ class InspectorAddon extends WidgetbookAddon<bool> {
     Widget child,
     bool setting,
   ) {
-    return setting
-        ? Scaffold(
-            backgroundColor: const Color(0xFF121515),
-            body: Inspector(
-              child: child,
-              isEnabled: setting,
-            ),
-          )
-        : child;
+    if (!setting) return child;
+
+    return Scaffold(
+      backgroundColor: const Color(0xFF121515),
+      body: Inspector(
+        isEnabled: true, // To bypass disabling on release builds
+        child: child,
+      ),
+    );
   }
 }

--- a/packages/widgetbook/lib/src/addons/inspector_addon/inspector_addon.dart
+++ b/packages/widgetbook/lib/src/addons/inspector_addon/inspector_addon.dart
@@ -31,14 +31,9 @@ class InspectorAddon extends WidgetbookAddon<bool> {
     Widget child,
     bool setting,
   ) {
-    return setting
-        ? Scaffold(
-            backgroundColor: const Color(0xFF121515),
-            body: Inspector(
-              child: child,
+    return Inspector(
               isEnabled: setting,
-            ),
-          )
-        : child;
+              child: child,
+            );
   }
 }

--- a/packages/widgetbook/test/src/addons/inspector_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/inspector_addon_test.dart
@@ -39,6 +39,19 @@ void main() {
       expect(find.text('Test'), findsOneWidget);
     });
 
+    testWidgets(
+        'buildUseCase with isEnabled true has Inspector with isEnabled true',
+        (tester) async {
+      await tester.pumpWidgetWithBuilder(
+        (context) => addon.buildUseCase(context, const Text('Test'), true),
+      );
+
+      final inspectorFinder = find.byType(Inspector);
+      expect(inspectorFinder, findsOneWidget);
+      final inspector = tester.firstWidget(inspectorFinder) as Inspector;
+      expect(inspector.isEnabled, true);
+    });
+
     testWidgets('buildUseCase with isEnabled false returns child directly',
         (tester) async {
       await tester.pumpWidgetWithBuilder(

--- a/packages/widgetbook/test/src/addons/inspector_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/inspector_addon_test.dart
@@ -29,6 +29,16 @@ void main() {
       expect(result, isTrue);
     });
 
+    testWidgets('buildUseCase with isEnabled true wraps child with Inspector',
+        (tester) async {
+      await tester.pumpWidgetWithBuilder(
+        (context) => addon.buildUseCase(context, const Text('Test'), true),
+      );
+
+      expect(find.byType(Inspector), findsOneWidget);
+      expect(find.text('Test'), findsOneWidget);
+    });
+
     testWidgets(
         'buildUseCase with isEnabled true has Inspector with isEnabled true',
         (tester) async {
@@ -40,20 +50,15 @@ void main() {
       expect(inspectorFinder, findsOneWidget);
       final inspector = tester.firstWidget(inspectorFinder) as Inspector;
       expect(inspector.isEnabled, true);
-      expect(find.text('Test'), findsOneWidget);
     });
 
-    testWidgets(
-        'buildUseCase with isEnabled false has Inspector with isEnabled false',
+    testWidgets('buildUseCase with isEnabled false returns child directly',
         (tester) async {
       await tester.pumpWidgetWithBuilder(
         (context) => addon.buildUseCase(context, const Text('Test'), false),
       );
 
-      final inspectorFinder = find.byType(Inspector);
-      expect(inspectorFinder, findsOneWidget);
-      final inspector = tester.firstWidget(inspectorFinder) as Inspector;
-      expect(inspector.isEnabled, false);
+      expect(find.byType(Inspector), findsNothing);
       expect(find.text('Test'), findsOneWidget);
     });
   });

--- a/packages/widgetbook/test/src/addons/inspector_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/inspector_addon_test.dart
@@ -29,16 +29,6 @@ void main() {
       expect(result, isTrue);
     });
 
-    testWidgets('buildUseCase with isEnabled true wraps child with Inspector',
-        (tester) async {
-      await tester.pumpWidgetWithBuilder(
-        (context) => addon.buildUseCase(context, const Text('Test'), true),
-      );
-
-      expect(find.byType(Inspector), findsOneWidget);
-      expect(find.text('Test'), findsOneWidget);
-    });
-
     testWidgets(
         'buildUseCase with isEnabled true has Inspector with isEnabled true',
         (tester) async {
@@ -50,15 +40,20 @@ void main() {
       expect(inspectorFinder, findsOneWidget);
       final inspector = tester.firstWidget(inspectorFinder) as Inspector;
       expect(inspector.isEnabled, true);
+      expect(find.text('Test'), findsOneWidget);
     });
 
-    testWidgets('buildUseCase with isEnabled false returns child directly',
+    testWidgets(
+        'buildUseCase with isEnabled false has Inspector with isEnabled false',
         (tester) async {
       await tester.pumpWidgetWithBuilder(
         (context) => addon.buildUseCase(context, const Text('Test'), false),
       );
 
-      expect(find.byType(Inspector), findsNothing);
+      final inspectorFinder = find.byType(Inspector);
+      expect(inspectorFinder, findsOneWidget);
+      final inspector = tester.firstWidget(inspectorFinder) as Inspector;
+      expect(inspector.isEnabled, false);
       expect(find.text('Test'), findsOneWidget);
     });
   });


### PR DESCRIPTION
By passing `enabled` to the `Inspector` widget we ensure that the inspector is properly toggled for release builds. See issue below for further details.

### List of issues which are fixed by the PR
- https://github.com/widgetbook/widgetbook/issues/1085

### Screenshots
For the following screenshots I ran `flutter build web` and then ran the build with `dhhtpd`.
First is before change, and second is with my change, where you can see the `Inspector` is now shown.

![image](https://github.com/widgetbook/widgetbook/assets/59177743/8fc96ca2-5a68-4f28-b1ea-304a03097ce6)

![image](https://github.com/widgetbook/widgetbook/assets/59177743/319843c9-3d7b-413c-afe5-adbb68cf2ef3)

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
