### PR TITLE
refactor(cli): upload files directly to storage

### DIFF
--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **REFACTOR**: Upload build files directly to storage, bypassing Widgetbook Cloud's server. This enhancement ensures that builds are instantly available on Widgetbook Cloud upon completion of the `cloud build push` command, eliminating the need for additional processing. ([#1229](https://github.com/widgetbook/widgetbook/pull/1229))
+
 ## 3.1.1
 
 - **FIX**: Reject builds without use-cases. ([#1213](https://github.com/widgetbook/widgetbook/pull/1213))

--- a/packages/widgetbook_cli/lib/src/api/api.dart
+++ b/packages/widgetbook_cli/lib/src/api/api.dart
@@ -1,3 +1,7 @@
+export 'models/build_draft_request.dart';
+export 'models/build_draft_response.dart';
+export 'models/build_ready_request.dart';
+export 'models/build_ready_response.dart';
 export 'models/build_request.dart';
 export 'models/build_response.dart';
 export 'models/upload_task.dart';

--- a/packages/widgetbook_cli/lib/src/api/models/build_draft_request.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/build_draft_request.dart
@@ -9,6 +9,7 @@ class BuildDraftRequest {
     required this.branch,
     required this.sha,
     required this.useCases,
+    required this.files,
   });
 
   final String apiKey;
@@ -18,6 +19,7 @@ class BuildDraftRequest {
   final String branch;
   final String sha;
   final List<UseCaseMetadata> useCases;
+  final Map<String, int> files;
 
   Map<String, dynamic> toJson() {
     return {
@@ -28,6 +30,7 @@ class BuildDraftRequest {
       'branch': branch,
       'sha': sha,
       'useCases': useCases.map((x) => x.toJson()).toList(),
+      'files': files,
     };
   }
 }

--- a/packages/widgetbook_cli/lib/src/api/models/build_draft_response.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/build_draft_response.dart
@@ -1,16 +1,19 @@
 class BuildDraftResponse {
   const BuildDraftResponse({
     required this.buildId,
+    required this.baseHref,
     required this.urls,
   });
 
   final String buildId;
+  final String baseHref;
   final Map<String, String> urls;
 
   // ignore: sort_constructors_first
   factory BuildDraftResponse.fromJson(Map<String, dynamic> json) {
     return BuildDraftResponse(
       buildId: json['buildId'] as String,
+      baseHref: json['baseHref'] as String,
       urls: Map<String, String>.from(json['urls'] as Map),
     );
   }

--- a/packages/widgetbook_cli/lib/src/api/models/build_draft_response.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/build_draft_response.dart
@@ -1,17 +1,17 @@
 class BuildDraftResponse {
   const BuildDraftResponse({
     required this.buildId,
-    required this.storageUrl,
+    required this.urls,
   });
 
   final String buildId;
-  final String storageUrl;
+  final Map<String, String> urls;
 
   // ignore: sort_constructors_first
   factory BuildDraftResponse.fromJson(Map<String, dynamic> json) {
     return BuildDraftResponse(
       buildId: json['buildId'] as String,
-      storageUrl: json['storageUrl'] as String,
+      urls: Map<String, String>.from(json['urls'] as Map),
     );
   }
 }

--- a/packages/widgetbook_cli/lib/src/api/storage_client.dart
+++ b/packages/widgetbook_cli/lib/src/api/storage_client.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:file/file.dart';
+import 'package:mime/mime.dart';
+import 'package:pool/pool.dart';
+import 'package:retry/retry.dart';
+
+/// HTTP client to connect to the Widgetbook Cloud Storage
+class StorageClient {
+  StorageClient({
+    Dio? client,
+  }) : client = client ?? Dio();
+
+  final Dio client;
+
+  Future<void> uploadFiles(
+    Map<File, String> files,
+  ) async {
+    // The files count can reach up to 20K, posting all of them concurrently
+    // can lead to going beyond the rate limit of the server. That's why we
+    // limit the number of concurrent requests using a pool.
+    final pool = Pool(
+      1000,
+      timeout: const Duration(
+        seconds: 30,
+      ),
+    );
+
+    final promises = files.entries.map((entry) async {
+      return retry(
+        maxAttempts: 3,
+        () => pool.withResource(
+          () => _uploadFile(entry.key, entry.value),
+        ),
+      );
+    });
+
+    await Future.wait(
+      promises,
+      eagerError: true,
+    );
+  }
+
+  Future<Response<void>> _uploadFile(
+    File file,
+    String url,
+  ) async {
+    final mimeType = lookupMimeType(file.path) ?? 'application/octet-stream';
+    final fileSize = file.statSync().size;
+
+    return client.put<void>(
+      url,
+      data: file.openRead(),
+      options: Options(
+        headers: {
+          HttpHeaders.contentTypeHeader: mimeType,
+          HttpHeaders.contentLengthHeader: fileSize,
+        },
+      ),
+    );
+  }
+}

--- a/packages/widgetbook_cli/lib/src/api/widgetbook_http_client.dart
+++ b/packages/widgetbook_cli/lib/src/api/widgetbook_http_client.dart
@@ -1,7 +1,4 @@
-import 'dart:io';
-
 import 'package:dio/dio.dart';
-import 'package:file/file.dart';
 
 import '../core/core.dart';
 import '../utils/utils.dart';
@@ -61,7 +58,7 @@ class WidgetbookHttpClient {
   ) async {
     try {
       final response = await client.post<Map<String, dynamic>>(
-        'v1.5/builds/draft',
+        'v2/builds/draft',
         data: request.toJson(),
         options: Options(
           headers: versions?.toHeaders(),
@@ -85,7 +82,7 @@ class WidgetbookHttpClient {
   ) async {
     try {
       final response = await client.post<Map<String, dynamic>>(
-        'v1.5/builds/submit',
+        'v2/builds/submit',
         data: request.toJson(),
       );
 
@@ -99,19 +96,5 @@ class WidgetbookHttpClient {
         message: message,
       );
     }
-  }
-
-  Future<void> uploadBuildFile(String signedUrl, File zipFile) {
-    // File name must match the name in the signed URL
-    return client.put<void>(
-      signedUrl,
-      data: zipFile.openRead(),
-      options: Options(
-        headers: {
-          HttpHeaders.contentTypeHeader: 'application/zip',
-          HttpHeaders.contentLengthHeader: zipFile.lengthSync(),
-        },
-      ),
-    );
   }
 }

--- a/packages/widgetbook_cli/lib/src/commands/build_push.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push.dart
@@ -180,24 +180,29 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
       (file) {
         final key = pathOf(file);
 
+        if (key != 'index.html') {
+          return StorageObject(
+            key: key,
+            url: buildDraft.urls[key]!,
+            size: filesSizeMap[key]!,
+            data: file.openRead(),
+          );
+        }
+
         // Modify index.html to include the correct base href
-        final data = key != 'index.html'
-            ? file.openRead()
-            : Stream.value(
-                file
-                    .readAsStringSync()
-                    .replaceFirst(
-                      RegExp('<base href=".*">'),
-                      '<base href="${buildDraft.baseHref}">',
-                    )
-                    .codeUnits,
-              );
+        final content = file.readAsStringSync();
+        final modifiedContent = content.replaceFirst(
+          RegExp('<base href=".*">'),
+          '<base href="${buildDraft.baseHref}">',
+        );
 
         return StorageObject(
           key: key,
           url: buildDraft.urls[key]!,
-          size: filesSizeMap[key]!,
-          data: data,
+          size: modifiedContent.length,
+          data: Stream.value(
+            modifiedContent.codeUnits,
+          ),
         );
       },
     );

--- a/packages/widgetbook_cli/lib/src/storage/storage.dart
+++ b/packages/widgetbook_cli/lib/src/storage/storage.dart
@@ -1,0 +1,2 @@
+export './storage_client.dart';
+export './storage_object.dart';

--- a/packages/widgetbook_cli/lib/src/storage/storage_object.dart
+++ b/packages/widgetbook_cli/lib/src/storage/storage_object.dart
@@ -1,0 +1,17 @@
+import 'package:mime/mime.dart';
+
+class StorageObject {
+  StorageObject({
+    required this.key,
+    required this.url,
+    required this.size,
+    required this.data,
+  });
+
+  final String key;
+  final String url;
+  final int size;
+  final Stream<List<int>> data;
+
+  String get mimeType => lookupMimeType(key) ?? 'application/octet-stream';
+}

--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   http_parser: ^4.0.1
   mason_logger: ^0.2.5
   meta: ^1.8.0
-  mime: ^1.0.5
+  mime: ^1.0.4
   path: ^1.8.2
   platform: ^3.0.0
   pool: ^1.5.1

--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -24,10 +24,13 @@ dependencies:
   http_parser: ^4.0.1
   mason_logger: ^0.2.5
   meta: ^1.8.0
+  mime: ^1.0.5
   path: ^1.8.2
   platform: ^3.0.0
+  pool: ^1.5.1
   process: ^5.0.0
   pub_updater: ^0.4.0
+  retry: ^3.1.2
   version: ^3.0.2
   yaml: ^3.1.2
 


### PR DESCRIPTION
Directly upload build files to storage, bypassing Widgetbook Cloud's server. This enhancement ensures that builds are instantly available on Widgetbook Cloud upon completion of the `cloud build push` command, eliminating the need for additional processing.