### PR TITLE
deps(generator): remove `widgetbook` dependency

### DIFF
--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **REFACTOR**: Remove `widgetbook` dependency. ([#1242](https://github.com/widgetbook/widgetbook/pull/1242))
+
 ## 3.8.0
 
 - **FEAT**: Add new builder option named `nav_path_mode`, that allows using the navigation path of the use-case instead of the component. For more info, check out the [customization docs](https://docs.widgetbook.io/guides/customization#using-nav_path_mode-option). ([#1188](https://github.com/widgetbook/widgetbook/pull/1188))

--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
   meta: ^1.7.0
   path: ^1.8.0
   source_gen: ^1.1.0
-  widgetbook: ^3.7.0
   widgetbook_annotation: ^3.1.0
   yaml: ^3.1.1
 


### PR DESCRIPTION
The dependency was added #842 to enforce minimum `widgetbook` version with `widgetbook_generator`. This is no longer needed for new versions.

Such dependency affects our `widgetbook_generator` score, because it depends on a package that uses Flutter, while the generator itself doesn't use Flutter.