### PR TITLE
ci: check analysis on min version

### DIFF
--- a/.github/workflows/_package.yml
+++ b/.github/workflows/_package.yml
@@ -11,6 +11,11 @@ on:
         type: string
 
 jobs:
+  # Although pana is now checking for pub downgrade, but the check
+  # does not validate the backwards compatibility of Flutter itself,
+  # but only the compatibility of the dependencies.
+  # This job installs the minimum Flutter version and checks if the
+  # dependencies are compatible with it.
   check-min-version:
     runs-on: ubuntu-latest
     defaults:
@@ -29,6 +34,9 @@ jobs:
 
       - name: Check Dependencies Compatibility
         run: flutter pub downgrade
+
+      - name: Check Analysis issues
+        run: dart analyze lib
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since [`pana` v0.22.04](https://pub.dev/packages/pana/changelog#0224), the `pub downgrade` is checked, which might make the `check-min-version` job obsolete at first glance. But in fact, this job is still useful as it checks Flutter's minimum version itself, and not just the dependencies, making our packages more backwards compatible.