### PR TITLE
feat(generator): add `nav_path_mode` option

### DIFF
--- a/docs/guides/customization.mdx
+++ b/docs/guides/customization.mdx
@@ -49,16 +49,39 @@ Widget build(BuildContext context) {
 ## Use-cases Navigation Path
 
 By default, use-cases has a navigation path in Widgetbook that is based on where their component file is located.
+There are multiple ways to customize the navigation path either globally or locally.
 
 <Info>
   The component name (e.g. `Button`) and the use-case name (e.g. `Primary`) are
   concatenated at the end of the path.
 
 ```
-[ Component Directory ] / [ Component Name ] / [ Use-case Name ]
+[ Nav Path ] / [ Component Name ] / [ Use-case Name ]
 ```
 
 </Info>
+
+### Using `nav_path_mode` option
+
+You can **globally** change the behavior of the navigation path generation for all use-cases by providing a `nav_path_mode` option in `build.yaml` as follows:
+
+| Option Value          | Navigation Path Based on                                           |
+| --------------------- | ------------------------------------------------------------------ |
+| `component` (default) | The component _(i.e. Widget)_ file.                                |
+| `use-case`            | The use-case file _(i.e. where the `@UseCase` annotation is used)_ |
+
+```yaml title="build.yaml"
+targets:
+  $default:
+    builders:
+      widgetbook_generator:use_case_builder:
+        options:
+          nav_path_mode: use-case
+```
+
+### Using `@UseCase.path` parameter
+
+To provide a custom navigation path for a **single** use-case, you can use the `path` parameter in the `@UseCase` annotation.
 
 ```dart
 import 'package:your_app/widgets/button.dart';
@@ -72,8 +95,6 @@ Widget buildPrimaryButton() {
   return Button();
 }
 ```
-
-To provide a custom navigation path, you can use the `path` parameter in the `@UseCase` annotation.
 
 <Info>
   If you wrap a folder name in **square brackets**, it will be treated as a

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FEAT**: Add new builder option named `nav_path_mode`, that allows using the navigation path of the use-case instead of the component. For more info, check out the [customization docs](https://docs.widgetbook.io/guides/customization#using-nav_path_mode-option). ([#1188](https://github.com/widgetbook/widgetbook/pull/1188))
+
 ## 3.7.0
 
 - **EXPERIMENTAL**: Preserve nullability of generic/function parameters. ([#1092](https://github.com/widgetbook/widgetbook/pull/1092))

--- a/packages/widgetbook_generator/build.yaml
+++ b/packages/widgetbook_generator/build.yaml
@@ -6,6 +6,12 @@ builders:
     auto_apply: dependents
     runs_before: [":app_builder", ":telemetry"]
     build_to: cache
+    defaults:
+      options:
+        # Possible values: "component" or "use_case"
+        # For more info:
+        # https://docs.widgetbook.io/guides/customization#use-cases-navigation-path
+        nav_path_mode: component
 
   app_builder:
     import: "package:widgetbook_generator/builder.dart"

--- a/packages/widgetbook_generator/build.yaml
+++ b/packages/widgetbook_generator/build.yaml
@@ -10,7 +10,7 @@ builders:
       options:
         # Possible values: "component" or "use_case"
         # For more info:
-        # https://docs.widgetbook.io/guides/customization#use-cases-navigation-path
+        # https://docs.widgetbook.io/guides/customization#using-nav_path_mode-option
         nav_path_mode: component
 
   app_builder:

--- a/packages/widgetbook_generator/lib/builder.dart
+++ b/packages/widgetbook_generator/lib/builder.dart
@@ -5,6 +5,7 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'src/generators/app_generator.dart';
 import 'src/generators/json_builder.dart';
 import 'src/generators/use_case_generator.dart';
+import 'src/models/nav_path_mode.dart';
 import 'src/next/components_builder.dart';
 import 'src/next/story_generator.dart';
 import 'src/telemetry/telemetry_reporter.dart';
@@ -16,8 +17,11 @@ import 'widgetbook_generator.dart';
 /// json objects representing the annotated elements. These files are used
 /// later on by other builders to generate more code.
 Builder useCaseBuilder(BuilderOptions options) {
+  final navPathModeConfig = options.config['nav_path_mode'] as String;
+  final navPathMode = parseNavPathMode(navPathModeConfig);
+
   return JsonBuilder(
-    UseCaseGenerator(),
+    UseCaseGenerator(navPathMode),
     generatedExtension: '.usecase.widgetbook.json',
     formatOutput: (input) {
       // [GeneratorForAnnotation] joins the JSON objects by two newlines,

--- a/packages/widgetbook_generator/lib/src/generators/use_case_generator.dart
+++ b/packages/widgetbook_generator/lib/src/generators/use_case_generator.dart
@@ -9,9 +9,12 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 import 'package:yaml/yaml.dart';
 
 import '../models/element_metadata.dart';
+import '../models/nav_path_mode.dart';
 import '../models/use_case_metadata.dart';
 
 class UseCaseGenerator extends GeneratorForAnnotation<UseCase> {
+  UseCaseGenerator(this.navPathMode);
+
   final packagesMapResource = Resource<YamlMap>(
     () async {
       final lockFile = await File('pubspec.lock').readAsString();
@@ -20,6 +23,8 @@ class UseCaseGenerator extends GeneratorForAnnotation<UseCase> {
       return yaml['packages'] as YamlMap;
     },
   );
+
+  final NavPathMode navPathMode;
 
   @override
   Future<String> generateForAnnotatedElement(
@@ -56,7 +61,11 @@ class UseCaseGenerator extends GeneratorForAnnotation<UseCase> {
     final useCasePath = await resolveElementPath(element, buildStep);
     final componentPath = await resolveElementPath(type.element!, buildStep);
 
-    final navPath = path ?? getNavPath(componentUri);
+    final targetNavUri = navPathMode == NavPathMode.component //
+        ? componentUri
+        : useCaseUri;
+
+    final navPath = path ?? getNavPath(targetNavUri);
 
     final metadata = UseCaseMetadata(
       functionName: element.name!,

--- a/packages/widgetbook_generator/lib/src/models/nav_path_mode.dart
+++ b/packages/widgetbook_generator/lib/src/models/nav_path_mode.dart
@@ -1,0 +1,46 @@
+NavPathMode parseNavPathMode(String value) {
+  switch (value) {
+    case 'component':
+      return NavPathMode.component;
+    case 'use-case':
+      return NavPathMode.useCase;
+    default:
+      throw ArgumentError(
+        'Unknown NavPathMode: $value. '
+        'Use either "component" or "use-case"',
+      );
+  }
+}
+
+enum NavPathMode {
+  /// Determines the navigation path based on where the [Widget] type
+  /// is located. Used to reflect the folder structure of your app.
+  /// This is the default mode.
+  ///
+  /// For example, the `navPath` for the following use-case
+  /// would be `widgets/PrimaryButton/Default`:
+  ///
+  /// ```dart
+  /// // widgetbook/lib/buttons/primary_button.dart
+  /// import 'package:my_app/widgets/primary_button.dart';
+  ///
+  /// @UseCase(name: 'Default', type: PrimaryButton)
+  /// Widget primaryButtonUseCase(Build Context) { ... }
+  /// ```
+  component,
+
+  /// Determines the navigation path based on where the [UseCase] annotation
+  /// is used. Used to reflect the folder structure of your widgetbook app.
+  ///
+  /// For example, the `navPath` for the following use-case
+  /// would be `buttons/PrimaryButton/Default`:
+  ///
+  /// ```dart
+  /// // widgetbook/lib/buttons/primary_button.dart
+  /// import 'package:my_app/widgets/primary_button.dart';
+  ///
+  /// @UseCase(name: 'Default', type: PrimaryButton)
+  /// Widget primaryButtonUseCase(Build Context) { ... }
+  /// ```
+  useCase,
+}

--- a/sandbox/build.yaml
+++ b/sandbox/build.yaml
@@ -1,6 +1,9 @@
 targets:
   $default:
     builders:
+      widgetbook_generator:use_case_builder:
+        options:
+          nav_path_mode: use-case
       widgetbook_generator:telemetry:
         enabled: false
       widgetbook_generator:experimental_story_builder:


### PR DESCRIPTION
The new `nav_path_mode` option allow to globally customize the behavior of navigation path generation.

| Option Value          | Navigation Path Based on                                           |
| :-------------------- | :----------------------------------------------------------------- |
| `component` (default) | The component _(i.e. Widget)_ file.                                |
| `use-case`            | The use-case file _(i.e. where the `@UseCase` annotation is used)_ |

To use the new option, add the following snippet to your `build.yaml` file:

```yaml
targets:
  $default:
    builders:
      widgetbook_generator:use_case_builder:
        options:
          nav_path_mode: use-case
```