### PR TITLE
feat(generator): support generic widgets

### DIFF
--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **FEAT**: Support default `setup` & `argsBuilder` via top-level definitions. ([#1130](https://github.com/widgetbook/widgetbook/pull/1130))
+- **FEAT**: Support generic widgets. ([#1131](https://github.com/widgetbook/widgetbook/pull/1131))
 
 ## 4.0.0-alpha.1
 

--- a/packages/widgetbook_generator/lib/src/core/args_class_builder.dart
+++ b/packages/widgetbook_generator/lib/src/core/args_class_builder.dart
@@ -15,14 +15,24 @@ class ArgsClassBuilder {
     return (argsType.element as ClassElement).constructors.first.parameters;
   }
 
+  Set<Reference> getTypeParams({bool withBounds = true}) {
+    return {
+      ...widgetType.getTypeParams(withBounds: withBounds),
+      ...argsType.getTypeParams(withBounds: withBounds),
+    };
+  }
+
   Class build() {
     final widgetClassRef = widgetType.getRef();
-    final argsClassRef = argsType.getRef(suffix: 'Args');
+    final argsClassRef = argsType.getRef(
+      suffix: 'Args',
+      types: getTypeParams(withBounds: false),
+    );
 
     return Class(
       (b) => b
         ..name = argsClassRef.symbol
-        ..types.addAll(argsType.getTypeParams())
+        ..types.addAll(getTypeParams())
         ..extend = TypeReference(
           (b) => b
             ..symbol = 'StoryArgs'

--- a/packages/widgetbook_generator/lib/src/core/args_class_builder.dart
+++ b/packages/widgetbook_generator/lib/src/core/args_class_builder.dart
@@ -16,15 +16,17 @@ class ArgsClassBuilder {
   }
 
   Class build() {
+    final widgetClassRef = widgetType.getRef();
+    final argsClassRef = argsType.getRef(suffix: 'Args');
+
     return Class(
       (b) => b
-        ..name = '${argsType.nonNullableName}Args'
+        ..name = argsClassRef.symbol
+        ..types.addAll(argsType.getTypeParams())
         ..extend = TypeReference(
           (b) => b
             ..symbol = 'StoryArgs'
-            ..types.addAll([
-              refer(widgetType.nonNullableName),
-            ]),
+            ..types.addAll([widgetClassRef]),
         )
         ..fields.addAll(
           params.map(

--- a/packages/widgetbook_generator/lib/src/core/component_builder.dart
+++ b/packages/widgetbook_generator/lib/src/core/component_builder.dart
@@ -19,39 +19,42 @@ class ComponentBuilder {
   final String path;
 
   Code build() {
-    return declareFinal('${widgetType.nonNullableName}Component')
-        .assign(
-          InvokeExpression.newOf(
-            TypeReference(
-              (b) => b
-                ..symbol = 'Component'
-                ..types.addAll([
-                  refer(widgetType.nonNullableName),
-                  refer('${argsType.nonNullableName}Args'),
-                ]),
+    return Block.of([
+      const Code('// ignore: strict_raw_type'),
+      declareFinal('${widgetType.nonGenericName}Component')
+          .assign(
+            InvokeExpression.newOf(
+              TypeReference(
+                (b) => b
+                  ..symbol = 'Component'
+                  ..types.addAll([
+                    refer(widgetType.nonGenericName),
+                    refer('${argsType.nonGenericName}Args'),
+                  ]),
+              ),
+              [],
+              {
+                'meta': refer('meta').property('init').call(
+                  [],
+                  {'path': literalString(navPath)},
+                ),
+                'stories': literalList(
+                  stories
+                      .map(
+                        (story) => refer(story.name).property('init').call(
+                          [],
+                          {
+                            'name': literalString(story.name.substring(1)),
+                          },
+                        ),
+                      )
+                      .toList(),
+                ),
+              },
             ),
-            [],
-            {
-              'meta': refer('meta').property('init').call(
-                [],
-                {'path': literalString(navPath)},
-              ),
-              'stories': literalList(
-                stories
-                    .map(
-                      (story) => refer(story.name).property('init').call(
-                        [],
-                        {
-                          'name': literalString(story.name.substring(1)),
-                        },
-                      ),
-                    )
-                    .toList(),
-              ),
-            },
-          ),
-        )
-        .statement;
+          )
+          .statement,
+    ]);
   }
 
   /// Gets the navigation path based on [widgetType], skipping both

--- a/packages/widgetbook_generator/lib/src/core/extensions.dart
+++ b/packages/widgetbook_generator/lib/src/core/extensions.dart
@@ -78,13 +78,14 @@ extension DartTypeX on DartType {
   TypeReference getRef({
     String? suffix,
     bool isNullable = false,
+    Set<Reference>? types,
   }) {
     return TypeReference(
       (b) => b
         ..isNullable = isNullable
         ..symbol = suffix == null ? nonGenericName : '$nonGenericName$suffix'
         ..types.addAll(
-          getTypeParams(withBounds: false),
+          types ?? getTypeParams(withBounds: false),
         ),
     );
   }

--- a/packages/widgetbook_generator/lib/src/core/extensions.dart
+++ b/packages/widgetbook_generator/lib/src/core/extensions.dart
@@ -49,6 +49,46 @@ extension DartTypeX on DartType {
     ),
   };
 
+  /// Gets class name without generic parameters
+  /// Can only be used on classes.
+  String get nonGenericName {
+    return element!.displayName;
+  }
+
+  List<Reference> getTypeParams({
+    bool withBounds = true,
+  }) {
+    if (this is ParameterizedType)
+      return element!.children
+          .whereType<TypeParameterElement>()
+          .map(
+            (e) => TypeReference(
+              (b) => b
+                ..symbol = e.name
+                ..bound = withBounds && e.bound != null
+                    ? refer(e.bound!.nonGenericName)
+                    : null,
+            ),
+          )
+          .toList();
+    else
+      return <TypeReference>[];
+  }
+
+  TypeReference getRef({
+    String? suffix,
+    bool isNullable = false,
+  }) {
+    return TypeReference(
+      (b) => b
+        ..isNullable = isNullable
+        ..symbol = suffix == null ? nonGenericName : '$nonGenericName$suffix'
+        ..types.addAll(
+          getTypeParams(withBounds: false),
+        ),
+    );
+  }
+
   String get nonNullableName {
     // We get the display string with nullability then we remove the trailing
     // "?" if it exists, to avoid this issue with function and generic types:

--- a/packages/widgetbook_generator/lib/src/core/extensions.dart
+++ b/packages/widgetbook_generator/lib/src/core/extensions.dart
@@ -55,24 +55,22 @@ extension DartTypeX on DartType {
     return element!.displayName;
   }
 
-  List<Reference> getTypeParams({
+  Iterable<Reference> getTypeParams({
     bool withBounds = true,
   }) {
-    if (this is ParameterizedType)
-      return element!.children
-          .whereType<TypeParameterElement>()
-          .map(
-            (e) => TypeReference(
-              (b) => b
-                ..symbol = e.name
-                ..bound = withBounds && e.bound != null
-                    ? refer(e.bound!.nonGenericName)
-                    : null,
-            ),
-          )
-          .toList();
-    else
-      return <TypeReference>[];
+    if (this is! ParameterizedType) return [];
+
+    return element!.children //
+        .whereType<TypeParameterElement>()
+        .map(
+          (typeElement) => TypeReference(
+            (b) => b
+              ..symbol = typeElement.name
+              ..bound = withBounds && typeElement.bound != null
+                  ? refer(typeElement.bound!.nonGenericName)
+                  : null,
+          ),
+        );
   }
 
   TypeReference getRef({

--- a/packages/widgetbook_generator/lib/src/core/scenario_typedef_builder.dart
+++ b/packages/widgetbook_generator/lib/src/core/scenario_typedef_builder.dart
@@ -10,15 +10,20 @@ class ScenarioTypedefBuilder {
   final DartType argsType;
 
   TypeDef build() {
+    final widgetTypeRef = widgetType.getRef();
+    final argsTypeRef = argsType.getRef(suffix: 'Args');
+    final scenarioTypeRef = widgetType.getRef(suffix: 'Scenario');
+
     return TypeDef(
       (b) => b
-        ..name = '${widgetType.nonNullableName}Scenario'
+        ..name = scenarioTypeRef.symbol
+        ..types.addAll(widgetType.getTypeParams())
         ..definition = TypeReference(
           (b) => b
             ..symbol = 'Scenario'
             ..types.addAll([
-              refer(widgetType.nonNullableName),
-              refer('${argsType.nonNullableName}Args'),
+              widgetTypeRef,
+              argsTypeRef,
             ]),
         ),
     );

--- a/packages/widgetbook_generator/lib/src/core/scenario_typedef_builder.dart
+++ b/packages/widgetbook_generator/lib/src/core/scenario_typedef_builder.dart
@@ -17,14 +17,17 @@ class ScenarioTypedefBuilder {
   }
 
   TypeDef build() {
+    final unboundedTypeParams = getTypeParams(withBounds: false);
     final widgetTypeRef = widgetType.getRef();
+
     final scenarioTypeRef = widgetType.getRef(
       suffix: 'Scenario',
-      types: getTypeParams(withBounds: false),
+      types: unboundedTypeParams,
     );
+
     final argsTypeRef = argsType.getRef(
       suffix: 'Args',
-      types: getTypeParams(withBounds: false),
+      types: unboundedTypeParams,
     );
 
     return TypeDef(

--- a/packages/widgetbook_generator/lib/src/core/scenario_typedef_builder.dart
+++ b/packages/widgetbook_generator/lib/src/core/scenario_typedef_builder.dart
@@ -9,15 +9,28 @@ class ScenarioTypedefBuilder {
   final DartType widgetType;
   final DartType argsType;
 
+  Set<Reference> getTypeParams({bool withBounds = true}) {
+    return {
+      ...widgetType.getTypeParams(withBounds: withBounds),
+      ...argsType.getTypeParams(withBounds: withBounds),
+    };
+  }
+
   TypeDef build() {
     final widgetTypeRef = widgetType.getRef();
-    final argsTypeRef = argsType.getRef(suffix: 'Args');
-    final scenarioTypeRef = widgetType.getRef(suffix: 'Scenario');
+    final scenarioTypeRef = widgetType.getRef(
+      suffix: 'Scenario',
+      types: getTypeParams(withBounds: false),
+    );
+    final argsTypeRef = argsType.getRef(
+      suffix: 'Args',
+      types: getTypeParams(withBounds: false),
+    );
 
     return TypeDef(
       (b) => b
         ..name = scenarioTypeRef.symbol
-        ..types.addAll(widgetType.getTypeParams())
+        ..types.addAll(getTypeParams())
         ..definition = TypeReference(
           (b) => b
             ..symbol = 'Scenario'

--- a/packages/widgetbook_generator/lib/src/core/story_class_builder.dart
+++ b/packages/widgetbook_generator/lib/src/core/story_class_builder.dart
@@ -22,22 +22,39 @@ class StoryClassBuilder {
     return (argsType.element as ClassElement).constructors.first.parameters;
   }
 
+  Set<Reference> getTypeParams({bool withBounds = true}) {
+    return {
+      ...widgetType.getTypeParams(withBounds: withBounds),
+      ...argsType.getTypeParams(withBounds: withBounds),
+    };
+  }
+
   Class build() {
     final isCustomArgs = widgetType != argsType;
     final hasRequiredArgs = params.any((param) => param.requiresArg);
 
     final widgetClassRef = widgetType.getRef();
-    final storyClassRef = widgetType.getRef(suffix: 'Story');
-    final argsClassRef = argsType.getRef(suffix: 'Args');
+
+    final storyClassRef = widgetType.getRef(
+      suffix: 'Story',
+      types: getTypeParams(withBounds: false),
+    );
+
+    final argsClassRef = argsType.getRef(
+      suffix: 'Args',
+      types: getTypeParams(withBounds: false),
+    );
+
     final nullableArgsClassRef = argsType.getRef(
       suffix: 'Args',
+      types: getTypeParams(withBounds: false),
       isNullable: true,
     );
 
     return Class(
       (b) => b
         ..name = storyClassRef.symbol
-        ..types.addAll(widgetType.getTypeParams())
+        ..types.addAll(getTypeParams())
         ..extend = TypeReference(
           (b) => b
             ..symbol = 'Story'

--- a/packages/widgetbook_generator/lib/src/core/story_class_builder.dart
+++ b/packages/widgetbook_generator/lib/src/core/story_class_builder.dart
@@ -32,22 +32,23 @@ class StoryClassBuilder {
   Class build() {
     final isCustomArgs = widgetType != argsType;
     final hasRequiredArgs = params.any((param) => param.requiresArg);
+    final unboundedTypeParams = getTypeParams(withBounds: false);
 
     final widgetClassRef = widgetType.getRef();
 
     final storyClassRef = widgetType.getRef(
       suffix: 'Story',
-      types: getTypeParams(withBounds: false),
+      types: unboundedTypeParams,
     );
 
     final argsClassRef = argsType.getRef(
       suffix: 'Args',
-      types: getTypeParams(withBounds: false),
+      types: unboundedTypeParams,
     );
 
     final nullableArgsClassRef = argsType.getRef(
       suffix: 'Args',
-      types: getTypeParams(withBounds: false),
+      types: unboundedTypeParams,
       isNullable: true,
     );
 

--- a/sandbox/lib/[sam]/generic_num.dart
+++ b/sandbox/lib/[sam]/generic_num.dart
@@ -1,0 +1,8 @@
+import 'generic_text.dart';
+
+class GenericNum<T extends num> extends GenericText<T> {
+  GenericNum({
+    super.key,
+    required super.value,
+  });
+}

--- a/sandbox/lib/[sam]/generic_num.stories.dart
+++ b/sandbox/lib/[sam]/generic_num.stories.dart
@@ -30,16 +30,16 @@ GenericNum<T> $argsBuilder<T extends num, R>(
 
 final $Integer = GenericNumStory<int, String>(
   argsBuilder: $argsBuilder,
-  args: GenericNumInputArgs(
-    number: Arg.fixed(0),
-    other: Arg.fixed('other'),
+  args: GenericNumInputArgs.fixed(
+    number: 0,
+    other: 'foo',
   ),
 );
 
 final $Double = GenericNumStory<double, Color>(
   argsBuilder: $argsBuilder,
-  args: GenericNumInputArgs(
-    number: Arg.fixed(0.0),
-    other: Arg.fixed(Colors.black),
+  args: GenericNumInputArgs.fixed(
+    number: 0.0,
+    other: Colors.black,
   ),
 );

--- a/sandbox/lib/[sam]/generic_num.stories.dart
+++ b/sandbox/lib/[sam]/generic_num.stories.dart
@@ -1,40 +1,45 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:widgetbook/widgetbook.dart';
 
 import 'generic_num.dart';
 
 part 'generic_num.stories.book.dart';
 
+// ignore: strict_raw_type
 final meta = MetaWithArgs<GenericNum, GenericNumInput>();
 
-class GenericNumInput<T extends num> {
+class GenericNumInput<T extends num, R> {
   const GenericNumInput({
     required this.number,
+    required this.other,
   });
 
   final T number;
+  final R other;
 }
 
 // TODO: support global argsBuilder/setup for generic types
-GenericNum<T> $argsBuilder<T extends num>(
+GenericNum<T> $argsBuilder<T extends num, R>(
   BuildContext context,
-  GenericNumInputArgs<T> args,
+  GenericNumInputArgs<T, R> args,
 ) {
-  return GenericNum(
+  return GenericNum<T>(
     value: args.number.resolve(context),
   );
 }
 
-final $Integer = GenericNumStory<int>(
+final $Integer = GenericNumStory<int, String>(
   argsBuilder: $argsBuilder,
   args: GenericNumInputArgs(
     number: Arg.fixed(0),
+    other: Arg.fixed('other'),
   ),
 );
 
-final $Double = GenericNumStory<double>(
+final $Double = GenericNumStory<double, Color>(
   argsBuilder: $argsBuilder,
   args: GenericNumInputArgs(
     number: Arg.fixed(0.0),
+    other: Arg.fixed(Colors.black),
   ),
 );

--- a/sandbox/lib/[sam]/generic_num.stories.dart
+++ b/sandbox/lib/[sam]/generic_num.stories.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/widgets.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import 'generic_num.dart';
+
+part 'generic_num.stories.book.dart';
+
+final meta = MetaWithArgs<GenericNum, GenericNumInput>();
+
+class GenericNumInput<T extends num> {
+  const GenericNumInput({
+    required this.number,
+  });
+
+  final T number;
+}
+
+// TODO: support global argsBuilder/setup for generic types
+GenericNum<T> $argsBuilder<T extends num>(
+  BuildContext context,
+  GenericNumInputArgs<T> args,
+) {
+  return GenericNum(
+    value: args.number.resolve(context),
+  );
+}
+
+final $Integer = GenericNumStory<int>(
+  argsBuilder: $argsBuilder,
+  args: GenericNumInputArgs(
+    number: Arg.fixed(0),
+  ),
+);
+
+final $Double = GenericNumStory<double>(
+  argsBuilder: $argsBuilder,
+  args: GenericNumInputArgs(
+    number: Arg.fixed(0.0),
+  ),
+);

--- a/sandbox/lib/[sam]/generic_text.dart
+++ b/sandbox/lib/[sam]/generic_text.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class GenericText<T> extends StatelessWidget {
+  const GenericText({
+    super.key,
+    required this.value,
+  });
+
+  final T value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      '[$T] $value',
+    );
+  }
+}

--- a/sandbox/lib/[sam]/generic_text.stories.dart
+++ b/sandbox/lib/[sam]/generic_text.stories.dart
@@ -9,13 +9,13 @@ part 'generic_text.stories.book.dart';
 final meta = Meta<GenericText>();
 
 final $IntStory = GenericTextStory<int>(
-  args: GenericTextArgs(
-    value: Arg.fixed(0),
+  args: GenericTextArgs.fixed(
+    value: 0,
   ),
 );
 
 final $BoolStory = GenericTextStory<bool>(
-  args: GenericTextArgs(
-    value: Arg.fixed(false),
+  args: GenericTextArgs.fixed(
+    value: false,
   ),
 );

--- a/sandbox/lib/[sam]/generic_text.stories.dart
+++ b/sandbox/lib/[sam]/generic_text.stories.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/widgets.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import 'generic_text.dart';
+
+part 'generic_text.stories.book.dart';
+
+// ignore: strict_raw_type
+final meta = Meta<GenericText>();
+
+final $IntStory = GenericTextStory<int>(
+  args: GenericTextArgs(
+    value: Arg.fixed(0),
+  ),
+);
+
+final $BoolStory = GenericTextStory<bool>(
+  args: GenericTextArgs(
+    value: Arg.fixed(false),
+  ),
+);


### PR DESCRIPTION
Add support for generic widgets.

```dart
// generic_text.dart
class GenericText<T> extends StatelessWidget {
  const GenericText({
    super.key,
    required this.value,
  });

  final T value;

  @override
  Widget build(BuildContext context) {
    return Text(
      '[$T] $value',
    );
  }
}
```

```dart
// generic_text.stories.dart
final meta = Meta<GenericText>();

final $IntStory = GenericTextStory<int>(
  args: GenericTextArgs.fixed(
    value: 0,
  ),
);

final $BoolStory = GenericTextStory<bool>(
  args: GenericTextArgs.fixed(
    value: false,
  ),
);
```