### PR TITLE
chore: add `analysis_options.yaml` to all packages

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,37 +1,40 @@
-include: package:very_good_analysis/analysis_options.yaml
-
 analyzer:
   language:
     strict-casts: true
     strict-inference: true
     strict-raw-types: true
+  exclude:
+    - "**/*.g.dart"
+    - "**/*.book.dart"
 
 linter:
   rules:
     # Constructors
-    - sort_unnamed_constructors_first
-    - sort_constructors_first
-    - prefer_const_constructors
-    - use_key_in_widget_constructors
+    sort_unnamed_constructors_first: true
+    sort_constructors_first: true
+    prefer_const_constructors: true
+    use_key_in_widget_constructors: true
 
     # Imports
-    - prefer_relative_imports
-    - directives_ordering
-    - combinators_ordering
-    - depend_on_referenced_packages
-    - avoid_web_libraries_in_flutter
+    prefer_relative_imports: true
+    directives_ordering: true
+    combinators_ordering: true
+    depend_on_referenced_packages: true
+    avoid_web_libraries_in_flutter: true
+    implementation_imports: true
 
     # Dependencies
-    - sort_pub_dependencies
+    sort_pub_dependencies: true
 
     # Style
-    - prefer_single_quotes
-    - require_trailing_commas
-    - noop_primitive_operations
-    - use_super_parameters
-    - avoid_redundant_argument_values
-    - avoid_renaming_method_parameters
+    prefer_single_quotes: true
+    require_trailing_commas: true
+    noop_primitive_operations: true
+    use_super_parameters: true
+    avoid_redundant_argument_values: true
+    avoid_renaming_method_parameters: true
 
     # Types
-    - unrelated_type_equality_checks
-    - avoid_types_on_closure_parameters
+    unrelated_type_equality_checks: true
+    avoid_types_on_closure_parameters: true
+    omit_local_variable_types: true

--- a/examples/full_example/analysis_options.yaml
+++ b/examples/full_example/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options.yaml

--- a/examples/knobs_example/analysis_options.yaml
+++ b/examples/knobs_example/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options.yaml

--- a/examples/monorepo_example/apps/admin_app/analysis_options.yaml
+++ b/examples/monorepo_example/apps/admin_app/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../../../analysis_options.yaml

--- a/examples/monorepo_example/apps/main_app/analysis_options.yaml
+++ b/examples/monorepo_example/apps/main_app/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../../../analysis_options.yaml

--- a/examples/monorepo_example/packages/shared_ui/analysis_options.yaml
+++ b/examples/monorepo_example/packages/shared_ui/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../../../analysis_options.yaml

--- a/examples/monorepo_example/widgetbook/analysis_options.yaml
+++ b/examples/monorepo_example/widgetbook/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../../analysis_options.yaml

--- a/examples/screen_util_example/analysis_options.yaml
+++ b/examples/screen_util_example/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options.yaml

--- a/packages/widgetbook/analysis_options.yaml
+++ b/packages/widgetbook/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options.yaml

--- a/packages/widgetbook/test/src/fields/duration_field_test.dart
+++ b/packages/widgetbook/test/src/fields/duration_field_test.dart
@@ -76,7 +76,7 @@ void main() {
   });
 
   group('Duration Codec', () {
-    final FieldCodec<Duration> codec = FieldCodec<Duration>(
+    final codec = FieldCodec<Duration>(
       toParam: (duration) => duration.inMilliseconds.toString(),
       toValue: (param) {
         if (param == null) return null;

--- a/packages/widgetbook_annotation/analysis_options.yaml
+++ b/packages/widgetbook_annotation/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options.yaml

--- a/packages/widgetbook_cli/analysis_options.yaml
+++ b/packages/widgetbook_cli/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options.yaml

--- a/packages/widgetbook_cli/lib/src/commands/cloud.dart
+++ b/packages/widgetbook_cli/lib/src/commands/cloud.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:args/src/arg_results.dart';
+import 'package:args/args.dart';
 
 import '../core/core.dart';
 import 'build_push.dart';

--- a/packages/widgetbook_cli/lib/src/commands/upgrade.dart
+++ b/packages/widgetbook_cli/lib/src/commands/upgrade.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:args/src/arg_results.dart';
+import 'package:args/args.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:pub_updater/pub_updater.dart';
 

--- a/packages/widgetbook_generator/analysis_options.yaml
+++ b/packages/widgetbook_generator/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options.yaml

--- a/packages/widgetbook_generator/test/helpers/code.dart
+++ b/packages/widgetbook_generator/test/helpers/code.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 
 /// Formats output with dart formatter.
 void useDartFormatter() {
-  final DartFormatter _formatter = DartFormatter();
+  final _formatter = DartFormatter();
 
   EqualsDart.format = (source) {
     try {

--- a/packages/widgetbook_test/analysis_options.yaml
+++ b/packages/widgetbook_test/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options.yaml

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -297,14 +297,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
-  very_good_analysis:
-    dependency: "direct dev"
-    description:
-      name: very_good_analysis
-      sha256: "9ae7f3a3bd5764fb021b335ca28a34f040cd0ab6eec00a1b213b445dae58a4b8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.1.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,4 +5,3 @@ environment:
 
 dev_dependencies:
   melos: ^6.0.0
-  very_good_analysis: ^5.0.0

--- a/sandbox/analysis_options.yaml
+++ b/sandbox/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: ../analysis_options.yaml
+
+linter:
+  rules:
+    # Allow imports from src files of `widgetbook` package
+    implementation_imports: false


### PR DESCRIPTION
Our old setup had only 1 `analysis_options.yaml` in the root of the repo, this file imported `very_good_analysis` package. Such setup wasn't working properly in all sub-folders, and a lot of rules were skipped.

We now have root `analysis_options.yaml` file in the root, but also an `analysis_options.yaml` file in each package/app that includes this root file.

The `very_good_analysis` packages was removed because it gives a warning in the sub-file.