### PR TITLE
feat(cli): add experimental `cloud` commands

### DIFF
--- a/packages/widgetbook_cli/lib/src/api/models/build_draft_request.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/build_draft_request.dart
@@ -7,8 +7,7 @@ class BuildDraftRequest {
     required this.repository,
     required this.actor,
     required this.branch,
-    required this.headSha,
-    this.baseSha,
+    required this.sha,
     required this.useCases,
   });
 
@@ -17,8 +16,7 @@ class BuildDraftRequest {
   final String repository;
   final String actor;
   final String branch;
-  final String headSha;
-  final String? baseSha;
+  final String sha;
   final List<UseCaseMetadata> useCases;
 
   Map<String, dynamic> toJson() {
@@ -28,8 +26,7 @@ class BuildDraftRequest {
       'repository': repository,
       'actor': actor,
       'branch': branch,
-      'headSha': headSha,
-      'baseSha': baseSha,
+      'sha': sha,
       'useCases': useCases.map((x) => x.toJson()).toList(),
     };
   }

--- a/packages/widgetbook_cli/lib/src/api/models/build_draft_request.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/build_draft_request.dart
@@ -1,0 +1,36 @@
+import '../../models/models.dart';
+
+class BuildDraftRequest {
+  const BuildDraftRequest({
+    required this.apiKey,
+    required this.versionControlProvider,
+    required this.repository,
+    required this.actor,
+    required this.branch,
+    required this.headSha,
+    this.baseSha,
+    required this.useCases,
+  });
+
+  final String apiKey;
+  final String versionControlProvider;
+  final String repository;
+  final String actor;
+  final String branch;
+  final String headSha;
+  final String? baseSha;
+  final List<UseCaseMetadata> useCases;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'apiKey': apiKey,
+      'versionControlProvider': versionControlProvider,
+      'repository': repository,
+      'actor': actor,
+      'branch': branch,
+      'headSha': headSha,
+      'baseSha': baseSha,
+      'useCases': useCases.map((x) => x.toJson()).toList(),
+    };
+  }
+}

--- a/packages/widgetbook_cli/lib/src/api/models/build_draft_response.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/build_draft_response.dart
@@ -1,0 +1,17 @@
+class BuildDraftResponse {
+  const BuildDraftResponse({
+    required this.buildId,
+    required this.storageUrl,
+  });
+
+  final String buildId;
+  final String storageUrl;
+
+  // ignore: sort_constructors_first
+  factory BuildDraftResponse.fromJson(Map<String, dynamic> json) {
+    return BuildDraftResponse(
+      buildId: json['buildId'] as String,
+      storageUrl: json['storageUrl'] as String,
+    );
+  }
+}

--- a/packages/widgetbook_cli/lib/src/api/models/build_ready_request.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/build_ready_request.dart
@@ -1,0 +1,16 @@
+class BuildReadyRequest {
+  const BuildReadyRequest({
+    required this.apiKey,
+    required this.buildId,
+  });
+
+  final String apiKey;
+  final String buildId;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'apiKey': apiKey,
+      'buildId': buildId,
+    };
+  }
+}

--- a/packages/widgetbook_cli/lib/src/api/models/build_ready_response.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/build_ready_response.dart
@@ -1,0 +1,17 @@
+class BuildReadyResponse {
+  const BuildReadyResponse({
+    required this.buildId,
+    required this.buildUrl,
+  });
+
+  final String buildId;
+  final String buildUrl;
+
+  // ignore: sort_constructors_first
+  factory BuildReadyResponse.fromJson(Map<String, dynamic> json) {
+    return BuildReadyResponse(
+      buildId: json['buildId'] as String,
+      buildUrl: json['buildUrl'] as String,
+    );
+  }
+}

--- a/packages/widgetbook_cli/lib/src/api/models/review_request.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/review_request.dart
@@ -4,7 +4,7 @@ class ReviewRequest extends ReviewRequestNext {
   const ReviewRequest({
     required super.apiKey,
     required super.buildId,
-    required super.projectId,
+    required this.projectId,
     required super.baseBranch,
     required super.headBranch,
     required super.baseSha,
@@ -12,12 +12,14 @@ class ReviewRequest extends ReviewRequestNext {
     required this.useCases,
   });
 
+  final String projectId;
   final List<ChangedUseCase> useCases;
 
   @override
   Map<String, dynamic> toJson() {
     return {
       ...super.toJson(),
+      'projectId': projectId,
       'useCases': useCases.map((e) => e.toJson()).toList(),
     };
   }
@@ -27,7 +29,6 @@ class ReviewRequestNext {
   const ReviewRequestNext({
     required this.apiKey,
     required this.buildId,
-    required this.projectId,
     required this.baseBranch,
     required this.headBranch,
     required this.baseSha,
@@ -36,7 +37,6 @@ class ReviewRequestNext {
 
   final String apiKey;
   final String buildId;
-  final String projectId;
   final String baseBranch;
   final String headBranch;
   final String baseSha;
@@ -46,7 +46,6 @@ class ReviewRequestNext {
     return {
       'apiKey': apiKey,
       'buildId': buildId,
-      'projectId': projectId,
       'baseBranch': baseBranch,
       'headBranch': headBranch,
       'baseSha': baseSha,

--- a/packages/widgetbook_cli/lib/src/api/models/review_request.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/review_request.dart
@@ -1,9 +1,9 @@
 import '../../models/changed_use_case.dart';
 
-class ReviewRequest extends ReviewRequestNext {
+class ReviewRequest extends ReviewSyncRequest {
   const ReviewRequest({
     required super.apiKey,
-    required super.buildId,
+    required this.buildId,
     required this.projectId,
     required super.baseBranch,
     required super.headBranch,
@@ -12,6 +12,7 @@ class ReviewRequest extends ReviewRequestNext {
     required this.useCases,
   });
 
+  final String buildId;
   final String projectId;
   final List<ChangedUseCase> useCases;
 
@@ -19,16 +20,16 @@ class ReviewRequest extends ReviewRequestNext {
   Map<String, dynamic> toJson() {
     return {
       ...super.toJson(),
+      'buildId': buildId,
       'projectId': projectId,
       'useCases': useCases.map((e) => e.toJson()).toList(),
     };
   }
 }
 
-class ReviewRequestNext {
-  const ReviewRequestNext({
+class ReviewSyncRequest {
+  const ReviewSyncRequest({
     required this.apiKey,
-    required this.buildId,
     required this.baseBranch,
     required this.headBranch,
     required this.baseSha,
@@ -36,7 +37,6 @@ class ReviewRequestNext {
   });
 
   final String apiKey;
-  final String buildId;
   final String baseBranch;
   final String headBranch;
   final String baseSha;
@@ -45,7 +45,6 @@ class ReviewRequestNext {
   Map<String, dynamic> toJson() {
     return {
       'apiKey': apiKey,
-      'buildId': buildId,
       'baseBranch': baseBranch,
       'headBranch': headBranch,
       'baseSha': baseSha,

--- a/packages/widgetbook_cli/lib/src/api/models/review_request.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/review_request.dart
@@ -1,9 +1,31 @@
 import '../../models/changed_use_case.dart';
 
-class ReviewRequest {
+class ReviewRequest extends ReviewRequestNext {
   const ReviewRequest({
-    required this.apiKey,
+    required super.apiKey,
+    required super.buildId,
+    required super.projectId,
+    required super.baseBranch,
+    required super.headBranch,
+    required super.baseSha,
+    required super.headSha,
     required this.useCases,
+  });
+
+  final List<ChangedUseCase> useCases;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      ...super.toJson(),
+      'useCases': useCases.map((e) => e.toJson()).toList(),
+    };
+  }
+}
+
+class ReviewRequestNext {
+  const ReviewRequestNext({
+    required this.apiKey,
     required this.buildId,
     required this.projectId,
     required this.baseBranch,
@@ -13,7 +35,6 @@ class ReviewRequest {
   });
 
   final String apiKey;
-  final List<ChangedUseCase> useCases;
   final String buildId;
   final String projectId;
   final String baseBranch;
@@ -22,9 +43,8 @@ class ReviewRequest {
   final String headSha;
 
   Map<String, dynamic> toJson() {
-    return <String, dynamic>{
+    return {
       'apiKey': apiKey,
-      'useCases': useCases.map((x) => x.toJson()).toList(),
       'buildId': buildId,
       'projectId': projectId,
       'baseBranch': baseBranch,

--- a/packages/widgetbook_cli/lib/src/api/models/review_response.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/review_response.dart
@@ -3,20 +3,17 @@ import 'upload_task.dart';
 class Review {
   const Review({
     required this.id,
+    required this.projectId,
   });
 
   final String id;
-
-  Map<String, dynamic> toJson() {
-    return <String, dynamic>{
-      'id': id,
-    };
-  }
+  final String projectId;
 
   // ignore: sort_constructors_first
   factory Review.fromJson(Map<String, dynamic> map) {
     return Review(
       id: map['id'] as String,
+      projectId: map['projectId'] as String,
     );
   }
 }

--- a/packages/widgetbook_cli/lib/src/api/models/review_response.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/review_response.dart
@@ -39,3 +39,18 @@ class ReviewResponse {
     );
   }
 }
+
+class ReviewSyncResponse {
+  const ReviewSyncResponse({
+    required this.reviewId,
+  });
+
+  final String reviewId;
+
+  // ignore: sort_constructors_first
+  factory ReviewSyncResponse.fromJson(Map<String, dynamic> map) {
+    return ReviewSyncResponse(
+      reviewId: map['reviewId'] as String,
+    );
+  }
+}

--- a/packages/widgetbook_cli/lib/src/api/widgetbook_http_client.dart
+++ b/packages/widgetbook_cli/lib/src/api/widgetbook_http_client.dart
@@ -64,16 +64,12 @@ class WidgetbookHttpClient {
 
   /// Sends review data to the Widgetbook Cloud backend.
   Future<ReviewSyncResponse> syncReview(
-    VersionsMetadata? versions,
     ReviewSyncRequest request,
   ) async {
     try {
       final response = await client.post<Map<String, dynamic>>(
         'v1.5/reviews',
         data: request.toJson(),
-        options: Options(
-          headers: versions?.toHeaders(),
-        ),
       );
 
       return ReviewSyncResponse.fromJson(response.data!);

--- a/packages/widgetbook_cli/lib/src/api/widgetbook_http_client.dart
+++ b/packages/widgetbook_cli/lib/src/api/widgetbook_http_client.dart
@@ -63,9 +63,9 @@ class WidgetbookHttpClient {
   }
 
   /// Sends review data to the Widgetbook Cloud backend.
-  Future<ReviewResponse> syncReview(
+  Future<ReviewSyncResponse> syncReview(
     VersionsMetadata? versions,
-    ReviewRequestNext request,
+    ReviewSyncRequest request,
   ) async {
     try {
       final response = await client.post<Map<String, dynamic>>(
@@ -76,7 +76,7 @@ class WidgetbookHttpClient {
         ),
       );
 
-      return ReviewResponse.fromJson(response.data!);
+      return ReviewSyncResponse.fromJson(response.data!);
     } catch (e) {
       final message = e is DioException //
           ? e.response?.toString()

--- a/packages/widgetbook_cli/lib/src/api/widgetbook_http_client.dart
+++ b/packages/widgetbook_cli/lib/src/api/widgetbook_http_client.dart
@@ -1,7 +1,14 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
+import 'package:file/file.dart';
 
 import '../core/core.dart';
 import '../utils/utils.dart';
+import 'models/build_draft_request.dart';
+import 'models/build_draft_response.dart';
+import 'models/build_ready_request.dart';
+import 'models/build_ready_response.dart';
 import 'models/build_request.dart';
 import 'models/build_response.dart';
 import 'models/review_request.dart';
@@ -63,7 +70,7 @@ class WidgetbookHttpClient {
     try {
       final formData = await request.toFormData();
       final response = await client.post<Map<String, dynamic>>(
-        '/builds/deploy',
+        'v1/builds/deploy',
         data: formData,
         options: Options(
           headers: versions?.toHeaders(),
@@ -80,5 +87,65 @@ class WidgetbookHttpClient {
         message: message,
       );
     }
+  }
+
+  Future<BuildDraftResponse> createBuildDraft(
+    VersionsMetadata? versions,
+    BuildDraftRequest request,
+  ) async {
+    try {
+      final response = await client.post<Map<String, dynamic>>(
+        'v1.5/builds/draft',
+        data: request.toJson(),
+        options: Options(
+          headers: versions?.toHeaders(),
+        ),
+      );
+
+      return BuildDraftResponse.fromJson(response.data!);
+    } catch (e) {
+      final message = e is DioException //
+          ? e.response?.toString()
+          : e.toString();
+
+      throw WidgetbookApiException(
+        message: message,
+      );
+    }
+  }
+
+  Future<BuildReadyResponse> submitBuildDraft(
+    BuildReadyRequest request,
+  ) async {
+    try {
+      final response = await client.post<Map<String, dynamic>>(
+        'v1.5/builds/submit',
+        data: request.toJson(),
+      );
+
+      return BuildReadyResponse.fromJson(response.data!);
+    } catch (e) {
+      final message = e is DioException //
+          ? e.response?.toString()
+          : e.toString();
+
+      throw WidgetbookApiException(
+        message: message,
+      );
+    }
+  }
+
+  Future<void> uploadBuildFile(String signedUrl, File zipFile) {
+    // File name must match the name in the signed URL
+    return client.put<void>(
+      signedUrl,
+      data: zipFile.openRead(),
+      options: Options(
+        headers: {
+          HttpHeaders.contentTypeHeader: 'application/zip',
+          HttpHeaders.contentLengthHeader: zipFile.lengthSync(),
+        },
+      ),
+    );
   }
 }

--- a/packages/widgetbook_cli/lib/src/api/widgetbook_http_client.dart
+++ b/packages/widgetbook_cli/lib/src/api/widgetbook_http_client.dart
@@ -43,7 +43,33 @@ class WidgetbookHttpClient {
 
     try {
       final response = await client.post<Map<String, dynamic>>(
-        '/reviews',
+        'v1/reviews',
+        data: request.toJson(),
+        options: Options(
+          headers: versions?.toHeaders(),
+        ),
+      );
+
+      return ReviewResponse.fromJson(response.data!);
+    } catch (e) {
+      final message = e is DioException //
+          ? e.response?.toString()
+          : e.toString();
+
+      throw WidgetbookApiException(
+        message: message,
+      );
+    }
+  }
+
+  /// Sends review data to the Widgetbook Cloud backend.
+  Future<ReviewResponse> syncReview(
+    VersionsMetadata? versions,
+    ReviewRequestNext request,
+  ) async {
+    try {
+      final response = await client.post<Map<String, dynamic>>(
+        'v1.5/reviews',
         data: request.toJson(),
         options: Options(
           headers: versions?.toHeaders(),

--- a/packages/widgetbook_cli/lib/src/commands/build_push.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push.dart
@@ -143,8 +143,18 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
     final archiveProgress = logger.progress('Creating build archive');
     final buildDirPath = p.join(args.path, 'build', 'web');
     final buildDir = fileSystem.directory(buildDirPath);
-    final zipFile = await zipEncoder.zip(buildDir, '$buildId.zip');
 
+    if (!buildDir.existsSync()) {
+      archiveProgress.fail();
+      logger.err(
+        'build/web directory does not exist.\n'
+        'Run the following command before publishing:\n\n\t'
+        'flutter build web --target path/to/widgetbook.dart\n\n',
+      );
+      return 22;
+    }
+
+    final zipFile = await zipEncoder.zip(buildDir, '$buildId.zip');
     if (zipFile == null) {
       archiveProgress.fail('Failed to create build archive');
       return 23;

--- a/packages/widgetbook_cli/lib/src/commands/build_push.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push.dart
@@ -25,7 +25,7 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
           environment: context.environment,
         ),
         super(
-          name: 'build push',
+          name: 'push',
           description: 'Pushes a new build to Widgetbook Cloud',
         ) {
     argParser
@@ -42,6 +42,11 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
       ..addOption(
         'branch',
         help: 'The name of the branch for which the Widgetbook is uploaded.',
+      )
+      ..addOption(
+        'repository',
+        help:
+            'The name of the repository for which the Widgetbook is uploaded.',
       )
       ..addOption(
         'commit',

--- a/packages/widgetbook_cli/lib/src/commands/build_push.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push.dart
@@ -10,10 +10,10 @@ import '../../widgetbook_cli.dart';
 import '../api/models/build_draft_request.dart';
 import '../api/models/build_ready_request.dart';
 import '../utils/executable_manager.dart';
-import 'push_args.dart';
+import 'build_push_args.dart';
 
-class PushCommand extends CliCommand<PushArgs> {
-  PushCommand({
+class BuildPushCommand extends CliCommand<BuildPushArgs> {
+  BuildPushCommand({
     required super.context,
     this.processManager = const LocalProcessManager(),
     this.fileSystem = const LocalFileSystem(),
@@ -63,7 +63,8 @@ class PushCommand extends CliCommand<PushArgs> {
   final UseCaseReader useCaseReader;
 
   @override
-  FutureOr<PushArgs> parseResults(Context context, ArgResults results) async {
+  FutureOr<BuildPushArgs> parseResults(
+      Context context, ArgResults results) async {
     final path = results['path'] as String;
     final apiKey = results['api-key'] as String;
 
@@ -92,7 +93,7 @@ class PushCommand extends CliCommand<PushArgs> {
       throw RepositoryNotFoundException();
     }
 
-    return PushArgs(
+    return BuildPushArgs(
       apiKey: apiKey,
       branch: branch,
       commit: commit,
@@ -105,7 +106,7 @@ class PushCommand extends CliCommand<PushArgs> {
   }
 
   @override
-  FutureOr<int> runWith(Context context, PushArgs args) async {
+  FutureOr<int> runWith(Context context, BuildPushArgs args) async {
     final lockPath = p.join(args.path, 'pubspec.lock');
     final versions = await VersionsMetadata.from(
       lockFile: fileSystem.file(lockPath),

--- a/packages/widgetbook_cli/lib/src/commands/build_push.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push.dart
@@ -64,7 +64,9 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
 
   @override
   FutureOr<BuildPushArgs> parseResults(
-      Context context, ArgResults results) async {
+    Context context,
+    ArgResults results,
+  ) async {
     final path = results['path'] as String;
     final apiKey = results['api-key'] as String;
 

--- a/packages/widgetbook_cli/lib/src/commands/build_push.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push.dart
@@ -25,7 +25,7 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
           environment: context.environment,
         ),
         super(
-          name: 'push',
+          name: 'build push',
           description: 'Pushes a new build to Widgetbook Cloud',
         ) {
     argParser
@@ -53,7 +53,7 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
         help: 'The username of the actor which triggered the build.',
       )
       ..addOption(
-        '--sync-reviews-of',
+        'sync-reviews-of',
         help: 'The base branch of the pull-request. For example, main.',
       );
   }

--- a/packages/widgetbook_cli/lib/src/commands/build_push_args.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push_args.dart
@@ -1,5 +1,3 @@
-import '../git/git.dart';
-
 /// Typed representation of the arguments passed to the push command.
 class BuildPushArgs {
   const BuildPushArgs({
@@ -10,7 +8,6 @@ class BuildPushArgs {
     required this.vendor,
     required this.actor,
     required this.repository,
-    this.baseBranch,
   });
 
   final String apiKey;
@@ -20,7 +17,4 @@ class BuildPushArgs {
   final String vendor;
   final String actor;
   final String repository;
-
-  // TODO: remove when API endpoint no longer needs this
-  final Reference? baseBranch;
 }

--- a/packages/widgetbook_cli/lib/src/commands/build_push_args.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push_args.dart
@@ -1,8 +1,8 @@
 import '../git/git.dart';
 
 /// Typed representation of the arguments passed to the push command.
-class PushArgs {
-  const PushArgs({
+class BuildPushArgs {
+  const BuildPushArgs({
     required this.apiKey,
     required this.branch,
     required this.commit,
@@ -25,7 +25,7 @@ class PushArgs {
   final Reference? baseBranch;
 
   @override
-  bool operator ==(covariant PushArgs other) {
+  bool operator ==(covariant BuildPushArgs other) {
     if (identical(this, other)) return true;
 
     return other.apiKey == apiKey &&

--- a/packages/widgetbook_cli/lib/src/commands/build_push_args.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push_args.dart
@@ -23,30 +23,4 @@ class BuildPushArgs {
 
   // TODO: remove when API endpoint no longer needs this
   final Reference? baseBranch;
-
-  @override
-  bool operator ==(covariant BuildPushArgs other) {
-    if (identical(this, other)) return true;
-
-    return other.apiKey == apiKey &&
-        other.branch == branch &&
-        other.commit == commit &&
-        other.path == path &&
-        other.vendor == vendor &&
-        other.actor == actor &&
-        other.repository == repository &&
-        other.baseBranch == baseBranch;
-  }
-
-  @override
-  int get hashCode {
-    return apiKey.hashCode ^
-        branch.hashCode ^
-        commit.hashCode ^
-        path.hashCode ^
-        vendor.hashCode ^
-        actor.hashCode ^
-        repository.hashCode ^
-        baseBranch.hashCode;
-  }
 }

--- a/packages/widgetbook_cli/lib/src/commands/cloud.dart
+++ b/packages/widgetbook_cli/lib/src/commands/cloud.dart
@@ -1,32 +1,43 @@
-import 'package:args/command_runner.dart';
+import 'dart:async';
+
+import 'package:args/src/arg_results.dart';
 
 import '../core/core.dart';
 import 'build_push.dart';
 import 'review_sync.dart';
 
-class CloudCommand extends Command<int> {
+class CloudCommand extends CliVoidCommand {
   CloudCommand({
-    required Context context,
-  }) {
+    required super.context,
+  }) : super(
+          name: 'cloud',
+          description: 'Manage your Widgetbook Cloud projects.',
+        ) {
     addSubcommand(
-      BuildPushCommand(
-        context: context,
+      CliCommandsGroup(
+        name: 'build',
+        description: 'Manage your Widgetbook Cloud builds.',
+        commands: [
+          BuildPushCommand(
+            context: context,
+          ),
+        ],
       ),
     );
 
     addSubcommand(
-      ReviewSyncCommand(
-        context: context,
+      CliCommandsGroup(
+        name: 'review',
+        description: 'Manage your Widgetbook Cloud reviews.',
+        commands: [
+          ReviewSyncCommand(
+            context: context,
+          ),
+        ],
       ),
     );
   }
 
   @override
-  final String name = 'cloud';
-
-  @override
-  final String description = 'Manage your Widgetbook Cloud projects.';
-
-  @override
-  Future<int> run() async => 0;
+  FutureOr<int> runWith(Context context, ArgResults args) => 0;
 }

--- a/packages/widgetbook_cli/lib/src/commands/cloud.dart
+++ b/packages/widgetbook_cli/lib/src/commands/cloud.dart
@@ -1,0 +1,25 @@
+import 'package:args/command_runner.dart';
+
+import '../core/core.dart';
+import 'push.dart';
+
+class CloudCommand extends Command<int> {
+  CloudCommand({
+    required Context context,
+  }) {
+    addSubcommand(
+      PushCommand(
+        context: context,
+      ),
+    );
+  }
+
+  @override
+  final String name = 'cloud';
+
+  @override
+  final String description = 'Manage your Widgetbook Cloud projects.';
+
+  @override
+  Future<int> run() async => 0;
+}

--- a/packages/widgetbook_cli/lib/src/commands/cloud.dart
+++ b/packages/widgetbook_cli/lib/src/commands/cloud.dart
@@ -1,14 +1,14 @@
 import 'package:args/command_runner.dart';
 
 import '../core/core.dart';
-import 'push.dart';
+import 'build_push.dart';
 
 class CloudCommand extends Command<int> {
   CloudCommand({
     required Context context,
   }) {
     addSubcommand(
-      PushCommand(
+      BuildPushCommand(
         context: context,
       ),
     );

--- a/packages/widgetbook_cli/lib/src/commands/cloud.dart
+++ b/packages/widgetbook_cli/lib/src/commands/cloud.dart
@@ -2,6 +2,7 @@ import 'package:args/command_runner.dart';
 
 import '../core/core.dart';
 import 'build_push.dart';
+import 'review_sync.dart';
 
 class CloudCommand extends Command<int> {
   CloudCommand({
@@ -9,6 +10,12 @@ class CloudCommand extends Command<int> {
   }) {
     addSubcommand(
       BuildPushCommand(
+        context: context,
+      ),
+    );
+
+    addSubcommand(
+      ReviewSyncCommand(
         context: context,
       ),
     );

--- a/packages/widgetbook_cli/lib/src/commands/publish.dart
+++ b/packages/widgetbook_cli/lib/src/commands/publish.dart
@@ -34,7 +34,6 @@ class PublishCommand extends CliCommand<PublishArgs> {
           name: 'publish',
           description: 'Publish a new build',
         ) {
-    progress = logger.progress('Publishing Widgetbook');
     argParser
       ..addOption(
         'path',
@@ -76,7 +75,7 @@ class PublishCommand extends CliCommand<PublishArgs> {
   final ZipEncoder zipEncoder;
   final UseCaseReader useCaseReader;
   final WidgetbookHttpClient _client;
-  late final Progress progress;
+  late final Progress progress = logger.progress('Publishing Widgetbook');
 
   @override
   Future<PublishArgs> parseResults(Context context, ArgResults results) async {

--- a/packages/widgetbook_cli/lib/src/commands/publish.dart
+++ b/packages/widgetbook_cli/lib/src/commands/publish.dart
@@ -7,9 +7,7 @@ import 'package:file/local.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:process/process.dart';
-import 'package:yaml/yaml.dart';
 
-import '../../metadata.dart';
 import '../api/api.dart';
 import '../core/core.dart';
 import '../git/git.dart';
@@ -138,7 +136,12 @@ class PublishCommand extends CliCommand<PublishArgs> {
 
       progress.update('Getting versions');
 
-      final versions = await getVersions(args);
+      final lockPath = p.join(args.path, 'pubspec.lock');
+      final versions = await VersionsMetadata.from(
+        lockFile: fileSystem.file(lockPath),
+        flutterVersionOutput: await processManager.runFlutter(['--version']),
+      );
+
       logger.info('\nThe following versions are used: ');
       logger.info('  Flutter    : ${versions?.flutter ?? '-'}');
       logger.info('  Widgetbook : ${versions?.widgetbook ?? '-'}');
@@ -351,39 +354,5 @@ class PublishCommand extends CliCommand<PublishArgs> {
       '\n> Build: $buildUrl'
       "${reviewId != null ? '\n> Review: $reviewUrl' : ''}",
     );
-  }
-
-  /// Gets metadata about the currently used versions of Flutter and
-  /// all Widgetbook packages.
-  Future<VersionsMetadata?> getVersions(PublishArgs args) async {
-    try {
-      final lockPath = p.join(args.path, 'pubspec.lock');
-      final lockContent = await fileSystem.file(lockPath).readAsString();
-      final lockFile = loadYaml(lockContent) as YamlMap;
-      final packages = lockFile['packages'] as YamlMap;
-
-      return VersionsMetadata(
-        cli: packageVersion,
-        flutter: await getFlutterVersion(),
-        widgetbook: getPackageVersion(packages, 'widgetbook'),
-        annotation: getPackageVersion(packages, 'widgetbook_annotation'),
-        generator: getPackageVersion(packages, 'widgetbook_generator'),
-      );
-    } catch (_) {
-      return null;
-    }
-  }
-
-  Future<String?> getFlutterVersion() async {
-    final result = await processManager.runFlutter(['--version']);
-    final regex = RegExp(r'Flutter (\d+.\d+.\d+)');
-    final match = regex.firstMatch(result);
-
-    return match?.group(1);
-  }
-
-  String? getPackageVersion(YamlMap packages, String name) {
-    final package = packages[name] as YamlMap?;
-    return package?['version']?.toString();
   }
 }

--- a/packages/widgetbook_cli/lib/src/commands/publish.dart
+++ b/packages/widgetbook_cli/lib/src/commands/publish.dart
@@ -220,7 +220,7 @@ class PublishCommand extends CliCommand<PublishArgs> {
 
     progress.update('Generating zip');
     final encoder = zipEncoder;
-    final zipFile = await encoder.zip(buildDir);
+    final zipFile = await encoder.zip(buildDir, 'web.zip');
 
     if (zipFile == null) {
       logger.err('Could not create .zip file.');

--- a/packages/widgetbook_cli/lib/src/commands/push.dart
+++ b/packages/widgetbook_cli/lib/src/commands/push.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+
+import 'package:args/src/arg_results.dart';
+
+import 'package:file/file.dart';
+
+import 'package:file/local.dart';
+import 'package:path/path.dart' as p;
+import 'package:process/process.dart';
+import 'package:yaml/yaml.dart';
+
+import '../../widgetbook_cli.dart';
+import '../api/models/build_draft_request.dart';
+import '../api/models/build_ready_request.dart';
+import '../utils/executable_manager.dart';
+import 'push_args.dart';
+
+class PushCommand extends CliCommand<PushArgs> {
+  PushCommand({
+    required super.context,
+    this.processManager = const LocalProcessManager(),
+    this.fileSystem = const LocalFileSystem(),
+    this.zipEncoder = const ZipEncoder(),
+    this.useCaseReader = const UseCaseReader(),
+  })  : client = WidgetbookHttpClient(
+          environment: context.environment,
+        ),
+        super(
+          name: 'push',
+          description: 'Pushes a new build to Widgetbook Cloud',
+        ) {
+    argParser
+      ..addOption(
+        'api-key',
+        help: 'The project specific API key for Widgetbook Cloud.',
+        mandatory: true,
+      );
+  }
+
+  final WidgetbookHttpClient client;
+  final ProcessManager processManager;
+  final FileSystem fileSystem;
+  final ZipEncoder zipEncoder;
+  final UseCaseReader useCaseReader;
+
+  @override
+  FutureOr<PushArgs> parseResults(Context context, ArgResults results) {
+    return PushArgs(
+      apiKey: results['api-key'] as String,
+      versionControlProvider: 'github', // TODO
+      repository: 'widgetbook', // TODO
+      actor: 'widgetbook', // TODO
+      branch: 'main', // TODO
+      headSha: 'TODO', // TODO
+      baseSha: 'TODO', // TODO
+    );
+  }
+
+  @override
+  FutureOr<int> runWith(Context context, PushArgs args) async {
+    final versions = await getVersions(args);
+    final buildDraft = await client.createBuildDraft(
+      versions,
+      BuildDraftRequest(
+        apiKey: args.apiKey,
+        versionControlProvider: args.versionControlProvider,
+        repository: args.repository,
+        actor: args.actor,
+        branch: args.branch,
+        headSha: args.headSha,
+        baseSha: args.baseSha,
+        useCases: await useCaseReader.read('.'), // TODO: custom path
+      ),
+    );
+
+    final buildId = buildDraft.buildId;
+    final buildDirPath = p.join('build', 'web'); // TODO: custom path
+    final buildDir = fileSystem.directory(buildDirPath);
+
+    // Modify index.html
+    final indexFile = buildDir.childFile('index.html');
+    final indexContent = await indexFile.readAsString();
+    final regex = RegExp(r'<base href=".+" */?>');
+    final modifiedContent = indexContent.replaceAll(
+      regex,
+      '<base href="/${buildDraft.buildId}/">',
+    );
+
+    await indexFile.writeAsString(modifiedContent); // TODO: avoid overwriting
+
+    final zipFile = await zipEncoder.zip(buildDir, '$buildId.zip');
+    final signedUrl = buildDraft.storageUrl;
+
+    await client.uploadBuildFile(signedUrl, zipFile!); // TODO: handle null
+
+    print('Uploaded build $buildId to $signedUrl');
+
+    final response = await client.submitBuildDraft(
+      BuildReadyRequest(
+        apiKey: args.apiKey,
+        buildId: buildId,
+      ),
+    );
+
+    logger.info('Build $buildId is ready at ${response.buildUrl}');
+
+    return 0;
+  }
+
+  /// Gets metadata about the currently used versions of Flutter and
+  /// all Widgetbook packages.
+  Future<VersionsMetadata?> getVersions(PushArgs args) async {
+    try {
+      final lockPath = p.join('pubspec.lock'); // TODO: custom path
+      final lockContent = await fileSystem.file(lockPath).readAsString();
+      final lockFile = loadYaml(lockContent) as YamlMap;
+      final packages = lockFile['packages'] as YamlMap;
+
+      return VersionsMetadata(
+        cli: packageVersion,
+        flutter: await getFlutterVersion(),
+        widgetbook: getPackageVersion(packages, 'widgetbook'),
+        annotation: getPackageVersion(packages, 'widgetbook_annotation'),
+        generator: getPackageVersion(packages, 'widgetbook_generator'),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<String?> getFlutterVersion() async {
+    final result = await processManager.runFlutter(['--version']);
+    final regex = RegExp(r'Flutter (\d+.\d+.\d+)');
+    final match = regex.firstMatch(result);
+
+    return match?.group(1);
+  }
+
+  String? getPackageVersion(YamlMap packages, String name) {
+    final package = packages[name] as YamlMap?;
+    return package?['version']?.toString();
+  }
+}

--- a/packages/widgetbook_cli/lib/src/commands/push.dart
+++ b/packages/widgetbook_cli/lib/src/commands/push.dart
@@ -74,26 +74,13 @@ class PushCommand extends CliCommand<PushArgs> {
     );
 
     final buildId = buildDraft.buildId;
-    final buildDirPath = p.join('build', 'web'); // TODO: custom path
-    final buildDir = fileSystem.directory(buildDirPath);
-
-    // Modify index.html
-    final indexFile = buildDir.childFile('index.html');
-    final indexContent = await indexFile.readAsString();
-    final regex = RegExp(r'<base href=".+" */?>');
-    final modifiedContent = indexContent.replaceAll(
-      regex,
-      '<base href="/${buildDraft.buildId}/">',
-    );
-
-    await indexFile.writeAsString(modifiedContent); // TODO: avoid overwriting
-
-    final zipFile = await zipEncoder.zip(buildDir, '$buildId.zip');
     final signedUrl = buildDraft.storageUrl;
 
-    await client.uploadBuildFile(signedUrl, zipFile!); // TODO: handle null
+    final buildDirPath = p.join('build', 'web'); // TODO: custom path
+    final buildDir = fileSystem.directory(buildDirPath);
+    final zipFile = await zipEncoder.zip(buildDir, '$buildId.zip');
 
-    print('Uploaded build $buildId to $signedUrl');
+    await client.uploadBuildFile(signedUrl, zipFile!); // TODO: handle null
 
     final response = await client.submitBuildDraft(
       BuildReadyRequest(

--- a/packages/widgetbook_cli/lib/src/commands/push_args.dart
+++ b/packages/widgetbook_cli/lib/src/commands/push_args.dart
@@ -1,20 +1,52 @@
+import '../git/git.dart';
+
 /// Typed representation of the arguments passed to the push command.
 class PushArgs {
   const PushArgs({
     required this.apiKey,
-    required this.versionControlProvider,
-    required this.repository,
-    required this.actor,
     required this.branch,
-    required this.headSha,
-    this.baseSha,
+    required this.commit,
+    required this.path,
+    required this.vendor,
+    required this.actor,
+    required this.repository,
+    this.baseBranch,
   });
 
   final String apiKey;
-  final String versionControlProvider;
-  final String repository;
-  final String actor;
   final String branch;
-  final String headSha;
-  final String? baseSha;
+  final String commit;
+  final String path;
+  final String vendor;
+  final String actor;
+  final String repository;
+
+  // TODO: remove when API endpoint no longer needs this
+  final Reference? baseBranch;
+
+  @override
+  bool operator ==(covariant PushArgs other) {
+    if (identical(this, other)) return true;
+
+    return other.apiKey == apiKey &&
+        other.branch == branch &&
+        other.commit == commit &&
+        other.path == path &&
+        other.vendor == vendor &&
+        other.actor == actor &&
+        other.repository == repository &&
+        other.baseBranch == baseBranch;
+  }
+
+  @override
+  int get hashCode {
+    return apiKey.hashCode ^
+        branch.hashCode ^
+        commit.hashCode ^
+        path.hashCode ^
+        vendor.hashCode ^
+        actor.hashCode ^
+        repository.hashCode ^
+        baseBranch.hashCode;
+  }
 }

--- a/packages/widgetbook_cli/lib/src/commands/push_args.dart
+++ b/packages/widgetbook_cli/lib/src/commands/push_args.dart
@@ -1,0 +1,20 @@
+/// Typed representation of the arguments passed to the push command.
+class PushArgs {
+  const PushArgs({
+    required this.apiKey,
+    required this.versionControlProvider,
+    required this.repository,
+    required this.actor,
+    required this.branch,
+    required this.headSha,
+    this.baseSha,
+  });
+
+  final String apiKey;
+  final String versionControlProvider;
+  final String repository;
+  final String actor;
+  final String branch;
+  final String headSha;
+  final String? baseSha;
+}

--- a/packages/widgetbook_cli/lib/src/commands/review_sync.dart
+++ b/packages/widgetbook_cli/lib/src/commands/review_sync.dart
@@ -113,7 +113,17 @@ class ReviewSyncCommand extends CliCommand<ReviewSyncArgs> {
     );
 
     // TODO: get review URL from response
-    syncProgress.complete('Synced review [${response.review.id}]');
+    final reviewUrl = Uri.parse(
+      p.join(
+        context.environment.appUrl,
+        'projects/${response.review.projectId}',
+        'reviews/${response.review.id}',
+        'builds/${args.buildId}',
+        'use-cases',
+      ),
+    );
+
+    syncProgress.complete('Review ready at $reviewUrl');
 
     return 0;
   }

--- a/packages/widgetbook_cli/lib/src/commands/review_sync.dart
+++ b/packages/widgetbook_cli/lib/src/commands/review_sync.dart
@@ -29,6 +29,11 @@ class ReviewSyncCommand extends CliCommand<ReviewSyncArgs> {
         mandatory: true,
       )
       ..addOption(
+        'path',
+        help: 'The path to the build folder of your application.',
+        defaultsTo: './',
+      )
+      ..addOption(
         'head-branch',
         help: 'The head branch of the pull-request. For example, feat/foo.',
       )

--- a/packages/widgetbook_cli/lib/src/commands/review_sync.dart
+++ b/packages/widgetbook_cli/lib/src/commands/review_sync.dart
@@ -19,7 +19,7 @@ class ReviewSyncCommand extends CliCommand<ReviewSyncArgs> {
           environment: context.environment,
         ),
         super(
-          name: 'sync',
+          name: 'review sync',
           description: 'Syncs Widgetbook Cloud Review',
         ) {
     argParser

--- a/packages/widgetbook_cli/lib/src/commands/review_sync.dart
+++ b/packages/widgetbook_cli/lib/src/commands/review_sync.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'package:args/src/arg_results.dart';
+import 'package:file/file.dart';
+import 'package:file/local.dart';
+import 'package:path/path.dart' as p;
+import 'package:process/process.dart';
+
+import '../../widgetbook_cli.dart';
+import '../utils/executable_manager.dart';
+import 'review_sync_args.dart';
+
+class ReviewSyncCommand extends CliCommand<ReviewSyncArgs> {
+  ReviewSyncCommand({
+    required super.context,
+    this.processManager = const LocalProcessManager(),
+    this.fileSystem = const LocalFileSystem(),
+  })  : client = WidgetbookHttpClient(
+          environment: context.environment,
+        ),
+        super(
+          name: 'sync',
+          description: 'Syncs Widgetbook Cloud Review',
+        ) {
+    argParser
+      ..addOption(
+        'api-key',
+        help: 'The project specific API key for Widgetbook Cloud.',
+        mandatory: true,
+      )
+      ..addOption(
+        'build-id',
+        help: 'ID of the build to sync.',
+        mandatory: true,
+      )
+      ..addOption(
+        'head-branch',
+        help: 'The head branch of the pull-request. For example, feat/foo.',
+      )
+      ..addOption(
+        'base-branch',
+        help: 'The base branch of the pull-request. For example, main.',
+        mandatory: true,
+      )
+      ..addOption(
+        'head-sha',
+        help: 'The sha of head commit of the pull-request.',
+      )
+      ..addOption(
+        'base-sha',
+        help: 'The sha of base commit of the pull-request.',
+      );
+  }
+
+  final WidgetbookHttpClient client;
+  final ProcessManager processManager;
+  final FileSystem fileSystem;
+
+  @override
+  FutureOr<ReviewSyncArgs> parseResults(
+    Context context,
+    ArgResults results,
+  ) async {
+    final path = results['path'] as String;
+    final apiKey = results['api-key'] as String;
+    final buildId = results['build-id'] as String;
+
+    final repository = context.repository!;
+    final currentBranch = await repository.currentBranch;
+    final headBranch = results['head-branch'] as String? ?? currentBranch.name;
+    final headSha = results['head-sha'] as String? ??
+        context.providerSha ??
+        currentBranch.sha;
+
+    final baseBranch = results['base-branch'] as String;
+    final baseSha = results['base-sha'] as String? ??
+        (await repository.findBranch(
+          baseBranch,
+          remote: true,
+        ))
+            ?.sha;
+
+    return ReviewSyncArgs(
+      apiKey: apiKey,
+      path: path,
+      buildId: buildId,
+      headBranch: headBranch,
+      baseBranch: baseBranch,
+      headSha: headSha,
+      baseSha: baseSha!,
+    );
+  }
+
+  @override
+  FutureOr<int> runWith(Context context, ReviewSyncArgs args) async {
+    final lockPath = p.join(args.path, 'pubspec.lock');
+    final versions = await VersionsMetadata.from(
+      lockFile: fileSystem.file(lockPath),
+      flutterVersionOutput: await processManager.runFlutter(['--version']),
+    );
+
+    final syncProgress = logger.progress('Syncing review');
+    final response = await client.syncReview(
+      versions,
+      ReviewRequestNext(
+        apiKey: args.apiKey,
+        buildId: args.buildId,
+        baseBranch: args.baseBranch,
+        headBranch: args.headBranch,
+        baseSha: args.baseSha,
+        headSha: args.headSha,
+      ),
+    );
+
+    // TODO: get review URL from response
+    syncProgress.complete('Synced review [${response.review.id}]');
+
+    return 0;
+  }
+}

--- a/packages/widgetbook_cli/lib/src/commands/review_sync.dart
+++ b/packages/widgetbook_cli/lib/src/commands/review_sync.dart
@@ -29,11 +29,6 @@ class ReviewSyncCommand extends CliCommand<ReviewSyncArgs> {
         mandatory: true,
       )
       ..addOption(
-        'build-id',
-        help: 'ID of the build to sync.',
-        mandatory: true,
-      )
-      ..addOption(
         'head-branch',
         help: 'The head branch of the pull-request. For example, feat/foo.',
       )
@@ -63,7 +58,6 @@ class ReviewSyncCommand extends CliCommand<ReviewSyncArgs> {
   ) async {
     final path = results['path'] as String;
     final apiKey = results['api-key'] as String;
-    final buildId = results['build-id'] as String;
 
     final repository = context.repository!;
     final currentBranch = await repository.currentBranch;
@@ -83,7 +77,6 @@ class ReviewSyncCommand extends CliCommand<ReviewSyncArgs> {
     return ReviewSyncArgs(
       apiKey: apiKey,
       path: path,
-      buildId: buildId,
       headBranch: headBranch,
       baseBranch: baseBranch,
       headSha: headSha,
@@ -102,9 +95,8 @@ class ReviewSyncCommand extends CliCommand<ReviewSyncArgs> {
     final syncProgress = logger.progress('Syncing review');
     final response = await client.syncReview(
       versions,
-      ReviewRequestNext(
+      ReviewSyncRequest(
         apiKey: args.apiKey,
-        buildId: args.buildId,
         baseBranch: args.baseBranch,
         headBranch: args.headBranch,
         baseSha: args.baseSha,
@@ -112,18 +104,7 @@ class ReviewSyncCommand extends CliCommand<ReviewSyncArgs> {
       ),
     );
 
-    // TODO: get review URL from response
-    final reviewUrl = Uri.parse(
-      p.join(
-        context.environment.appUrl,
-        'projects/${response.review.projectId}',
-        'reviews/${response.review.id}',
-        'builds/${args.buildId}',
-        'use-cases',
-      ),
-    );
-
-    syncProgress.complete('Review ready at $reviewUrl');
+    syncProgress.complete('Review [${response.reviewId}] synced');
 
     return 0;
   }

--- a/packages/widgetbook_cli/lib/src/commands/review_sync.dart
+++ b/packages/widgetbook_cli/lib/src/commands/review_sync.dart
@@ -19,7 +19,7 @@ class ReviewSyncCommand extends CliCommand<ReviewSyncArgs> {
           environment: context.environment,
         ),
         super(
-          name: 'review sync',
+          name: 'sync',
           description: 'Syncs Widgetbook Cloud Review',
         ) {
     argParser

--- a/packages/widgetbook_cli/lib/src/commands/review_sync_args.dart
+++ b/packages/widgetbook_cli/lib/src/commands/review_sync_args.dart
@@ -1,7 +1,6 @@
 class ReviewSyncArgs {
   ReviewSyncArgs({
     required this.apiKey,
-    required this.path,
     required this.baseBranch,
     required this.headBranch,
     required this.baseSha,
@@ -9,7 +8,6 @@ class ReviewSyncArgs {
   });
 
   final String apiKey;
-  final String path;
   final String baseBranch;
   final String headBranch;
   final String baseSha;

--- a/packages/widgetbook_cli/lib/src/commands/review_sync_args.dart
+++ b/packages/widgetbook_cli/lib/src/commands/review_sync_args.dart
@@ -2,7 +2,6 @@ class ReviewSyncArgs {
   ReviewSyncArgs({
     required this.apiKey,
     required this.path,
-    required this.buildId,
     required this.baseBranch,
     required this.headBranch,
     required this.baseSha,
@@ -11,7 +10,6 @@ class ReviewSyncArgs {
 
   final String apiKey;
   final String path;
-  final String buildId;
   final String baseBranch;
   final String headBranch;
   final String baseSha;

--- a/packages/widgetbook_cli/lib/src/commands/review_sync_args.dart
+++ b/packages/widgetbook_cli/lib/src/commands/review_sync_args.dart
@@ -1,0 +1,19 @@
+class ReviewSyncArgs {
+  ReviewSyncArgs({
+    required this.apiKey,
+    required this.path,
+    required this.buildId,
+    required this.baseBranch,
+    required this.headBranch,
+    required this.baseSha,
+    required this.headSha,
+  });
+
+  final String apiKey;
+  final String path;
+  final String buildId;
+  final String baseBranch;
+  final String headBranch;
+  final String baseSha;
+  final String headSha;
+}

--- a/packages/widgetbook_cli/lib/src/core/cli_commands_group.dart
+++ b/packages/widgetbook_cli/lib/src/core/cli_commands_group.dart
@@ -1,0 +1,22 @@
+import 'dart:async';
+
+import 'package:args/command_runner.dart';
+
+class CliCommandsGroup extends Command<int> {
+  CliCommandsGroup({
+    required this.name,
+    required this.description,
+    required List<Command<int>> commands,
+  }) {
+    commands.forEach(addSubcommand);
+  }
+
+  @override
+  final String name;
+
+  @override
+  final String description;
+
+  @override
+  FutureOr<int> run() => 0;
+}

--- a/packages/widgetbook_cli/lib/src/core/cli_runner.dart
+++ b/packages/widgetbook_cli/lib/src/core/cli_runner.dart
@@ -6,6 +6,7 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:pub_updater/pub_updater.dart';
 
 import '../../metadata.dart';
+import '../commands/cloud.dart';
 import '../commands/publish.dart';
 import '../commands/upgrade.dart';
 import '../utils/utils.dart';
@@ -37,6 +38,12 @@ class CliRunner extends CommandRunner<int> {
       PublishCommand(
         context: context,
         logger: _logger,
+      ),
+    );
+
+    addCommand(
+      CloudCommand(
+        context: context,
       ),
     );
   }

--- a/packages/widgetbook_cli/lib/src/core/core.dart
+++ b/packages/widgetbook_cli/lib/src/core/core.dart
@@ -1,4 +1,5 @@
 export 'cli_command.dart';
+export 'cli_commands_group.dart';
 export 'cli_runner.dart';
 export 'context.dart';
 export 'context_manager.dart';

--- a/packages/widgetbook_cli/lib/src/core/environment.dart
+++ b/packages/widgetbook_cli/lib/src/core/environment.dart
@@ -15,7 +15,7 @@ class ProductionEnv extends Environment {
       : super(
           name: 'production',
           appUrl: 'https://app.widgetbook.io/',
-          apiUrl: 'https://api.widgetbook.io/v1/',
+          apiUrl: 'https://api.widgetbook.io/',
         );
 }
 
@@ -24,7 +24,7 @@ class StagingEnv extends Environment {
       : super(
           name: 'staging',
           appUrl: 'https://staging.app.widgetbook.io/',
-          apiUrl: 'https://staging.api.widgetbook.io/v1/',
+          apiUrl: 'https://staging.api.widgetbook.io/',
         );
 }
 
@@ -33,6 +33,6 @@ class DebugEnv extends Environment {
       : super(
           name: 'debug',
           appUrl: 'https://staging.app.widgetbook.io/',
-          apiUrl: 'http://localhost:3000/v1/',
+          apiUrl: 'http://localhost:3000/',
         );
 }

--- a/packages/widgetbook_cli/lib/src/models/use_case_metadata.dart
+++ b/packages/widgetbook_cli/lib/src/models/use_case_metadata.dart
@@ -55,4 +55,15 @@ class UseCaseMetadata {
           map['designLink'] != null ? map['designLink'] as String : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'name': useCaseName,
+      'componentName': componentName,
+      'navPath': navPath,
+      'componentDefinitionPath': componentDefinitionPath,
+      'componentImportStatement': componentImportStatement,
+      'designLink': designLink,
+    };
+  }
 }

--- a/packages/widgetbook_cli/lib/src/utils/zip_encoder.dart
+++ b/packages/widgetbook_cli/lib/src/utils/zip_encoder.dart
@@ -1,6 +1,7 @@
 import 'package:archive/archive_io.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
+import 'package:path/path.dart' as p;
 
 class ZipEncoder {
   const ZipEncoder({
@@ -11,16 +12,17 @@ class ZipEncoder {
 
   /// Returns the encoded ZIP file,
   /// or null if file could not be encoded.
-  Future<File?> zip(Directory dir) async {
-    final filename = '${dir.path}.zip';
+  Future<File?> zip(Directory dir, String filename) async {
     final encoder = ZipFileEncoder();
+    final parentDir = fileSystem.directory(dir.parent.path);
+    final relativeFilename = p.join(parentDir.path, filename);
 
     encoder.zipDirectory(
       dir,
-      filename: filename,
+      filename: relativeFilename,
     );
 
-    final file = fileSystem.file(filename);
+    final file = fileSystem.file(relativeFilename);
     final exists = await file.exists();
 
     return exists ? file : null;

--- a/packages/widgetbook_cli/test/src/commands/publish_test.dart
+++ b/packages/widgetbook_cli/test/src/commands/publish_test.dart
@@ -422,7 +422,7 @@ void main() {
           () => fileSystem.directory(any<String>()),
         ).thenReturn(directory);
 
-        when(() => zipEncoder.zip(any())).thenAnswer((_) async => null);
+        when(() => zipEncoder.zip(any(), any())).thenAnswer((_) async => null);
 
         expectLater(
           () => command.publishBuild(
@@ -461,7 +461,7 @@ void main() {
         () => fileSystem.directory(any<String>()),
       ).thenReturn(directory);
 
-      when(() => zipEncoder.zip(any())).thenAnswer((_) async => file);
+      when(() => zipEncoder.zip(any(), any())).thenAnswer((_) async => file);
 
       when(
         () => client.uploadBuild(
@@ -510,7 +510,7 @@ void main() {
         () => fileSystem.directory(any<String>()),
       ).thenReturn(directory);
 
-      when(() => zipEncoder.zip(any())).thenAnswer((_) async => file);
+      when(() => zipEncoder.zip(any(), any())).thenAnswer((_) async => file);
 
       when(
         () => client.uploadBuild(

--- a/packages/widgetbook_cli/test/src/commands/publish_test.dart
+++ b/packages/widgetbook_cli/test/src/commands/publish_test.dart
@@ -31,6 +31,7 @@ void main() {
     tasks: [],
     review: Review(
       id: 'reviewId',
+      projectId: 'widgetbook',
     ),
   );
 


### PR DESCRIPTION
Add two new experimental cloud commands:

1. `widgetbook cloud build push` - pushes Widgetbook information to Widgetbook Cloud.
2. `widgetbook cloud review sync` - compares 2 builds using the new visual diff algorithm, instead of git-based diff.


#### Installation

```bash
dart pub global activate -sgit https://github.com/widgetbook/widgetbook.git \
    --git-path packages/widgetbook_cli \
    --git-ref feat/cli/cloud-cmds
```
