### PR TITLE
feat: allow custom theming

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **FIX**: Skip decoding non-ascii characters in URLs. ([#1218](https://github.com/widgetbook/widgetbook/pull/1218) - by [@shigomany](https://github.com/shigomany))
 - **FIX**: Encode all fields values to allow reserved characters (e.g. commas, colons and curly brackets). ([#1214](https://github.com/widgetbook/widgetbook/pull/1214))
+- **Feat**: Allow custom theming/personalization of widgetbook. ([#1225](https://github.com/widgetbook/widgetbook/pull/1225))
 
 ## 3.8.1
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - **FIX**: Skip decoding non-ascii characters in URLs. ([#1218](https://github.com/widgetbook/widgetbook/pull/1218) - by [@shigomany](https://github.com/shigomany))
 - **FIX**: Encode all fields values to allow reserved characters (e.g. commas, colons and curly brackets). ([#1214](https://github.com/widgetbook/widgetbook/pull/1214))
-- **Feat**: Allow custom theming/personalization of widgetbook. ([#1225](https://github.com/widgetbook/widgetbook/pull/1225))
+- **FEAT**: Allow changing Widgetbook's theme and mode. ([#1225](https://github.com/widgetbook/widgetbook/pull/1225) - by [@Mastersam07](https://github.com/Mastersam07))
 
 ## 3.8.1
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Unreleased
 
+- **FEAT**: Allow changing Widgetbook's theme and mode. ([#1225](https://github.com/widgetbook/widgetbook/pull/1225) - by [@Mastersam07](https://github.com/Mastersam07))
 - **FIX**: Skip decoding non-ascii characters in URLs. ([#1218](https://github.com/widgetbook/widgetbook/pull/1218) - by [@shigomany](https://github.com/shigomany))
 - **FIX**: Encode all fields values to allow reserved characters (e.g. commas, colons and curly brackets). ([#1214](https://github.com/widgetbook/widgetbook/pull/1214))
-- **FEAT**: Allow changing Widgetbook's theme and mode. ([#1225](https://github.com/widgetbook/widgetbook/pull/1225) - by [@Mastersam07](https://github.com/Mastersam07))
 
 ## 3.8.1
 

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -25,6 +25,8 @@ class Widgetbook extends StatefulWidget {
     this.appBuilder = widgetsAppBuilder,
     this.addons,
     this.integrations,
+    this.lightTheme,
+    this.darkTheme,
   });
 
   /// A [Widgetbook] with [CupertinoApp] as an [appBuilder].
@@ -35,6 +37,8 @@ class Widgetbook extends StatefulWidget {
     this.appBuilder = cupertinoAppBuilder,
     this.addons,
     this.integrations,
+    this.lightTheme,
+    this.darkTheme,
   });
 
   /// A [Widgetbook] with [MaterialApp] as an [appBuilder].
@@ -45,6 +49,8 @@ class Widgetbook extends StatefulWidget {
     this.appBuilder = materialAppBuilder,
     this.addons,
     this.integrations,
+    this.lightTheme,
+    this.darkTheme,
   });
 
   /// The initial route for that will be used on first startup.
@@ -70,6 +76,16 @@ class Widgetbook extends StatefulWidget {
   /// integrate with Widgetbook Cloud via [WidgetbookCloudIntegration], but
   /// can also be used to integrate with third-party packages.
   final List<WidgetbookIntegration>? integrations;
+
+  /// The custom theme for the Widgetbook interface when using light mode.
+  ///
+  /// This theme will override the default light theme provided by Widgetbook.
+  final ThemeData? lightTheme;
+
+  /// The custom theme for the Widgetbook interface when using dark mode.
+  ///
+  /// This theme will override the default dark theme provided by Widgetbook.
+  final ThemeData? darkTheme;
 
   @override
   State<Widgetbook> createState() => _WidgetbookState();
@@ -110,8 +126,8 @@ class _WidgetbookState extends State<Widgetbook> {
       state: state,
       child: MaterialApp.router(
         title: 'Widgetbook',
-        theme: Themes.light,
-        darkTheme: Themes.dark,
+        theme: widget.lightTheme ?? Themes.light,
+        darkTheme: widget.darkTheme ?? Themes.dark,
         routerConfig: router,
         debugShowCheckedModeBanner: false,
       ),

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -27,6 +27,7 @@ class Widgetbook extends StatefulWidget {
     this.integrations,
     this.lightTheme,
     this.darkTheme,
+    this.themeMode,
   });
 
   /// A [Widgetbook] with [CupertinoApp] as an [appBuilder].
@@ -39,6 +40,7 @@ class Widgetbook extends StatefulWidget {
     this.integrations,
     this.lightTheme,
     this.darkTheme,
+    this.themeMode,
   });
 
   /// A [Widgetbook] with [MaterialApp] as an [appBuilder].
@@ -51,6 +53,7 @@ class Widgetbook extends StatefulWidget {
     this.integrations,
     this.lightTheme,
     this.darkTheme,
+    this.themeMode,
   });
 
   /// The initial route for that will be used on first startup.
@@ -86,6 +89,12 @@ class Widgetbook extends StatefulWidget {
   ///
   /// This theme will override the default dark theme provided by Widgetbook.
   final ThemeData? darkTheme;
+
+  /// The theme mode to be applied to the Widgetbook application.
+  ///
+  /// This parameter allows you to set the theme to light, dark, or follow the system setting.
+  /// By default, it follows the system theme.
+  final ThemeMode? themeMode;
 
   @override
   State<Widgetbook> createState() => _WidgetbookState();
@@ -126,6 +135,7 @@ class _WidgetbookState extends State<Widgetbook> {
       state: state,
       child: MaterialApp.router(
         title: 'Widgetbook',
+        themeMode: widget.themeMode ?? ThemeMode.system,
         theme: widget.lightTheme ?? Themes.light,
         darkTheme: widget.darkTheme ?? Themes.dark,
         routerConfig: router,


### PR DESCRIPTION
Today, widgetbook uses [constant predefined theme](https://github.com/widgetbook/widgetbook/blob/f65e24018ca3f2afdeda2aae19744f7fd32c001d/packages/widgetbook/lib/src/widgetbook.dart#L113-L114) which means one can't personalize widgetbook.

This PR aims to allow customisation of Widgetbook's theme.

### List of issues which are fixed by the PR
Closes #1183 

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
