### PR TITLE
refactor(generator): add `project_id` to telemetry

### DIFF
--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -28,6 +28,7 @@ We send the following information, which **has no personal data**:
 
 1. The package name.
 1. Unique **hashed** anonymous ID based on your git config email.
+1. The SHA of the first commit in the repository, to identify distinct projects.
 1. Information about Widgetbook Components like:
    - The number of components.
    - The number of components with various counts of use-cases.

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **FEAT**: Add new builder option named `nav_path_mode`, that allows using the navigation path of the use-case instead of the component. For more info, check out the [customization docs](https://docs.widgetbook.io/guides/customization#using-nav_path_mode-option). ([#1188](https://github.com/widgetbook/widgetbook/pull/1188))
+- **REFACTOR**: Send a unique project identifier for [telemetry](https://docs.widgetbook.io/telemetry). ([#1189](https://github.com/widgetbook/widgetbook/pull/1189))
 
 ## 3.7.0
 

--- a/packages/widgetbook_generator/lib/src/telemetry/usage_report.dart
+++ b/packages/widgetbook_generator/lib/src/telemetry/usage_report.dart
@@ -5,6 +5,7 @@ import '../models/use_case_metadata.dart';
 class UsageReport {
   UsageReport.from({
     required this.trackingId,
+    required this.projectId,
     required this.project,
     required List<UseCaseMetadata> useCases,
     required this.version,
@@ -29,6 +30,7 @@ class UsageReport {
   }
 
   final String trackingId;
+  final String projectId;
   final String project;
   final DateTime timestamp = DateTime.now();
 
@@ -55,7 +57,7 @@ class UsageReport {
       );
 
   /// Unique ID to identify the report
-  String get id => '$project'
+  String get id => '$projectId'
       '-C$componentsCount'
       '-U$useCasesCount'
       '-P${packages.length}'
@@ -74,6 +76,7 @@ class UsageReport {
         '\$insert_id': id,
         'version': version,
         'project': project,
+        'project_id': projectId,
         'packages': packages.toList(),
         'components': componentsCount,
         'use_cases': useCasesCount,

--- a/packages/widgetbook_generator/test/src/telemetry/usage_report_test.dart
+++ b/packages/widgetbook_generator/test/src/telemetry/usage_report_test.dart
@@ -76,7 +76,7 @@ void main() {
     test('correct id', () {
       expect(
         report.id,
-        equals('test-C2-U5-P2-V3.x.x'),
+        equals('yyyy-C2-U5-P2-V3.x.x'),
       );
     });
 

--- a/packages/widgetbook_generator/test/src/telemetry/usage_report_test.dart
+++ b/packages/widgetbook_generator/test/src/telemetry/usage_report_test.dart
@@ -8,6 +8,7 @@ void main() {
     final report = UsageReport.from(
       version: '3.x.x',
       project: 'test',
+      projectId: 'yyyy',
       trackingId: 'xxxx',
       useCases: [
         MockUseCaseMetadata(
@@ -94,6 +95,7 @@ void main() {
             '\$insert_id': report.id,
             'version': '3.x.x',
             'project': report.project,
+            'project_id': report.projectId,
             'packages': report.packages.toList(),
             'components': 2,
             'use_cases': 5,


### PR DESCRIPTION
Since all projects are now named `widgetbook_workspace`, we need another identifier for projects. So starting from the next version of the generator, we will be reporting the SHA of the first commit in the repository to use it as a project identifier.