### PR TITLE
docs: use `super.key`

### DIFF
--- a/docs/addons/theme-addon.mdx
+++ b/docs/addons/theme-addon.mdx
@@ -139,11 +139,10 @@ accomplished using an `InheritedWidget`. For instance, you could define an AppTh
 ```dart title="Example: AppTheme InheritedWidget"
 class AppTheme extends InheritedWidget {
   const AppTheme({
-    Key? key,
     required this.data,
     required Widget child,
+    super.key,
   }) : super(
-          key: key,
           child: child,
         );
 

--- a/docs/cookbook/custom-theme.mdx
+++ b/docs/cookbook/custom-theme.mdx
@@ -33,11 +33,10 @@ holds the theme data and exposes it through a static of method. Here's an exampl
 ```dart
 class AppTheme extends InheritedWidget {
   const AppTheme({
-    Key? key,
     required this.data,
     required Widget child,
+    super.key,
   }) : super(
-          key: key,
           child: child,
         );
 

--- a/docs/getting-started/complete-example.mdx
+++ b/docs/getting-started/complete-example.mdx
@@ -37,11 +37,11 @@ class CustomCard extends StatelessWidget {
   final double borderRadius;
 
   const CustomCard({
-    Key? key,
     required this.child,
     this.backgroundColor = Colors.white,
     this.borderRadius = 8.0,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -70,10 +70,10 @@ class CustomTextField extends StatelessWidget {
   final String hintText;
 
   const CustomTextField({
-    Key? key,
     required this.controller,
     this.hintText = '',
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -176,7 +176,7 @@ void main() {
 // use @App annotation
 @widgetbook.App()
 class WidgetbookApp extends StatelessWidget {
-  const WidgetbookApp({Key? key}) : super(key: key);
+  const WidgetbookApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -210,7 +210,7 @@ void main() {
 }
 
 class HotReload extends StatelessWidget {
-  const HotReload({Key? key}) : super(key: key);
+  const HotReload({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -179,7 +179,7 @@ your_flutter_project/
     }
 
     class HotReload extends StatelessWidget {
-      const HotReload({Key? key}) : super(key: key);
+      const HotReload({super.key});
 
       @override
       Widget build(BuildContext context) {

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -110,7 +110,7 @@ void main() {
 
 @widgetbook.App()
 class WidgetbookApp extends StatelessWidget {
-  const WidgetbookApp({Key? key}) : super(key: key);
+  const WidgetbookApp({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/docs/getting-started/structure.mdx
+++ b/docs/getting-started/structure.mdx
@@ -84,7 +84,7 @@ void main() {
 }
 
 class HotReload extends StatelessWidget {
-  const HotReload({Key? key}) : super(key: key);
+  const HotReload({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/docs/knobs/example.mdx
+++ b/docs/knobs/example.mdx
@@ -95,7 +95,6 @@ void main() {
 
 class MyHomePage extends StatefulWidget {
   const MyHomePage({
-    Key? key,
     required this.title,
     this.incrementBy = 1,
     this.countLabel,
@@ -104,7 +103,8 @@ class MyHomePage extends StatefulWidget {
     this.color = Colors.blue
     this.duration = Duration.zero,
     this.dateTime,
-  }) : super(key: key);
+    super.key,
+  });
 
   final String title;
   final int incrementBy;
@@ -173,7 +173,7 @@ class _MyHomePageState extends State<MyHomePage> {
 }
 
 class KnobsExample extends StatelessWidget {
-  const KnobsExample({Key? key}) : super(key: key);
+  const KnobsExample({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/docs/monorepo/getting-started.mdx
+++ b/docs/monorepo/getting-started.mdx
@@ -197,7 +197,7 @@ void main() {
 
 @widgetbook.App()
 class WidgetbookApp extends StatelessWidget {
-  const WidgetbookApp({Key? key}) : super(key: key);
+  const WidgetbookApp({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/docs/widgetbook-cloud/reviews.mdx
+++ b/docs/widgetbook-cloud/reviews.mdx
@@ -49,7 +49,7 @@ In order for the addons and knobs in your Widgetbook builds to work with our rev
 ```dart
 @widgetbook.App()
 class WidgetbookApp extends StatelessWidget {
-  const WidgetbookApp({Key? key}) : super(key: key);
+  const WidgetbookApp({super.key});
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
A very minor improvement on the getting started docs to make the snippet in the setup docs to use super parameters.

### List of issues which are fixed by the PR
*You must list at least one issue.*

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
