### PR TITLE
deps: bump sdk to 3 & flutter to 3.16

### DIFF
--- a/.github/workflows/widgetbook-annotation.yaml
+++ b/.github/workflows/widgetbook-annotation.yaml
@@ -17,4 +17,4 @@ jobs:
     uses: ./.github/workflows/_package.yml
     with:
       working_directory: packages/widgetbook_annotation
-      min_flutter_version: 3.7.0
+      min_flutter_version: 3.16.0

--- a/.github/workflows/widgetbook-generator.yaml
+++ b/.github/workflows/widgetbook-generator.yaml
@@ -17,4 +17,4 @@ jobs:
     uses: ./.github/workflows/_package.yml
     with:
       working_directory: packages/widgetbook_generator
-      min_flutter_version: 3.7.0
+      min_flutter_version: 3.16.0

--- a/.github/workflows/widgetbook.yaml
+++ b/.github/workflows/widgetbook.yaml
@@ -17,4 +17,4 @@ jobs:
     uses: ./.github/workflows/_package.yml
     with:
       working_directory: packages/widgetbook
-      min_flutter_version: 3.7.0
+      min_flutter_version: 3.16.0

--- a/examples/full_example/pubspec.lock
+++ b/examples/full_example/pubspec.lock
@@ -18,10 +18,10 @@ packages:
     dependency: transitive
     description:
       name: accessibility_tools
-      sha256: "0a16adc8dfa3a7ebd38775135d86443011a65d4ecbb438913e4992b5d29135fe"
+      sha256: deca88d9f181ad6fdd12df9c5fa952c763264da14336ca1c0e4124525725b174
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   analyzer:
     dependency: transitive
     description:

--- a/examples/knobs_example/pubspec.lock
+++ b/examples/knobs_example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: accessibility_tools
-      sha256: "0a16adc8dfa3a7ebd38775135d86443011a65d4ecbb438913e4992b5d29135fe"
+      sha256: deca88d9f181ad6fdd12df9c5fa952c763264da14336ca1c0e4124525725b174
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   async:
     dependency: transitive
     description:

--- a/examples/monorepo_example/widgetbook/pubspec.lock
+++ b/examples/monorepo_example/widgetbook/pubspec.lock
@@ -18,10 +18,10 @@ packages:
     dependency: transitive
     description:
       name: accessibility_tools
-      sha256: "0a16adc8dfa3a7ebd38775135d86443011a65d4ecbb438913e4992b5d29135fe"
+      sha256: deca88d9f181ad6fdd12df9c5fa952c763264da14336ca1c0e4124525725b174
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   analyzer:
     dependency: transitive
     description:

--- a/examples/screen_util_example/pubspec.lock
+++ b/examples/screen_util_example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: accessibility_tools
-      sha256: "0a16adc8dfa3a7ebd38775135d86443011a65d4ecbb438913e4992b5d29135fe"
+      sha256: deca88d9f181ad6fdd12df9c5fa952c763264da14336ca1c0e4124525725b174
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   async:
     dependency: transitive
     description:

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **BREAKING**: Set minimum SDK version to 3.0.0 & minimum Flutter version to 3.16.0. ([#1243](https://github.com/widgetbook/widgetbook/pull/1243))
 - **FEAT**: Allow changing Widgetbook's theme and mode. ([#1225](https://github.com/widgetbook/widgetbook/pull/1225) - by [@Mastersam07](https://github.com/Mastersam07))
 - **FIX**: Skip decoding non-ascii characters in URLs. ([#1218](https://github.com/widgetbook/widgetbook/pull/1218) - by [@shigomany](https://github.com/shigomany))
 - **FIX**: Encode all fields values to allow reserved characters (e.g. commas, colons and curly brackets). ([#1214](https://github.com/widgetbook/widgetbook/pull/1214))

--- a/packages/widgetbook/lib/src/routing/app_router_delegate.dart
+++ b/packages/widgetbook/lib/src/routing/app_router_delegate.dart
@@ -40,7 +40,7 @@ class AppRouterDelegate extends RouterDelegate<AppRouteConfig>
     return Navigator(
       key: navigatorKey,
       // The onPopPage parameter is deprecated after Flutter 3.16.0,
-      // But we cannot migrate it because our minimum version is 3.7.0.
+      // But we cannot migrate it because our minimum version is 3.16.0.
       // ignore: deprecated_member_use
       onPopPage: (route, result) => route.didPop(result),
       pages: [

--- a/packages/widgetbook/lib/src/themes.dart
+++ b/packages/widgetbook/lib/src/themes.dart
@@ -31,7 +31,7 @@ class Themes {
     surfaceTint: Color(0xFFA1C9FF),
 
     // The following parameters are deprecated in Flutter 3.22.0,
-    // But we cannot remove them because our minimum version is 3.7.0,
+    // But we cannot remove them because our minimum version is 3.16.0,
     // and these parameters are required there.
 
     // ignore: deprecated_member_use
@@ -71,7 +71,7 @@ class Themes {
     surfaceTint: Color(0xFF0060A7),
 
     // The following parameters are deprecated in Flutter 3.22.0,
-    // But we cannot remove them because our minimum version is 3.7.0,
+    // But we cannot remove them because our minimum version is 3.16.0,
     // and these parameters are required there.
 
     // ignore: deprecated_member_use
@@ -90,7 +90,7 @@ class Themes {
       isDense: true,
       // By default, this is [ColorScheme.surfaceContainerHighest], but we
       // need to override it to [ColorScheme.surfaceVariant] due to the minimum
-      // Flutter version being 3.7.0, which does not have the new parameter.
+      // Flutter version being 3.16.0, which does not have the new parameter.
       // ignore: deprecated_member_use
       fillColor: colorScheme.surfaceVariant,
       focusedBorder: OutlineInputBorder(
@@ -116,7 +116,7 @@ class Themes {
       overlayShape: SliderComponentShape.noThumb,
       // By default, this is [ColorScheme.surfaceContainerHighest], but we
       // need to override it to [ColorScheme.surfaceVariant] due to the minimum
-      // Flutter version being 3.7.0, which does not have the new parameter.
+      // Flutter version being 3.16.0, which does not have the new parameter.
       // ignore: deprecated_member_use
       inactiveTrackColor: _darkColorScheme.surfaceVariant,
     ),
@@ -140,7 +140,7 @@ class Themes {
       overlayShape: SliderComponentShape.noThumb,
       // By default, this is [ColorScheme.surfaceContainerHighest], but we
       // need to override it to [ColorScheme.surfaceVariant] due to the minimum
-      // Flutter version being 3.7.0, which does not have the new parameter.
+      // Flutter version being 3.16.0, which does not have the new parameter.
       // ignore: deprecated_member_use
       inactiveTrackColor: _lightColorScheme.surfaceVariant,
     ),

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -12,11 +12,11 @@ screenshots:
     path: assets/logo.png
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
-  flutter: ">=3.7.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.16.0"
 
 dependencies:
-  accessibility_tools: ">=0.2.0 <=1.0.0"
+  accessibility_tools: ">=0.2.0 <2.0.0"
   collection: ^1.15.0
   device_frame: ^1.1.0
   flutter:

--- a/packages/widgetbook_annotation/CHANGELOG.md
+++ b/packages/widgetbook_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **BREAKING**: Set minimum SDK version to 3.0.0. ([#1243](https://github.com/widgetbook/widgetbook/pull/1243))
+
 ## 3.1.0
 
 - **BREAKING**: Set minimum SDK version to 2.19.0. ([#1030](https://github.com/widgetbook/widgetbook/pull/1030))

--- a/packages/widgetbook_annotation/pubspec.yaml
+++ b/packages/widgetbook_annotation/pubspec.yaml
@@ -12,7 +12,7 @@ screenshots:
     path: assets/logo.png
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
   test: ^1.24.1

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- **BREAKING**: Set minimum SDK version to 3.0.0. ([#1243](https://github.com/widgetbook/widgetbook/pull/1243))
+- **BREAKING**: Drop `analyzer` 5.x support. ([#1243](https://github.com/widgetbook/widgetbook/pull/1243))
 - **REFACTOR**: Remove `widgetbook` dependency. ([#1242](https://github.com/widgetbook/widgetbook/pull/1242))
 
 ## 3.8.0

--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -12,10 +12,10 @@ screenshots:
     path: assets/logo.png
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=5.10.0 <7.0.0"
+  analyzer: ^6.0.0
   build: ^2.1.0
   code_builder: ^4.5.0
   collection: ^1.15.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: widgetbook_workspace
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
   melos: ^6.0.0

--- a/sandbox/pubspec.lock
+++ b/sandbox/pubspec.lock
@@ -18,10 +18,10 @@ packages:
     dependency: transitive
     description:
       name: accessibility_tools
-      sha256: "0a16adc8dfa3a7ebd38775135d86443011a65d4ecbb438913e4992b5d29135fe"
+      sha256: deca88d9f181ad6fdd12df9c5fa952c763264da14336ca1c0e4124525725b174
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   alchemist:
     dependency: "direct dev"
     description:


### PR DESCRIPTION
The minimum versions for Dart and Flutter are now 3.0.0 and 3.16.0 respectively.

Reasons for such change:
1. Allow `accessibility_tools` v1.0.1 that requires Flutter 3.16, to get our package score back, and have a green CI again that was failing due to the `pana` job. **[failed]**
2. Use new language features from Dart 3.
3. Reduce deprecated code that was ignored due to supporting Flutter 3.7, which was released more than a year ago.