### PR TITLE
docs: remove unused import in `AccessibilityAddon` guide

### DIFF
--- a/docs/addons/accessibility-addon.mdx
+++ b/docs/addons/accessibility-addon.mdx
@@ -22,7 +22,6 @@ the [`accessibility_tools`](https://pub.dev/packages/accessibility_tools) packag
 
    ```dart title="addons/accessibility_addon.dart"
    import 'package:accessibility_tools/accessibility_tools.dart';
-   import 'package:flutter/material.dart';
    import 'package:widgetbook/widgetbook.dart';
 
    class AccessibilityAddon extends BuilderAddon {


### PR DESCRIPTION
The material import is unused in the `accessibility_addon.dart` file.

### List of issues which are fixed by the PR
N/A

### Screenshots
N/A

### Checklist

- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
