### PR TITLE
docs: add ci to cloud hosting

### DIFF
--- a/docs/widgetbook-cloud/hosting.mdx
+++ b/docs/widgetbook-cloud/hosting.mdx
@@ -38,6 +38,12 @@ To create a Widgetbook Build, follow these steps inside your Widgetbook project:
    widgetbook cloud build push --api-key PROJECT_API_KEY
    ```
 
+<Info>
+The `cloud push` command uses the following directories:
+  1. `build/web/`: to create a `.zip` archive that will be uploaded to Widgetbook Cloud.
+  2. `.dart_tool/build/generated/[your_app_name]/`: to send metadata, _about the generated use-cases_, that will be used for [Widgetbook Cloud Review](/widgetbook-cloud/reviews). 
+</Info>
+
 ## CI
 
 To automate the process of pushing a new build to Widgetbook Cloud, you can use CI/CD.

--- a/docs/widgetbook-cloud/hosting.mdx
+++ b/docs/widgetbook-cloud/hosting.mdx
@@ -42,68 +42,78 @@ To create a Widgetbook Build, follow these steps inside your Widgetbook project:
 
 To automate the process of pushing a new build to Widgetbook Cloud, you can use CI/CD.
 
-### GitHub Actions
-
-```yaml
-name: Widgetbook Cloud Hosting
-on: push
-
-jobs:
-  widgetbook-cloud-hosting:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-
-      - name: Install Widgetbook CLI
-        run: dart pub global activate widgetbook_cli
-
-      - name: Build Widgetbook
-        working-directory: widgetbook
-        run: |
-          flutter pub get
-          dart run build_runner build -d
-          flutter build web -t lib/main.dart
-
-      - name: Push Widgetbook Build
-        working-directory: widgetbook
-        run: widgetbook cloud build push --api-key ${{ secrets.WIDGETBOOK_API_KEY }}
-```
-
-### Codemagic
-
-```yaml
-workflows:
-  widgetbook-cloud-hosting:
+<Tabs
+  groupId="ci"
+  values={[
+    { label: "GitHub Actions", value: "github" },
+    { label: "Codemagic", value: "codemagic" },
+  ]}
+>
+  <TabItem value="github">
+    ```yaml
     name: Widgetbook Cloud Hosting
+    on: push
 
-    triggering:
-      events:
-        - push
+    jobs:
+      widgetbook-cloud-hosting:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout
+            uses: actions/checkout@v3
 
-    environment:
-      flutter: stable
-      groups:
-        - widgetbook_credentials
+          - name: Setup flutter
+            uses: subosito/flutter-action@v2
+            with:
+              channel: stable
 
-    scripts:
-      - name: Install Widgetbook CLI
-        working_directory: mobile/ios
-        script: dart pub global activate widgetbook_cli
+          - name: Install Widgetbook CLI
+            run: dart pub global activate widgetbook_cli
 
-      - name: Build Widgetbook
-        working_directory: widgetbook
-        script: |
-          flutter pub get
-          dart run build_runner build -d
-          flutter build web -t lib/main.dart
+          - name: Build Widgetbook
+            working-directory: widgetbook
+            run: |
+              flutter pub get
+              dart run build_runner build -d
+              flutter build web -t lib/main.dart
 
-      - name: Push Widgetbook Build
-        working_directory: widgetbook
-        script: widgetbook cloud build push --api-key $WIDGETBOOK_API_KEY
-```
+          - name: Push Widgetbook Build
+            working-directory: widgetbook
+            run: widgetbook cloud build push --api-key ${{ secrets.WIDGETBOOK_API_KEY }}
+    ```
+
+  </TabItem>
+
+  <TabItem value="codemagic">
+    ```yaml
+    workflows:
+      widgetbook-cloud-hosting:
+        name: Widgetbook Cloud Hosting
+
+        triggering:
+          events:
+            - push
+
+        environment:
+          flutter: stable
+          groups:
+            - widgetbook_credentials
+
+        scripts:
+          - name: Install Widgetbook CLI
+            working_directory: mobile/ios
+            script: dart pub global activate widgetbook_cli
+
+          - name: Build Widgetbook
+            working_directory: widgetbook
+            script: |
+              flutter pub get
+              dart run build_runner build -d
+              flutter build web -t lib/main.dart
+
+          - name: Push Widgetbook Build
+            working_directory: widgetbook
+            script: widgetbook cloud build push --api-key $WIDGETBOOK_API_KEY
+    ```
+
+  </TabItem>
+</Tabs>

--- a/docs/widgetbook-cloud/hosting.mdx
+++ b/docs/widgetbook-cloud/hosting.mdx
@@ -42,6 +42,20 @@ To create a Widgetbook Build, follow these steps inside your Widgetbook project:
 
 To automate the process of pushing a new build to Widgetbook Cloud, you can use CI/CD.
 
+
+<Info>
+The following workflows assume you have Widgetbook structured as a sub-package
+
+```tree
+your_app/
+├── pubsepc.yaml
+├── lib/
+└── widgetbook/
+    ├── pubsepc.yaml
+    └── lib/
+```
+</Info>
+
 <Tabs
   groupId="ci"
   values={[
@@ -66,8 +80,11 @@ To automate the process of pushing a new build to Widgetbook Cloud, you can use 
             with:
               channel: stable
 
-          - name: Install Widgetbook CLI
-            run: dart pub global activate widgetbook_cli
+          - name: Bootstrap App
+            run: |
+              flutter pub get
+              # Add any other steps needed to make your
+              # app widgets available for Widgetbook
 
           - name: Build Widgetbook
             working-directory: widgetbook
@@ -76,11 +93,13 @@ To automate the process of pushing a new build to Widgetbook Cloud, you can use 
               dart run build_runner build -d
               flutter build web -t lib/main.dart
 
+          - name: Install Widgetbook CLI
+            run: dart pub global activate widgetbook_cli
+
           - name: Push Widgetbook Build
             working-directory: widgetbook
             run: widgetbook cloud build push --api-key ${{ secrets.WIDGETBOOK_API_KEY }}
     ```
-
   </TabItem>
 
   <TabItem value="codemagic">
@@ -99,9 +118,11 @@ To automate the process of pushing a new build to Widgetbook Cloud, you can use 
             - widgetbook_credentials
 
         scripts:
-          - name: Install Widgetbook CLI
-            working_directory: mobile/ios
-            script: dart pub global activate widgetbook_cli
+          - name: Bootstrap App
+            script: |
+              flutter pub get
+              # Add any other steps needed to make your
+              # app widgets available for Widgetbook
 
           - name: Build Widgetbook
             working_directory: widgetbook
@@ -110,10 +131,12 @@ To automate the process of pushing a new build to Widgetbook Cloud, you can use 
               dart run build_runner build -d
               flutter build web -t lib/main.dart
 
+          - name: Install Widgetbook CLI
+            script: dart pub global activate widgetbook_cli
+
           - name: Push Widgetbook Build
             working_directory: widgetbook
             script: widgetbook cloud build push --api-key $WIDGETBOOK_API_KEY
     ```
-
   </TabItem>
 </Tabs>

--- a/docs/widgetbook-cloud/hosting.mdx
+++ b/docs/widgetbook-cloud/hosting.mdx
@@ -39,9 +39,11 @@ To create a Widgetbook Build, follow these steps inside your Widgetbook project:
    ```
 
 <Info>
-The `cloud push` command uses the following directories:
-  1. `build/web/`: to create a `.zip` archive that will be uploaded to Widgetbook Cloud.
-  2. `.dart_tool/build/generated/[your_app_name]/`: to send metadata, _about the generated use-cases_, that will be used for [Widgetbook Cloud Review](/widgetbook-cloud/reviews). 
+  The `cloud push` command uses the following directories: 1. `build/web/`: to
+  create a `.zip` archive that will be uploaded to Widgetbook Cloud. 2.
+  `.dart_tool/build/generated/[your_app_name]/`: to send metadata, _about the
+  generated use-cases_, that will be used for [Widgetbook Cloud
+  Review](/widgetbook-cloud/reviews).
 </Info>
 
 ## Pushing new builds with CI
@@ -59,6 +61,7 @@ your_app/
     ├── pubsepc.yaml
     └── lib/
 ```
+
 </Info>
 
 <Tabs
@@ -69,79 +72,89 @@ your_app/
   ]}
 >
   <TabItem value="github">
-    ```yaml
-    name: Widgetbook Cloud Hosting
-    on: push
+    1. Add `WIDGETBOOK_API_KEY` to your [GitHub repository's secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository). You can find the API key in the Widgetbook Cloud's **project settings page**.
 
-    jobs:
-      widgetbook-cloud-hosting:
-        runs-on: ubuntu-latest
-        steps:
-          - name: Checkout
-            uses: actions/checkout@v3
+    1. Create a new GitHub Actions workflow file in your repository under `.github/workflows/widgetbook-cloud-hosting.yml` with the following content:
 
-          - name: Setup flutter
-            uses: subosito/flutter-action@v2
-            with:
-              channel: stable
+        ```yaml
+        name: Widgetbook Cloud Hosting
+        on: push
 
-          - name: Bootstrap App
-            run: |
-              flutter pub get
-              # Add any other steps needed to make your
-              # app widgets available for Widgetbook
+        jobs:
+          widgetbook-cloud-hosting:
+            runs-on: ubuntu-latest
+            steps:
+              - name: Checkout
+                uses: actions/checkout@v3
 
-          - name: Build Widgetbook
-            working-directory: widgetbook
-            run: |
-              flutter pub get
-              dart run build_runner build -d
-              flutter build web -t lib/main.dart
+              - name: Setup flutter
+                uses: subosito/flutter-action@v2
+                with:
+                  channel: stable
 
-          - name: Install Widgetbook CLI
-            run: dart pub global activate widgetbook_cli
+              - name: Bootstrap App
+                run: |
+                  flutter pub get
+                  # Add any other steps needed to make your
+                  # app widgets available for Widgetbook
 
-          - name: Push Widgetbook Build
-            working-directory: widgetbook
-            run: widgetbook cloud build push --api-key ${{ secrets.WIDGETBOOK_API_KEY }}
-    ```
+              - name: Build Widgetbook
+                working-directory: widgetbook
+                run: |
+                  flutter pub get
+                  dart run build_runner build -d
+                  flutter build web -t lib/main.dart
+
+              - name: Install Widgetbook CLI
+                run: dart pub global activate widgetbook_cli
+
+              - name: Push Widgetbook Build
+                working-directory: widgetbook
+                run: widgetbook cloud build push --api-key ${{ secrets.WIDGETBOOK_API_KEY }}
+        ```
+
   </TabItem>
 
   <TabItem value="codemagic">
-    ```yaml
-    workflows:
-      widgetbook-cloud-hosting:
-        name: Widgetbook Cloud Hosting
+    1. Add `WIDGETBOOK_API_KEY` under `widgetbook_credentials` group in your [Codemagic project's environment variables](https://docs.codemagic.io/yaml-basic-configuration/configuring-environment-variables/#configuring-environment-variables). You can find the API key in the Widgetbook Cloud's **project settings page**.
 
-        triggering:
-          events:
-            - push
+    1. Add the following workflow to your Codemagic `codemagic.yaml` file.
 
-        environment:
-          flutter: stable
-          groups:
-            - widgetbook_credentials
+        ```yaml
+        workflows:
+          widgetbook-cloud-hosting:
+            name: Widgetbook Cloud Hosting
 
-        scripts:
-          - name: Bootstrap App
-            script: |
-              flutter pub get
-              # Add any other steps needed to make your
-              # app widgets available for Widgetbook
+            triggering:
+              events:
+                - push
 
-          - name: Build Widgetbook
-            working_directory: widgetbook
-            script: |
-              flutter pub get
-              dart run build_runner build -d
-              flutter build web -t lib/main.dart
+            environment:
+              flutter: stable
+              groups:
+                - widgetbook_credentials
 
-          - name: Install Widgetbook CLI
-            script: dart pub global activate widgetbook_cli
+            scripts:
+              - name: Bootstrap App
+                script: |
+                  flutter pub get
+                  # Add any other steps needed to make your
+                  # app widgets available for Widgetbook
 
-          - name: Push Widgetbook Build
-            working_directory: widgetbook
-            script: widgetbook cloud build push --api-key $WIDGETBOOK_API_KEY
-    ```
+              - name: Build Widgetbook
+                working_directory: widgetbook
+                script: |
+                  flutter pub get
+                  dart run build_runner build -d
+                  flutter build web -t lib/main.dart
+
+              - name: Install Widgetbook CLI
+                script: dart pub global activate widgetbook_cli
+
+              - name: Push Widgetbook Build
+                working_directory: widgetbook
+                script: widgetbook cloud build push --api-key $WIDGETBOOK_API_KEY
+        ```
+
   </TabItem>
 </Tabs>

--- a/docs/widgetbook-cloud/hosting.mdx
+++ b/docs/widgetbook-cloud/hosting.mdx
@@ -44,10 +44,9 @@ The `cloud push` command uses the following directories:
   2. `.dart_tool/build/generated/[your_app_name]/`: to send metadata, _about the generated use-cases_, that will be used for [Widgetbook Cloud Review](/widgetbook-cloud/reviews). 
 </Info>
 
-## CI
+## Pushing new builds with CI
 
-To automate the process of pushing a new build to Widgetbook Cloud, you can use CI/CD.
-
+To better integrate Widgetbook Cloud with your development workflow, it is recommended to use CI/CD to push a new build **on every push** of a new commit.
 
 <Info>
 The following workflows assume you have Widgetbook structured as a sub-package

--- a/docs/widgetbook-cloud/hosting.mdx
+++ b/docs/widgetbook-cloud/hosting.mdx
@@ -37,3 +37,73 @@ To create a Widgetbook Build, follow these steps inside your Widgetbook project:
    ```bash
    widgetbook cloud build push --api-key PROJECT_API_KEY
    ```
+
+## CI
+
+To automate the process of pushing a new build to Widgetbook Cloud, you can use CI/CD.
+
+### GitHub Actions
+
+```yaml
+name: Widgetbook Cloud Hosting
+on: push
+
+jobs:
+  widgetbook-cloud-hosting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install Widgetbook CLI
+        run: dart pub global activate widgetbook_cli
+
+      - name: Build Widgetbook
+        working-directory: widgetbook
+        run: |
+          flutter pub get
+          dart run build_runner build -d
+          flutter build web -t lib/main.dart
+
+      - name: Push Widgetbook Build
+        working-directory: widgetbook
+        run: widgetbook cloud build push --api-key ${{ secrets.WIDGETBOOK_API_KEY }}
+```
+
+### Codemagic
+
+```yaml
+workflows:
+  widgetbook-cloud-hosting:
+    name: Widgetbook Cloud Hosting
+
+    triggering:
+      events:
+        - push
+
+    environment:
+      flutter: stable
+      groups:
+        - widgetbook_credentials
+
+    scripts:
+      - name: Install Widgetbook CLI
+        working_directory: mobile/ios
+        script: dart pub global activate widgetbook_cli
+
+      - name: Build Widgetbook
+        working_directory: widgetbook
+        script: |
+          flutter pub get
+          dart run build_runner build -d
+          flutter build web -t lib/main.dart
+
+      - name: Push Widgetbook Build
+        working_directory: widgetbook
+        script: widgetbook cloud build push --api-key $WIDGETBOOK_API_KEY
+```


### PR DESCRIPTION
Add a CI guide to [Widgetbook Cloud Hosting](https://docs.widgetbook.io/widgetbook-cloud/hosting).

Preview can be found [here](https://docs.widgetbook.io/~1161/widgetbook-cloud/hosting).