### PR TITLE
feat: generate component default path

### DIFF
--- a/packages/widgetbook/lib/src/next/meta.dart
+++ b/packages/widgetbook/lib/src/next/meta.dart
@@ -3,11 +3,25 @@ import 'args/story_args.dart';
 class Meta<T> {
   const Meta({
     String? name,
-    this.path,
-  }) : name = name ?? '$T';
+    String? path,
+  })  : name = name ?? '$T',
+        $path = path;
 
   final String name;
-  final String? path;
+  final String? $path;
+
+  String? get path => $path;
+
+  /// Creates a copy of this using the provided [path] for late initialization.
+  /// If [$path] was already set, it should have precedence over [path].
+  Meta<T> init({
+    required String path,
+  }) {
+    return Meta<T>(
+      name: name,
+      path: $path == null ? path : $path,
+    );
+  }
 }
 
 /// Same as [Meta] but for custom [StoryArgs].

--- a/packages/widgetbook_generator/lib/src/next/component_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/component_builder.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:code_builder/code_builder.dart';
+import 'package:path/path.dart' as p;
 
 import 'extensions.dart';
 
@@ -29,7 +30,10 @@ class ComponentBuilder {
             ),
             [],
             {
-              'meta': refer('meta'),
+              'meta': refer('meta').property('init').call(
+                [],
+                {'path': literalString(navPath)},
+              ),
               'stories': literalList(
                 stories.map((story) => refer(story.name)).toList(),
               ),
@@ -37,5 +41,19 @@ class ComponentBuilder {
           ),
         )
         .statement;
+  }
+
+  /// Gets the navigation path based on [widgetType], skipping both
+  /// the `package:` and the `src` parts.
+  ///
+  /// For example, `package:my_app/src/widgets/foo/bar.dart`
+  /// will be converted to `widgets/foo`.
+  String get navPath {
+    final uri = widgetType.element!.source!.uri.toString();
+    final directory = p.dirname(uri);
+    final parts = p.split(directory);
+    final hasSrc = parts.length >= 2 && parts[1] == 'src';
+
+    return parts.skip(hasSrc ? 2 : 1).join('/');
   }
 }


### PR DESCRIPTION
A fallback path is now generated if the `Meta.path` parameter is not specified.