### PR TITLE
fix: update `DoubleInputField` regex

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **REFACTOR**: Wrap workbench with `Scaffold`. ([#1091](https://github.com/widgetbook/widgetbook/pull/1091))
+- **FIX**: Update `DoubleInputField` regex to accept more digits before the decimal point. ([#1117](https://github.com/widgetbook/widgetbook/pull/1117))
 
 ## 3.7.0
 

--- a/packages/widgetbook/lib/src/fields/double_input_field.dart
+++ b/packages/widgetbook/lib/src/fields/double_input_field.dart
@@ -15,7 +15,7 @@ class DoubleInputField extends NumInputField<double> {
           type: FieldType.doubleInput,
           formatters: [
             FilteringTextInputFormatter.allow(
-              RegExp(r'[0-9](.[0-9]*)?'),
+              RegExp(r'\d+.?\d*'),
             ),
           ],
         );


### PR DESCRIPTION
Before: 12.3 ❌ 
After: 12.3 ✅ 