### PR TITLE
fix: encode/decode fields labels to allow ':'

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **FIX**: Allow colons _(and other special characters)_ in fields' names. ([#1165](https://github.com/widgetbook/widgetbook/pull/1165) - by [@maudFrz](https://github.com/maudFrz))
 - **FIX**: Guard `list` knob against null values when searching. ([#1152](https://github.com/widgetbook/widgetbook/pull/1152) - by [@bramp](https://github.com/bramp))
 
 ## 3.7.1

--- a/packages/widgetbook/lib/src/fields/field_codec.dart
+++ b/packages/widgetbook/lib/src/fields/field_codec.dart
@@ -25,8 +25,10 @@ class FieldCodec<T> {
   /// print(encoded); // {foo:bar,baz:qux}
   /// ```
   static String encodeQueryGroup(Map<String, String> group) {
-    final pairs = group.entries
-        .map((entry) => '${Uri.encodeComponent(entry.key)}:${entry.value}');
+    final pairs = group.entries.map((entry) {
+      final String encodedKey = Uri.encodeComponent(entry.key);
+      return '$encodedKey:${entry.value}';
+    });
     return '{${pairs.join(',')}}';
   }
 
@@ -40,7 +42,8 @@ class FieldCodec<T> {
       params.map(
         (param) {
           final parts = param.split(':');
-          return MapEntry(Uri.decodeComponent(parts[0]), parts[1]);
+          final String decodedKey = Uri.decodeComponent(parts[0]);
+          return MapEntry(decodedKey, parts[1]);
         },
       ),
     );

--- a/packages/widgetbook/lib/src/fields/field_codec.dart
+++ b/packages/widgetbook/lib/src/fields/field_codec.dart
@@ -25,7 +25,8 @@ class FieldCodec<T> {
   /// print(encoded); // {foo:bar,baz:qux}
   /// ```
   static String encodeQueryGroup(Map<String, String> group) {
-    final pairs = group.entries.map((entry) => '${entry.key}:${entry.value}');
+    final pairs = group.entries
+        .map((entry) => '${Uri.encodeComponent(entry.key)}:${entry.value}');
     return '{${pairs.join(',')}}';
   }
 
@@ -39,7 +40,7 @@ class FieldCodec<T> {
       params.map(
         (param) {
           final parts = param.split(':');
-          return MapEntry(parts[0], parts[1]);
+          return MapEntry(Uri.decodeComponent(parts[0]), parts[1]);
         },
       ),
     );

--- a/packages/widgetbook/test/src/fields/field_codec_test.dart
+++ b/packages/widgetbook/test/src/fields/field_codec_test.dart
@@ -37,6 +37,23 @@ void main() {
           expect(result, equals(decodedGroup));
         },
       );
+
+      const queryGroupWithColon = {
+        'first_field : ': 'false',
+        'second_field': '2',
+      };
+
+      test(
+        'given a query group with field name containing a colon, '
+        'when [encodeQueryGroup] and [decodeQueryGroup] are successively called, '
+        'then the decoded result is the same as before encoding',
+        () {
+          final encodedResult =
+              FieldCodec.encodeQueryGroup(queryGroupWithColon);
+          final decodedResult = FieldCodec.decodeQueryGroup(encodedResult);
+          expect(decodedResult, equals(queryGroupWithColon));
+        },
+      );
     },
   );
 }


### PR DESCRIPTION
Using colon in label name of a knobs presents side effects. When changing the knob value, the UI is not refreshed.
This is caused by the way `Fields` are encoded/decoded. The current PR enables to fix the bug by encoding the field label. 

### List of issues which are fixed by the PR
#1164 

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.