### PR TITLE
fix: encode all fields values

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Encode all fields values to allow reserved characters (e.g. commas, colons and curly brackets). ([#1214](https://github.com/widgetbook/widgetbook/pull/1214))
+
 ## 3.8.1
 
 - **FIX**: Show popup routes (e.g. dialogs and modal sheets) inside the boundaries on the device frame. ([#1209](https://github.com/widgetbook/widgetbook/pull/1209))

--- a/packages/widgetbook/lib/src/fields/date_time_field.dart
+++ b/packages/widgetbook/lib/src/fields/date_time_field.dart
@@ -25,16 +25,9 @@ class DateTimeField extends Field<DateTime> {
   }) : super(
           type: FieldType.dateTime,
           codec: FieldCodec<DateTime>(
-            toParam: (value) {
-              // encode the date time to a string to replace all instances of
-              // ':' with '%3A' to avoid issues with retrieving the value
-              // from the param in the query group because it is saved in a map
-              return Uri.encodeComponent(value.toSimpleFormat());
-            },
+            toParam: (value) => value.toSimpleFormat(),
             toValue: (param) {
-              return param == null
-                  ? null
-                  : DateTime.tryParse(Uri.decodeComponent(param));
+              return param == null ? null : DateTime.tryParse(param);
             },
           ),
         );

--- a/packages/widgetbook/lib/src/fields/field_codec.dart
+++ b/packages/widgetbook/lib/src/fields/field_codec.dart
@@ -41,7 +41,7 @@ class FieldCodec<T> {
 
   /// Decodes a query group encoded value back to a [Map].
   static Map<String, String> decodeQueryGroup(String? group) {
-    if (group == null) return {};
+    if (group == null || group == '{}') return {};
 
     final params = group.substring(1, group.length - 1).split(',');
 

--- a/packages/widgetbook/lib/src/fields/field_codec.dart
+++ b/packages/widgetbook/lib/src/fields/field_codec.dart
@@ -26,9 +26,16 @@ class FieldCodec<T> {
   /// ```
   static String encodeQueryGroup(Map<String, String> group) {
     final pairs = group.entries.map((entry) {
-      final String encodedKey = Uri.encodeComponent(entry.key);
-      return '$encodedKey:${entry.value}';
+      // Both key and value are encoded to ensure that reserved
+      // characters (e.g. `:`, `{`, `}` and `,`) are not misinterpreted.
+      // For example, using a comma in a string value or a colon
+      // in a date value would break the decoding process.
+      final encodedKey = Uri.encodeComponent(entry.key);
+      final encodedValue = Uri.encodeComponent(entry.value);
+
+      return '$encodedKey:$encodedValue';
     });
+
     return '{${pairs.join(',')}}';
   }
 
@@ -42,8 +49,10 @@ class FieldCodec<T> {
       params.map(
         (param) {
           final parts = param.split(':');
-          final String decodedKey = Uri.decodeComponent(parts[0]);
-          return MapEntry(decodedKey, parts[1]);
+          final decodedKey = Uri.decodeComponent(parts[0]);
+          final decodedValue = Uri.decodeComponent(parts[1]);
+
+          return MapEntry(decodedKey, decodedValue);
         },
       ),
     );

--- a/packages/widgetbook/lib/src/fields/string_field.dart
+++ b/packages/widgetbook/lib/src/fields/string_field.dart
@@ -14,10 +14,8 @@ class StringField extends Field<String> {
   }) : super(
           type: FieldType.string,
           codec: FieldCodec(
-            toParam: (value) => Uri.encodeComponent(value),
-            toValue: (param) => param != null
-                ? Uri.decodeComponent(param) //
-                : null,
+            toParam: (value) => value,
+            toValue: (param) => param,
           ),
         );
 

--- a/packages/widgetbook/test/helper/tester_extension.dart
+++ b/packages/widgetbook/test/helper/tester_extension.dart
@@ -92,7 +92,7 @@ extension TesterExtension on WidgetTester {
     );
 
     await pumpWidgetWithQueryParams(
-      queryParams: groupValue.isNotEmpty ? {groupKey: groupValue} : {},
+      queryParams: value != null ? {groupKey: groupValue} : {},
       builder: (context) => field.build(context, groupKey),
     );
 

--- a/packages/widgetbook/test/helper/tester_extension.dart
+++ b/packages/widgetbook/test/helper/tester_extension.dart
@@ -86,13 +86,14 @@ extension TesterExtension on WidgetTester {
     Field<TValue> field,
     TValue? value,
   ) async {
-    const group = 'group_name';
+    const groupKey = 'group_name';
+    final groupValue = FieldCodec.encodeQueryGroup(
+      value != null ? {field.name: field.codec.toParam(value)} : {},
+    );
 
     await pumpWidgetWithQueryParams(
-      queryParams: value != null
-          ? {group: '{${field.name}:${field.codec.toParam(value)}}'}
-          : {},
-      builder: (context) => field.build(context, group),
+      queryParams: groupValue.isNotEmpty ? {groupKey: groupValue} : {},
+      builder: (context) => field.build(context, groupKey),
     );
 
     return widget<TWidget>(

--- a/packages/widgetbook/test/src/fields/field_codec_test.dart
+++ b/packages/widgetbook/test/src/fields/field_codec_test.dart
@@ -38,20 +38,21 @@ void main() {
         },
       );
 
-      const queryGroupWithColon = {
-        'first_field : ': 'false',
-        'second_field': '2',
-      };
-
       test(
-        'given a query group with field name containing a colon, '
+        'given a query group reserved characters, '
         'when [encodeQueryGroup] and [decodeQueryGroup] are successively called, '
         'then the decoded result is the same as before encoding',
         () {
-          final encodedResult =
-              FieldCodec.encodeQueryGroup(queryGroupWithColon);
-          final decodedResult = FieldCodec.decodeQueryGroup(encodedResult);
-          expect(decodedResult, equals(queryGroupWithColon));
+          final group = {
+            'Comma Field': 'Hello, World!',
+            'Colon Field': '2022-01-01 00:00',
+            'Special:Key': 'Special%Value',
+          };
+
+          final encodedGroup = FieldCodec.encodeQueryGroup(group);
+          final decodedGroup = FieldCodec.decodeQueryGroup(encodedGroup);
+
+          expect(decodedGroup, equals(group));
         },
       );
     },

--- a/packages/widgetbook/test/src/fields/string_field_test.dart
+++ b/packages/widgetbook/test/src/fields/string_field_test.dart
@@ -24,16 +24,6 @@ void main() {
       );
 
       test(
-        'given a value with commas, '
-        'when [codec.toParam] is called, '
-        'then it returns the value as URL-encoded string',
-        () {
-          final result = field.codec.toParam('doggo,');
-          expect(result, equals('doggo%2C'));
-        },
-      );
-
-      test(
         'given a string param, '
         'when [codec.toValue] is called, '
         'then it returns the actual value',
@@ -66,6 +56,20 @@ void main() {
           );
 
           expect(widget.initialValue, equals('doggo'));
+        },
+      );
+
+      testWidgets(
+        'given a state that has a field value with reserved character, '
+        'then [toWidget] builds that value correctly',
+        (tester) async {
+          const value = 'doggo, ';
+          final widget = await tester.pumpField<String, TextFormField>(
+            field,
+            value,
+          );
+
+          expect(widget.initialValue, equals(value));
         },
       );
     },


### PR DESCRIPTION
Previously, we were only encoding/decoding only `StringField` and `DateField` because they might contain some reserved characters like commas or colons. But this issue might happen with other fields as well, for example the `ListField` in #1179.

The encoding/decoding was lifted up to be done when grouping fields in `encodeQueryGroup`/`decodeQueryGroup`, to take effect on all fields.