### PR TITLE
refactor(cli): reduce build draft payload size

### DIFF
--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **REFACTOR**: Speed up the creation of build drafts, by reducing the payload size. ([#1232](https://github.com/widgetbook/widgetbook/pull/1232))
+
 ## 3.2.0
 
 - **REFACTOR**: Upload build files directly to storage, bypassing Widgetbook Cloud's server. This enhancement ensures that builds are instantly available on Widgetbook Cloud upon completion of the `cloud build push` command, eliminating the need for additional processing. ([#1229](https://github.com/widgetbook/widgetbook/pull/1229))

--- a/packages/widgetbook_cli/lib/src/api/models/build_draft_request.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/build_draft_request.dart
@@ -9,7 +9,7 @@ class BuildDraftRequest {
     required this.branch,
     required this.sha,
     required this.useCases,
-    required this.files,
+    required this.size,
   });
 
   final String apiKey;
@@ -19,7 +19,7 @@ class BuildDraftRequest {
   final String branch;
   final String sha;
   final List<UseCaseMetadata> useCases;
-  final Map<String, int> files;
+  final int size;
 
   Map<String, dynamic> toJson() {
     return {
@@ -30,7 +30,7 @@ class BuildDraftRequest {
       'branch': branch,
       'sha': sha,
       'useCases': useCases.map((x) => x.toJson()).toList(),
-      'files': files,
+      'size': size,
     };
   }
 }

--- a/packages/widgetbook_cli/lib/src/api/models/build_draft_response.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/build_draft_response.dart
@@ -2,19 +2,37 @@ class BuildDraftResponse {
   const BuildDraftResponse({
     required this.buildId,
     required this.baseHref,
-    required this.urls,
+    required this.storage,
   });
 
   final String buildId;
   final String baseHref;
-  final Map<String, String> urls;
+  final StorageInfo storage;
 
   // ignore: sort_constructors_first
   factory BuildDraftResponse.fromJson(Map<String, dynamic> json) {
     return BuildDraftResponse(
       buildId: json['buildId'] as String,
       baseHref: json['baseHref'] as String,
-      urls: Map<String, String>.from(json['urls'] as Map),
+      storage: StorageInfo.fromJson(json['storage'] as Map<String, dynamic>),
+    );
+  }
+}
+
+class StorageInfo {
+  const StorageInfo({
+    required this.url,
+    required this.fields,
+  });
+
+  final String url;
+  final Map<String, String> fields;
+
+  // ignore: sort_constructors_first
+  factory StorageInfo.fromJson(Map<String, dynamic> json) {
+    return StorageInfo(
+      url: json['url'] as String,
+      fields: Map<String, String>.from(json['fields'] as Map),
     );
   }
 }

--- a/packages/widgetbook_cli/lib/src/storage/storage_client.dart
+++ b/packages/widgetbook_cli/lib/src/storage/storage_client.dart
@@ -23,7 +23,7 @@ class StorageClient {
     // can lead to going beyond the rate limit of the server. That's why we
     // limit the number of concurrent requests using a pool.
     final pool = Pool(
-      1000,
+      500,
       timeout: const Duration(
         seconds: 30,
       ),

--- a/packages/widgetbook_cli/lib/src/storage/storage_object.dart
+++ b/packages/widgetbook_cli/lib/src/storage/storage_object.dart
@@ -3,13 +3,11 @@ import 'package:mime/mime.dart';
 class StorageObject {
   StorageObject({
     required this.key,
-    required this.url,
     required this.size,
     required this.data,
   });
 
   final String key;
-  final String url;
   final int size;
   final Stream<List<int>> data;
 

--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   args: ^2.3.0
   ci: ^0.1.0
   collection: ^1.15.0
-  dio: ^5.2.0
+  dio: ^5.6.0
   file: ^7.0.0
   http_parser: ^4.0.1
   mason_logger: ^0.2.5


### PR DESCRIPTION
The `build push` command used to send a map of all the files paths and their sizes to the server, then receive a map with files paths and their urls. 

This approach was memory/time consuming on our server when the build had a lot of files. The server will now only send 1 URL back, that can be re-used among all files.