### PR TITLE
fix(cli): open streams on upload

### DIFF
--- a/packages/widgetbook_cli/lib/src/commands/build_push.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push.dart
@@ -183,7 +183,7 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
           return StorageObject(
             key: key,
             size: file.statSync().size,
-            data: file.openRead(),
+            reader: file.openRead,
           );
         }
 
@@ -197,7 +197,7 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
         return StorageObject(
           key: key,
           size: modifiedContent.length,
-          data: Stream.value(
+          reader: () => Stream.value(
             modifiedContent.codeUnits,
           ),
         );

--- a/packages/widgetbook_cli/lib/src/storage/storage_client.dart
+++ b/packages/widgetbook_cli/lib/src/storage/storage_client.dart
@@ -61,7 +61,7 @@ class StorageClient {
         ...fields,
         'key': fileKey,
         'file': MultipartFile.fromStream(
-          () => object.data,
+          () => object.reader(),
           object.size,
           filename: fileKey,
           contentType: DioMediaType.parse(object.mimeType),

--- a/packages/widgetbook_cli/lib/src/storage/storage_object.dart
+++ b/packages/widgetbook_cli/lib/src/storage/storage_object.dart
@@ -4,12 +4,12 @@ class StorageObject {
   StorageObject({
     required this.key,
     required this.size,
-    required this.data,
+    required this.reader,
   });
 
   final String key;
   final int size;
-  final Stream<List<int>> data;
+  final Stream<List<int>> Function() reader;
 
   String get mimeType => lookupMimeType(key) ?? 'application/octet-stream';
 }


### PR DESCRIPTION
Reading all the `StorageObject` at once was causing issues due to a lot of concurrent open files. The implementation is adjusted to delay reading the steam only when needed in the `_uploadObject(...)` function.