### PR TITLE
fix: show popup routes within device frame

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Show popup routes (e.g. dialogs and modal sheets) inside the boundaries on the device frame. ([#1209](https://github.com/widgetbook/widgetbook/pull/1209))
+
 ## 3.8.0
 
 - **FIX**: Maintain theme in Flutter v3.22. ([#1184](https://github.com/widgetbook/widgetbook/pull/1184))

--- a/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
@@ -81,11 +81,20 @@ class DeviceFrameAddon extends WidgetbookAddon<DeviceFrameSetting> {
           orientation: setting.orientation,
           device: setting.device,
           isFrameVisible: setting.hasFrame,
-          screen: setting.hasFrame
-              ? child
-              : SafeArea(
-                  child: child,
-                ),
+          // A navigator below the device frame is necessary to make
+          // the popup routes (e.g. dialogs and bottom sheets) work within
+          // the device frame, otherwise they would use the navigator from
+          // the app builder, causing these routes to fill the whole
+          // workbench and not just the device frame.
+          screen: Navigator(
+            onGenerateRoute: (_) => PageRouteBuilder(
+              pageBuilder: (context, _, __) => setting.hasFrame
+                  ? child
+                  : SafeArea(
+                      child: child,
+                    ),
+            ),
+          ),
         ),
       ),
     );

--- a/packages/widgetbook/lib/src/next/addons/device_frame_addon.dart
+++ b/packages/widgetbook/lib/src/next/addons/device_frame_addon.dart
@@ -46,11 +46,20 @@ class DeviceFrameMode extends Mode<DeviceFrameConfig> {
           orientation: value.orientation,
           device: value.device,
           isFrameVisible: value.hasFrame,
-          screen: value.hasFrame
-              ? child
-              : SafeArea(
-                  child: child,
-                ),
+          // A navigator below the device frame is necessary to make
+          // the popup routes (e.g. dialogs and bottom sheets) work within
+          // the device frame, otherwise they would use the navigator from
+          // the app builder, causing these routes to fill the whole
+          // workbench and not just the device frame.
+          screen: Navigator(
+            onGenerateRoute: (_) => PageRouteBuilder(
+              pageBuilder: (context, _, __) => value.hasFrame
+                  ? child
+                  : SafeArea(
+                      child: child,
+                    ),
+            ),
+          ),
         ),
       ),
     );

--- a/packages/widgetbook/test/src/addons/device_frame_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/device_frame_addon_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widgetbook/widgetbook.dart';
 
@@ -78,6 +78,89 @@ void main() {
           expect(
             deviceFrame.device,
             equals(device),
+          );
+        },
+      );
+
+      testWidgets(
+        'given a use-case that has a dialog, '
+        'when the dialog is opened, '
+        'then it is show inside the [DeviceFrame]',
+        (tester) async {
+          final device = devices.last;
+
+          await tester.pumpWidgetWithBuilder(
+            (context) => addon.buildUseCase(
+              context,
+              Builder(
+                builder: (context) {
+                  return TextButton(
+                    onPressed: () {
+                      showDialog<void>(
+                        useRootNavigator: false,
+                        context: context,
+                        builder: (context) => const Placeholder(),
+                      );
+                    },
+                    child: const Text('Open'),
+                  );
+                },
+              ),
+              DeviceFrameSetting(
+                device: device,
+              ),
+            ),
+          );
+
+          await tester.findAndTap(find.byType(TextButton));
+
+          expect(
+            find.descendant(
+              of: find.byType(DeviceFrame),
+              matching: find.byType(Placeholder),
+            ),
+            findsOneWidget,
+          );
+        },
+      );
+
+      testWidgets(
+        'given a use-case that has a bottom modal sheet, '
+        'when the dialog is opened, '
+        'then it is show inside the [DeviceFrame]',
+        (tester) async {
+          final device = devices.last;
+
+          await tester.pumpWidgetWithBuilder(
+            (context) => addon.buildUseCase(
+              context,
+              Builder(
+                builder: (context) {
+                  return TextButton(
+                    onPressed: () {
+                      showModalBottomSheet<void>(
+                        context: context,
+                        builder: (context) => const Placeholder(),
+                      );
+                    },
+                    child: const Text('Open'),
+                  );
+                },
+              ),
+              DeviceFrameSetting(
+                device: device,
+              ),
+            ),
+          );
+
+          await tester.findAndTap(find.byType(TextButton));
+
+          expect(
+            find.descendant(
+              of: find.byType(DeviceFrame),
+              matching: find.byType(Placeholder),
+            ),
+            findsOneWidget,
           );
         },
       );


### PR DESCRIPTION
Include a `Navigator` inside the `DeviceFrameAddon` to be used for popup routes (e.g. dialogs and bottom sheets).