### PR TITLE
docs(widgetbook): improve `ThemeAddon` doc comments

### DIFF
--- a/packages/widgetbook/lib/src/addons/theme_addon/cupertino_theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/cupertino_theme_addon.dart
@@ -4,6 +4,8 @@ import 'theme_addon.dart';
 
 /// A [ThemeAddon] for changing the active [CupertinoThemeData] via
 /// [CupertinoTheme].
+///
+/// {@macro ThemeAddon.initialTheme}
 class CupertinoThemeAddon extends ThemeAddon<CupertinoThemeData> {
   CupertinoThemeAddon({
     required super.themes,

--- a/packages/widgetbook/lib/src/addons/theme_addon/material_theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/material_theme_addon.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'theme_addon.dart';
 
 /// A [ThemeAddon] for changing the active [ThemeData] via [Theme].
+///
+/// {@macro ThemeAddon.initialTheme}
 class MaterialThemeAddon extends ThemeAddon<ThemeData> {
   MaterialThemeAddon({
     required super.themes,

--- a/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
@@ -16,8 +16,8 @@ typedef ThemeBuilder<T> = Widget Function(
 /// [Widget]s.
 ///
 /// {@template ThemeAddon.initialTheme}
-/// The [initialTheme] is the first theme used when the app is started. When
-/// provided, it must be within [themes]. Otherwise, if [initialTheme] is `null`,
+/// The [initialTheme] is the first theme used when the app is started. If
+/// provided, it must be within [themes]. Otherwise, when [initialTheme] is `null`,
 /// the first theme in [themes] is used.
 /// {@endtemplate}
 class ThemeAddon<T> extends WidgetbookAddon<WidgetbookTheme<T>> {

--- a/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
+++ b/packages/widgetbook/lib/src/addons/theme_addon/theme_addon.dart
@@ -10,8 +10,16 @@ typedef ThemeBuilder<T> = Widget Function(
   Widget child,
 );
 
-/// A [WidgetbookAddon] for changing the active custom theme. A [themeBuilder]
-/// must be provided that returns an [InheritedWidget] or similar [Widget]s.
+/// A [WidgetbookAddon] for changing the active custom theme.
+///
+/// A [themeBuilder] must be provided that returns an [InheritedWidget] or similar
+/// [Widget]s.
+///
+/// {@template ThemeAddon.initialTheme}
+/// The [initialTheme] is the first theme used when the app is started. When
+/// provided, it must be within [themes]. Otherwise, if [initialTheme] is `null`,
+/// the first theme in [themes] is used.
+/// {@endtemplate}
 class ThemeAddon<T> extends WidgetbookAddon<WidgetbookTheme<T>> {
   ThemeAddon({
     required this.themes,


### PR DESCRIPTION
### Description

Updates the documentation for `ThemeAddon` and `MaterialThemeAddon`.

Changes:
- Adds information to `ThemeAddon` regarding the `initialTheme` member.
- Adds the same information to `MaterialThemeAddon` regarding the `initialTheme` member
- Updates the `ThemeAddon` class documentation about `themeBuilder` to comply with Effective Dart ([DO separate the first sentence of a doc comment into its own paragraph](https://dart.dev/effective-dart/documentation#do-separate-the-first-sentence-of-a-doc-comment-into-its-own-paragraph))

### Checklist

- [X] I signed the [CLA].
~- [ ] I listed at least one issue that this PR fixes in the description above.~
- [X] I updated/added relevant documentation (doc comments with `///`).
~- [ ] I added new tests to check the change I am making].~
- [X] All existing and new tests are passing.

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
