### PR TITLE
feat: add `builder` parameter

### DIFF
--- a/packages/widgetbook/lib/src/state/default_app_builders.dart
+++ b/packages/widgetbook/lib/src/state/default_app_builders.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
+@Deprecated('Use [widgetBuilder] instead.')
 Widget widgetsAppBuilder(BuildContext context, Widget child) {
   return WidgetsApp(
     debugShowCheckedModeBanner: false,
@@ -9,6 +10,7 @@ Widget widgetsAppBuilder(BuildContext context, Widget child) {
   );
 }
 
+@Deprecated('Use [materialBuilder] instead.')
 Widget materialAppBuilder(BuildContext context, Widget child) {
   return MaterialApp(
     debugShowCheckedModeBanner: false,
@@ -18,6 +20,7 @@ Widget materialAppBuilder(BuildContext context, Widget child) {
   );
 }
 
+@Deprecated('Use [cupertinoBuilder] instead.')
 Widget cupertinoAppBuilder(BuildContext context, Widget child) {
   return CupertinoApp(
     debugShowCheckedModeBanner: false,

--- a/packages/widgetbook/lib/src/state/default_builders.dart
+++ b/packages/widgetbook/lib/src/state/default_builders.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'widgetbook_state.dart';
+
+Widget widgetsBuilder(
+  BuildContext context,
+  AddonsBuilder addonsBuilder,
+  Widget useCase,
+) {
+  return WidgetsApp(
+    debugShowCheckedModeBanner: false,
+    color: Colors.white,
+    builder: (context, child) => addonsBuilder(context, child!),
+    home: useCase,
+  );
+}
+
+Widget materialBuilder(
+  BuildContext context,
+  AddonsBuilder addonsBuilder,
+  Widget useCase,
+) {
+  return MaterialApp(
+    debugShowCheckedModeBanner: false,
+    builder: (context, child) => addonsBuilder(context, child!),
+    home: useCase,
+  );
+}
+
+Widget cupertinoBuilder(
+  BuildContext context,
+  AddonsBuilder addonsBuilder,
+  Widget useCase,
+) {
+  return CupertinoApp(
+    debugShowCheckedModeBanner: false,
+    builder: (context, child) => addonsBuilder(context, child!),
+    home: useCase,
+  );
+}

--- a/packages/widgetbook/lib/src/state/state.dart
+++ b/packages/widgetbook/lib/src/state/state.dart
@@ -1,3 +1,4 @@
 export 'default_app_builders.dart';
+export 'default_builders.dart';
 export 'widgetbook_scope.dart';
 export 'widgetbook_state.dart';

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -9,6 +9,7 @@ import '../integrations/widgetbook_integration.dart';
 import '../knobs/knobs.dart';
 import '../navigation/navigation.dart';
 import '../routing/routing.dart';
+import 'default_app_builders.dart';
 import 'default_builders.dart';
 import 'widgetbook_scope.dart';
 
@@ -28,7 +29,8 @@ class WidgetbookState extends ChangeNotifier {
     this.query,
     this.previewMode = false,
     this.queryParams = const {},
-    this.appBuilder,
+    // ignore: deprecated_member_use_from_same_package
+    this.appBuilder = widgetsAppBuilder,
     this.builder = widgetsBuilder,
     this.addons,
     this.integrations,
@@ -59,7 +61,7 @@ class WidgetbookState extends ChangeNotifier {
   final WidgetbookRoot root;
 
   @Deprecated('Use [builder] instead.')
-  final AppBuilder? appBuilder;
+  final AppBuilder appBuilder;
 
   List<WidgetbookNode> get directories => root.children!;
 

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -9,10 +9,18 @@ import '../integrations/widgetbook_integration.dart';
 import '../knobs/knobs.dart';
 import '../navigation/navigation.dart';
 import '../routing/routing.dart';
-import 'default_app_builders.dart';
+import 'default_builders.dart';
 import 'widgetbook_scope.dart';
 
 typedef AppBuilder = Widget Function(BuildContext context, Widget child);
+
+typedef AddonsBuilder = Widget Function(BuildContext context, Widget child);
+
+typedef WidgetbookBuilder = Widget Function(
+  BuildContext context,
+  AddonsBuilder addonsBuilder,
+  Widget useCase,
+);
 
 class WidgetbookState extends ChangeNotifier {
   WidgetbookState({
@@ -20,7 +28,8 @@ class WidgetbookState extends ChangeNotifier {
     this.query,
     this.previewMode = false,
     this.queryParams = const {},
-    this.appBuilder = widgetsAppBuilder,
+    this.appBuilder,
+    this.builder = widgetsBuilder,
     this.addons,
     this.integrations,
     required this.root,
@@ -44,10 +53,13 @@ class WidgetbookState extends ChangeNotifier {
   Map<String, String> queryParams;
 
   late final KnobsRegistry knobs;
-  final AppBuilder appBuilder;
+  final WidgetbookBuilder builder;
   final List<WidgetbookAddon>? addons;
   final List<WidgetbookIntegration>? integrations;
   final WidgetbookRoot root;
+
+  @Deprecated('Use [builder] instead.')
+  final AppBuilder? appBuilder;
 
   List<WidgetbookNode> get directories => root.children!;
 

--- a/packages/widgetbook/lib/src/workbench/workbench.dart
+++ b/packages/widgetbook/lib/src/workbench/workbench.dart
@@ -16,13 +16,15 @@ class Workbench extends StatelessWidget {
     return Scaffold(
       // Some addons require a Scaffold to work properly.
       body: SafeBoundaries(
-        child: state.appBuilder(
-          context,
-          ColoredBox(
-            // Background color for the area behind device frame if
-            // the [DeviceFrameAddon] is used.
-            color: Theme.of(context).scaffoldBackgroundColor,
-            child: MultiAddonBuilder(
+        child: ColoredBox(
+          // Background color for the area behind device frame if
+          // the [DeviceFrameAddon] is used. This has to be here instead of
+          // inside the [DeviceFrameAddon] because the state.builder provides
+          // a new [WidgetsApp] that will have its own theme.
+          color: Theme.of(context).scaffoldBackgroundColor,
+          child: state.builder(
+            context,
+            (context, child) => MultiAddonBuilder(
               addons: state.addons,
               builder: (context, addon, child) {
                 final state = WidgetbookState.of(context);
@@ -38,22 +40,23 @@ class Workbench extends StatelessWidget {
                   newSetting,
                 );
               },
-              child: Stack(
-                // The Stack is used to loosen the constraints of
-                // the UseCaseBuilder. Without the Stack, UseCaseBuilder
-                // would expand to the whole size of the Workbench.
-                children: [
-                  UseCaseBuilder(
-                    key: ValueKey(state.uri),
-                    builder: (context) {
-                      return WidgetbookState.of(context)
-                              .useCase
-                              ?.build(context) ??
-                          const SizedBox.shrink();
-                    },
-                  ),
-                ],
-              ),
+              child: child,
+            ),
+            Stack(
+              // The Stack is used to loosen the constraints of
+              // the UseCaseBuilder. Without the Stack, UseCaseBuilder
+              // would expand to the whole size of the Workbench.
+              children: [
+                UseCaseBuilder(
+                  key: ValueKey(state.uri),
+                  builder: (context) {
+                    return WidgetbookState.of(context)
+                            .useCase
+                            ?.build(context) ??
+                        const SizedBox.shrink();
+                  },
+                ),
+              ],
             ),
           ),
         ),

--- a/packages/widgetbook/test/src/routing/app_router_delegate_test.dart
+++ b/packages/widgetbook/test/src/routing/app_router_delegate_test.dart
@@ -56,7 +56,7 @@ void main() {
         'then shell is hidden',
         (tester) async {
           final state = WidgetbookState(
-            appBuilder: materialAppBuilder,
+            builder: materialBuilder,
             root: WidgetbookRoot(
               children: [],
             ),


### PR DESCRIPTION
Deprecates the `Widgetbook.appBuilder` parameter, in favor of the new parameter `Widgetbook.builder`. The new parameter allows injecting widgets between the Addons and the UseCase. This can be helpful for injecting the [`Navigator`](https://api.flutter.dev/flutter/widgets/Navigator-class.html) widget between the two, to make popup routes _(For example: [`showDialog`](https://api.flutter.dev/flutter/material/showDialog.html), [`showMenu`](https://api.flutter.dev/flutter/material/showMenu.html), and [`showModalBottomSheet`](https://api.flutter.dev/flutter/material/showModalBottomSheet.html))_ to work within the `DeviceFrameAddon` _(see #1201 for info)_.

### Migration

1. If you are **not overriding** the default `appBuilder`, then **no migration needed**.
1. If you have a custom `appBuilder`:

    ```dart
    // Old code (DEPRECATED)
    appBuilder: (context, child) {
      return MaterialApp(
        home: CustomWidget(
          // This [child] is a tree of both
          // addons and use-case together.
          child: child,
        ), 
      );
    }
    ```

    ```dart
    // New code
    builder: (context, addonsBuilder, useCase) {
      return MaterialApp(
        // The [addonsBuilder] is passed to [MaterialApp.builder]
        // to inject it above the [Navigator]. The [child] here
        // is the [Navigator] widget, and it will always be non-null,
        // as long as we are passing [home] or any alternative.
        builder: (context, child) => addonsBuilder(context, child!),
        // You can choose to wrap either the [useCase] or [addonsBuilder]
        // with your [CustomWidget], depending on your needs.
        home: CustomWidget(
          // The [useCase] does not have the addons with it.
          child: useCase,
        ),
      );
    }
    ```
