### PR TITLE
fix: skip decoding non-ascii characters

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **FIX**: Changed behavior for handle non-ASCII characters (e.g. Russian symbols, commas, colons etc)
 - **FIX**: Encode all fields values to allow reserved characters (e.g. commas, colons and curly brackets). ([#1214](https://github.com/widgetbook/widgetbook/pull/1214))
 
 ## 3.8.1

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **FIX**: Changed behavior for handle non-ASCII characters (e.g. Russian symbols, commas, colons etc)
+- **FIX**: Skip decoding non-ascii characters in URLs. ([#1218](https://github.com/widgetbook/widgetbook/pull/1218) - by [@shigomany](https://github.com/shigomany))
 - **FIX**: Encode all fields values to allow reserved characters (e.g. commas, colons and curly brackets). ([#1214](https://github.com/widgetbook/widgetbook/pull/1214))
 
 ## 3.8.1

--- a/packages/widgetbook/lib/src/fields/field_codec.dart
+++ b/packages/widgetbook/lib/src/fields/field_codec.dart
@@ -39,9 +39,8 @@ class FieldCodec<T> {
     return '{${pairs.join(',')}}';
   }
 
-  /// Tring to decode [component] if possible.
-  ///
-  /// If not possible returned null.
+  /// Decodes [component] using [Uri.decodeComponent],
+  /// but returns null if the decoding fails due to non-ASCII characters.
   static String? tryDecodeComponent(String component) {
     try {
       return Uri.decodeComponent(component);

--- a/packages/widgetbook/lib/src/fields/field_codec.dart
+++ b/packages/widgetbook/lib/src/fields/field_codec.dart
@@ -39,6 +39,17 @@ class FieldCodec<T> {
     return '{${pairs.join(',')}}';
   }
 
+  /// Tring to decode [component] if possible.
+  ///
+  /// If not possible returned null.
+  static String? tryDecodeComponent(String component) {
+    try {
+      return Uri.decodeComponent(component);
+    } on ArgumentError {
+      return null;
+    }
+  }
+
   /// Decodes a query group encoded value back to a [Map].
   static Map<String, String> decodeQueryGroup(String? group) {
     if (group == null || group == '{}') return {};
@@ -49,10 +60,10 @@ class FieldCodec<T> {
       params.map(
         (param) {
           final parts = param.split(':');
-          final decodedKey = Uri.decodeComponent(parts[0]);
-          final decodedValue = Uri.decodeComponent(parts[1]);
+          final decodedKey = tryDecodeComponent(parts[0]);
+          final decodedValue = tryDecodeComponent(parts[1]);
 
-          return MapEntry(decodedKey, decodedValue);
+          return MapEntry(decodedKey ?? parts[0], decodedValue ?? parts[1]);
         },
       ),
     );

--- a/packages/widgetbook/test/src/routing/non_ascii_chars_test.dart
+++ b/packages/widgetbook/test/src/routing/non_ascii_chars_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/src/routing/routing.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import '../../helper/helper.dart';
+
+void main() {
+  group(
+    '$AppRouteConfig for non-ascii characters',
+    () {
+      testWidgets(
+        'given query parameter in URL address '
+        'when query contains encoded special characters like: ` `, `,` etc. '
+        'then this query string should decode',
+        (tester) async {
+          final state = await tester.pumpWidgetWithQueryParams(
+            queryParams: {},
+            builder: (context) => const SizedBox(),
+          );
+          final targetQuery = '{Test: %20 non-ascii}';
+          final config = AppRouteConfig(
+            uri: Uri.parse('/?knob=$targetQuery'),
+          );
+
+          state.updateFromRouteConfig(config);
+          expect(
+            state.queryParams['knob'].toString(),
+            equals(
+              targetQuery.replaceAll('%20', ' '),
+            ),
+          );
+        },
+      );
+
+      testWidgets(
+        'given non-ASCII characters in URL'
+        'then the application is open without decoding',
+        (tester) async {
+          const textKey = Key('knob-string-field');
+          const keyOfData = 'Тест field';
+          const valueOfData = 'значение';
+          final state = await tester.pumpWidgetWithQueryParams(
+            queryParams: {},
+            builder: (context) {
+              final text = context.knobs.string(
+                label: keyOfData,
+              );
+              return Text('$text', key: textKey);
+            },
+          );
+          await tester.pumpAndSettle();
+
+          // Checking not initialized field
+          final emptyTextWidget =
+              await tester.widget<Text>(find.byKey(textKey));
+          expect(emptyTextWidget.data, '');
+
+          // Simulate as opened URL via broweser.
+          state.updateFromRouteConfig(
+            AppRouteConfig(
+              uri: state.uri.replace(
+                queryParameters: {
+                  'knobs': '{$keyOfData:$valueOfData}',
+                },
+              ),
+            ),
+          );
+
+          await tester.pumpAndSettle();
+
+          final actualTextWidget =
+              await tester.widget<Text>(find.byKey(textKey));
+          expect(actualTextWidget.data, valueOfData);
+        },
+      );
+
+      testWidgets(
+        'given non-ASCII characters and special charater (`,`) in URL'
+        'then captured error bacause URL\'s characters are invalid',
+        (tester) async {
+          final binding = TestWidgetsFlutterBinding.ensureInitialized();
+          const textKey = Key('knob-string-field');
+          const keyOfData = 'text field';
+          const escapedCharacters = ',,,';
+          const valueOfData = 'value ';
+
+          final state = await tester.pumpWidgetWithQueryParams(
+            queryParams: {},
+            builder: (context) {
+              final text = context.knobs.string(
+                label: keyOfData,
+              );
+              return Text('$text', key: textKey);
+            },
+          );
+          await tester.pumpAndSettle();
+          // Checking for not initialized field
+          final emptyTextWidget =
+              await tester.widget<Text>(find.byKey(textKey));
+          expect(emptyTextWidget.data, '');
+
+          // Simulate as opened URL via broweser.
+          state.updateFromRouteConfig(
+            AppRouteConfig(
+              uri: state.uri.replace(
+                queryParameters: {
+                  'knobs': '{$keyOfData:$valueOfData$escapedCharacters}',
+                },
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+          final error = binding.takeException();
+          expect(error, isRangeError);
+        },
+      );
+    },
+  );
+}

--- a/packages/widgetbook/test/src/routing/non_ascii_chars_test.dart
+++ b/packages/widgetbook/test/src/routing/non_ascii_chars_test.dart
@@ -10,8 +10,8 @@ void main() {
     '$AppRouteConfig for non-ascii characters',
     () {
       testWidgets(
-        'given query parameter in URL address '
-        'when query contains encoded special characters like: ` `, `,` etc. '
+        'given query parameter in URL address, '
+        'when query contains encoded special characters like: ` `, `,` etc., '
         'then this query string should decode',
         (tester) async {
           final state = await tester.pumpWidgetWithQueryParams(
@@ -34,7 +34,7 @@ void main() {
       );
 
       testWidgets(
-        'given non-ASCII characters in URL'
+        'given non-ASCII characters in URL, '
         'then the application is open without decoding',
         (tester) async {
           const textKey = Key('knob-string-field');
@@ -46,17 +46,23 @@ void main() {
               final text = context.knobs.string(
                 label: keyOfData,
               );
-              return Text('$text', key: textKey);
+              return Text(
+                '$text',
+                key: textKey,
+              );
             },
           );
+
           await tester.pumpAndSettle();
 
           // Checking not initialized field
-          final emptyTextWidget =
-              await tester.widget<Text>(find.byKey(textKey));
+          final emptyTextWidget = await tester.widget<Text>(
+            find.byKey(textKey),
+          );
+
           expect(emptyTextWidget.data, '');
 
-          // Simulate as opened URL via broweser.
+          // Simulate as opened URL via browser.
           state.updateFromRouteConfig(
             AppRouteConfig(
               uri: state.uri.replace(
@@ -69,15 +75,17 @@ void main() {
 
           await tester.pumpAndSettle();
 
-          final actualTextWidget =
-              await tester.widget<Text>(find.byKey(textKey));
+          final actualTextWidget = await tester.widget<Text>(
+            find.byKey(textKey),
+          );
+
           expect(actualTextWidget.data, valueOfData);
         },
       );
 
       testWidgets(
-        'given non-ASCII characters and special charater (`,`) in URL'
-        'then captured error bacause URL\'s characters are invalid',
+        'given non-ASCII characters and special charter (`,`) in URL, '
+        'then captured error because URL\'s characters are invalid',
         (tester) async {
           final binding = TestWidgetsFlutterBinding.ensureInitialized();
           const textKey = Key('knob-string-field');
@@ -91,16 +99,21 @@ void main() {
               final text = context.knobs.string(
                 label: keyOfData,
               );
-              return Text('$text', key: textKey);
+              return Text(
+                '$text',
+                key: textKey,
+              );
             },
           );
           await tester.pumpAndSettle();
+
           // Checking for not initialized field
-          final emptyTextWidget =
-              await tester.widget<Text>(find.byKey(textKey));
+          final emptyTextWidget = await tester.widget<Text>(
+            find.byKey(textKey),
+          );
           expect(emptyTextWidget.data, '');
 
-          // Simulate as opened URL via broweser.
+          // Simulate as opened URL via browser
           state.updateFromRouteConfig(
             AppRouteConfig(
               uri: state.uri.replace(
@@ -110,6 +123,7 @@ void main() {
               ),
             ),
           );
+
           await tester.pumpAndSettle();
           final error = binding.takeException();
           expect(error, isRangeError);


### PR DESCRIPTION
When url with non-ascii symbols opened it gave error for twice parsed url.

For example (sandbox app):

If i will open URL
http://localhost:{port}/#/?path=settings/nullablesetting/default&knobs={Description:%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82} or http://localhost:{port}/#/?path=settings/nullablesetting/default&knobs={%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82:asciiword} (first option non-ascii used as value, in second option as key)
in browser i will get this error on screenshot.

This happens for severl reasons:

In router information already exist Uri decoded query parameters.
For string_field.dart method Uri.decodeComponent called twice.

### List of issues which are fixed by the PR
*You must list at least one issue.*

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
