### PR TITLE
refactor(generator): add `$` prefix to defaults

### DIFF
--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **FEAT**: Support default `setup` & `argsBuilder` via top-level definitions. ([#1130](https://github.com/widgetbook/widgetbook/pull/1130))
+- **FEAT**: Support default `setup` & `argsBuilder` via top-level definitions of `$setup` & `$argsBuilder`. ([#1130](https://github.com/widgetbook/widgetbook/pull/1130), [#1133](https://github.com/widgetbook/widgetbook/pull/1133))
 - **FEAT**: Support generic widgets. ([#1131](https://github.com/widgetbook/widgetbook/pull/1131))
 
 ## 4.0.0-alpha.1

--- a/packages/widgetbook_generator/lib/src/core/story_class_builder.dart
+++ b/packages/widgetbook_generator/lib/src/core/story_class_builder.dart
@@ -75,8 +75,15 @@ class StoryClassBuilder {
                   (b) => b
                     ..name = 'setup'
                     ..named = true
-                    ..toSuper = true
-                    ..defaultTo = hasSetup ? refer('setup').code : null,
+                    ..toSuper = !hasArgsBuilder
+                    ..type = !hasArgsBuilder
+                        ? null
+                        : TypeReference(
+                            (b) => b
+                              ..symbol = 'SetupBuilder'
+                              ..isNullable = true
+                              ..types.addAll([argsClassRef]),
+                          ),
                 ),
                 Parameter(
                   (b) => b
@@ -90,11 +97,9 @@ class StoryClassBuilder {
                   (b) => b
                     ..name = 'argsBuilder'
                     ..named = true
-                    ..toSuper = isCustomArgs
-                    ..defaultTo =
-                        hasArgsBuilder ? refer('argsBuilder').code : null
+                    ..toSuper = isCustomArgs && !hasArgsBuilder
                     ..required = isCustomArgs && !hasArgsBuilder
-                    ..type = isCustomArgs
+                    ..type = isCustomArgs && !hasArgsBuilder
                         ? null
                         : TypeReference(
                             (b) => b
@@ -113,7 +118,7 @@ class StoryClassBuilder {
                       [],
                     ),
                   ),
-                if (!isCustomArgs)
+                if (!isCustomArgs && !hasArgsBuilder)
                   'argsBuilder': refer('argsBuilder').ifNullThen(
                     Method(
                       (b) => b
@@ -132,6 +137,14 @@ class StoryClassBuilder {
                               .call([refer('context')]),
                         ).code,
                     ).closure,
+                  ),
+                if (hasArgsBuilder)
+                  'argsBuilder': refer('argsBuilder').ifNullThen(
+                    refer('\$argsBuilder'),
+                  ),
+                if (hasSetup)
+                  'setup': refer('setup').ifNullThen(
+                    refer('\$setup'),
                   ),
               };
 

--- a/packages/widgetbook_generator/lib/src/core/story_generator.dart
+++ b/packages/widgetbook_generator/lib/src/core/story_generator.dart
@@ -31,11 +31,11 @@ class StoryGenerator extends Generator {
 
     final hasSetup = library.allElements
         .whereType<FunctionElement>()
-        .any((element) => element.name == 'setup');
+        .any((element) => element.name == '\$setup');
 
     final hasArgsBuilder = library.allElements
         .whereType<FunctionElement>()
-        .any((element) => element.name == 'argsBuilder');
+        .any((element) => element.name == '\$argsBuilder');
 
     final genLib = Library(
       (b) => b

--- a/sandbox/lib/[sam]/generic_num.stories.dart
+++ b/sandbox/lib/[sam]/generic_num.stories.dart
@@ -18,7 +18,16 @@ class GenericNumInput<T extends num, R> {
   final R other;
 }
 
-// TODO: support global argsBuilder/setup for generic types
+Widget $setup<T extends num, R>(
+  BuildContext context,
+  Widget child,
+  GenericNumInputArgs<T, R> args,
+) {
+  return GenericNum<T>(
+    value: args.number.resolve(context),
+  );
+}
+
 GenericNum<T> $argsBuilder<T extends num, R>(
   BuildContext context,
   GenericNumInputArgs<T, R> args,

--- a/sandbox/lib/[sam]/label_badge.stories.dart
+++ b/sandbox/lib/[sam]/label_badge.stories.dart
@@ -8,7 +8,7 @@ part 'label_badge.stories.book.dart';
 final meta = MetaWithArgs<LabelBadge, NumericBadgeInput>();
 
 // This will be used as the default `setup`
-Widget setup(
+Widget $setup(
   BuildContext context,
   Widget child,
   NumericBadgeInputArgs args,
@@ -21,7 +21,7 @@ Widget setup(
 }
 
 // This will be used as the default `argsBuilder`
-LabelBadge argsBuilder(
+LabelBadge $argsBuilder(
   BuildContext context,
   NumericBadgeInputArgs args,
 ) {


### PR DESCRIPTION
The default `setup` and `argsBuilder` were added in #1130, but to add support for these functions with generic widgets, they had to be renamed  to `$setup` and `$argsBuilder` because:
  1. Tear-off of generic functions is not allowed in the constructor.
  1.  The name `argsBuilder` cannot be used in `super` initializer due to shadowing.