### PR TITLE
docs: remove extra space

### DIFF
--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -43,7 +43,7 @@ flutter pub add widgetbook_annotation widgetbook
 and the following dev dependencies:
 
 ```bash
-flutter pub add widgetbook_generator  build_runner --dev
+flutter pub add widgetbook_generator build_runner --dev
 ```
 
 This will add a line like this to your package's pubspec.yaml (and run an implicit


### PR DESCRIPTION
Remove extra whitespace in install documents

### List of issues which are fixed by the PR

- #1143 

### Screenshots

There is an extra space here.

<img width="740" alt="image" src="https://github.com/widgetbook/widgetbook/assets/43127622/611ce594-305f-4d14-8055-bb65170799ff">

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
