### PR TITLE
fix: guard `list` knob against null search values

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Guard `list` knob against null values when searching. ([#1152](https://github.com/widgetbook/widgetbook/pull/1152) - by [@bramp](https://github.com/bramp))
+
 ## 3.7.1
 
 - **REFACTOR**: Wrap workbench with `Scaffold`. ([#1091](https://github.com/widgetbook/widgetbook/pull/1091))

--- a/packages/widgetbook/lib/src/fields/list_field.dart
+++ b/packages/widgetbook/lib/src/fields/list_field.dart
@@ -38,7 +38,11 @@ class ListField<T> extends Field<T> {
       trailingIcon: const Icon(Icons.keyboard_arrow_down_rounded),
       selectedTrailingIcon: const Icon(Icons.keyboard_arrow_up_rounded),
       initialSelection: value ?? values.first,
-      onSelected: (value) => updateField(context, group, value!),
+      onSelected: (value) {
+        if (value != null) {
+          updateField(context, group, value);
+        }
+      },
       dropdownMenuEntries: values
           .map(
             (value) => DropdownMenuEntry(

--- a/packages/widgetbook/test/src/fields/list_field_test.dart
+++ b/packages/widgetbook/test/src/fields/list_field_test.dart
@@ -69,6 +69,26 @@ void main() {
           expect(widget.initialSelection, equals(2));
         },
       );
+
+      testWidgets(
+        'given a state that has a field value, '
+        'when the text is changed to invalid entry "4", '
+        'no exceptions are thrown',
+        (tester) async {
+          await tester.pumpField<int, DropdownMenu<int>>(
+            field,
+            2,
+          );
+
+          await tester.findAndEnter(find.byType(TextField), '4');
+
+          await tester.testTextInput.receiveAction(TextInputAction.done);
+          await tester.pump();
+        },
+        // The test only works on a desktop platforms, as they allow the
+        // drop down text to be edited.
+        variant: TargetPlatformVariant.only(TargetPlatform.macOS),
+      );
     },
   );
 }


### PR DESCRIPTION
The DropdownMenu has search enabled, which allows users to type any input. If the user types something that doesn't match an existing item, value is null, leading to a null pointer issue.

The test is a little finicky, this behaviour only happens on Desktops, or when the `DropdownMenu` is created with `requestFocusOnTap: true`. IMHO it might be better to allow requestFocusOnTap to be set in the `ListField`, but that's. more invasive code change, so instead I used a TargetPlatformVariant.

### List of issues which are fixed by the PR

Fixes https://github.com/widgetbook/widgetbook/issues/1151

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.


If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
