### PR TITLE
docs: fix theme hex

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3,7 +3,7 @@
   "twitter": "widgetbook_io",
   "logo": "/assets/logos/logo-light.png",
   "logoDark": "/assets/logos/logo-dark.png",
-  "theme": "0060A7",
+  "theme": "#0060A7",
   "googleAnalytics": "G-74GW877FF8",
   "docsearch": {
     "appId": "325TRD6FM7",


### PR DESCRIPTION
docs.page technically should accept a theme value of a hex code starting with a #
