### PR TITLE
refactor(cli): send build size

### DIFF
--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **REFACTOR**: send build archive file size while creating the build draft. ([#1170](https://github.com/widgetbook/widgetbook/pull/1170))
+
 ## 3.1.0
 
 - **BREAKING**: Set minimum SDK version to 3.0.0. ([#1030](https://github.com/widgetbook/widgetbook/pull/1030))

--- a/packages/widgetbook_cli/lib/src/api/models/build_draft_request.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/build_draft_request.dart
@@ -9,6 +9,7 @@ class BuildDraftRequest {
     required this.branch,
     required this.sha,
     required this.useCases,
+    required this.size,
   });
 
   final String apiKey;
@@ -19,6 +20,9 @@ class BuildDraftRequest {
   final String sha;
   final List<UseCaseMetadata> useCases;
 
+  // Build file size in bytes
+  final int size;
+
   Map<String, dynamic> toJson() {
     return {
       'apiKey': apiKey,
@@ -28,6 +32,7 @@ class BuildDraftRequest {
       'branch': branch,
       'sha': sha,
       'useCases': useCases.map((x) => x.toJson()).toList(),
+      'size': size,
     };
   }
 }

--- a/packages/widgetbook_cli/lib/src/api/widgetbook_http_client.dart
+++ b/packages/widgetbook_cli/lib/src/api/widgetbook_http_client.dart
@@ -102,7 +102,6 @@ class WidgetbookHttpClient {
   }
 
   Future<void> uploadBuildFile(String signedUrl, File zipFile) {
-    // File name must match the name in the signed URL
     return client.put<void>(
       signedUrl,
       data: zipFile.openRead(),


### PR DESCRIPTION
Sends the build file size as it's required by the new endpoint.
A temp archive file is created before creating the draft to send it's size,
then the file is renamed to `build/[draft-id].zip` for connivence.