### PR TITLE
fix(cli): use staging `appUrl` for non-prod envs

### DIFF
--- a/packages/widgetbook_cli/lib/src/core/environment.dart
+++ b/packages/widgetbook_cli/lib/src/core/environment.dart
@@ -23,7 +23,7 @@ class StagingEnv extends Environment {
   StagingEnv()
       : super(
           name: 'staging',
-          appUrl: 'https://dev.app.widgetbook.io/',
+          appUrl: 'https://staging.app.widgetbook.io/',
           apiUrl: 'https://staging.api.widgetbook.io/v1/',
         );
 }
@@ -32,7 +32,7 @@ class DebugEnv extends Environment {
   DebugEnv()
       : super(
           name: 'debug',
-          appUrl: 'https://dev.app.widgetbook.io/',
+          appUrl: 'https://staging.app.widgetbook.io/',
           apiUrl: 'http://localhost:3000/v1/',
         );
 }


### PR DESCRIPTION
Only affects the `widgetbook_staging` and `widgetbook_debug` binaries.
The `widgetbook` binary is not affected.