### PR TITLE
fix: remove default value for `listOrNull` knob

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **FEAT**: Allow changing Widgetbook's theme and mode. ([#1225](https://github.com/widgetbook/widgetbook/pull/1225) - by [@Mastersam07](https://github.com/Mastersam07))
 - **FIX**: Skip decoding non-ascii characters in URLs. ([#1218](https://github.com/widgetbook/widgetbook/pull/1218) - by [@shigomany](https://github.com/shigomany))
 - **FIX**: Encode all fields values to allow reserved characters (e.g. commas, colons and curly brackets). ([#1214](https://github.com/widgetbook/widgetbook/pull/1214))
+- **FIX**: Remove default value (i.e. first item) from `listOrNull` knob. ([#1233](https://github.com/widgetbook/widgetbook/pull/1233))
 
 ## 3.8.1
 

--- a/packages/widgetbook/lib/src/fields/list_field.dart
+++ b/packages/widgetbook/lib/src/fields/list_field.dart
@@ -37,7 +37,7 @@ class ListField<T> extends Field<T> {
     return DropdownMenu<T>(
       trailingIcon: const Icon(Icons.keyboard_arrow_down_rounded),
       selectedTrailingIcon: const Icon(Icons.keyboard_arrow_up_rounded),
-      initialSelection: value ?? values.first,
+      initialSelection: value,
       onSelected: (value) {
         if (value != null) {
           updateField(context, group, value);

--- a/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
@@ -158,11 +158,10 @@ class KnobsBuilder {
     String? description,
     LabelBuilder<T?>? labelBuilder,
   }) {
-    assert(options.isNotEmpty, 'Must specify at least one option');
     return onKnobAdded(
       ListKnob<T?>.nullable(
         label: label,
-        initialValue: initialOption ?? options.first,
+        initialValue: initialOption,
         description: description,
         options: options,
         labelBuilder: labelBuilder,

--- a/packages/widgetbook/test/src/knobs/list_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/list_knob_test.dart
@@ -61,8 +61,8 @@ void main() {
     '$ListKnob.nullable',
     () {
       testWidgets(
-        'when field is updated, '
-        'then the value should be updated',
+        'when no initial value is provided, '
+        'then a null value is returned',
         (tester) async {
           await tester.pumpKnob(
             (context) => Text(
@@ -70,6 +70,39 @@ void main() {
                 label: 'Knob',
                 options: ['A', 'B', 'C'],
               ).toString(),
+            ),
+          );
+
+          final menu = tester.widget<DropdownMenu<String?>>(
+            find.byType(DropdownMenu<String?>),
+          );
+
+          // DropdownMenu has no initialSelection as
+          // no initial value is provided
+          expect(
+            menu.initialSelection,
+            isNull,
+          );
+          expect(
+            find.text('null'),
+            findsOneWidget,
+          );
+        },
+      );
+
+      testWidgets(
+        'when field is updated, '
+        'then the value should be updated',
+        (tester) async {
+          await tester.pumpKnob(
+            (context) => Text(
+              context.knobs
+                  .listOrNull(
+                    label: 'Knob',
+                    options: ['A', 'B', 'C'],
+                    initialOption: 'A',
+                  )
+                  .toString(),
             ),
           );
 
@@ -90,16 +123,14 @@ void main() {
         (tester) async {
           await tester.pumpKnob(
             (context) => Text(
-              context.knobs.listOrNull(
-                label: 'Knob',
-                options: ['A', 'B', 'C'],
-              ).toString(),
+              context.knobs
+                  .listOrNull(
+                    label: 'Knob',
+                    options: ['A', 'B', 'C'],
+                    initialOption: 'A',
+                  )
+                  .toString(),
             ),
-          );
-
-          expect(
-            find.textWidget('A'),
-            findsNWidgets(2),
           );
 
           const value = 'C';


### PR DESCRIPTION
Remove the default value, _which was the first item in `options`_, for the `listOrNull` knob.