### PR TITLE
refactor: use `textScaler` in `TextScaleAddon`

### DIFF
--- a/docs/addons/text-scale-addon.mdx
+++ b/docs/addons/text-scale-addon.mdx
@@ -2,7 +2,7 @@
 
 The Text Scale Addon is a Widgetbook utility designed for modifying the active text scale
 factor using MediaQuery. This enables users to manipulate the
-MediaQueryData.textScaleFactor value and observe its impact on rendering use-cases.
+`MediaQuery.textScaler` value and observe its impact on rendering use-cases.
 Visualizing changes in text scale can prove valuable for developers, as it allows them to
 understand how layout adjustments correspond to variations in text scale and,
 consequently, text size.

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **BREAKING**: Set minimum SDK version to 3.0.0 & minimum Flutter version to 3.16.0. ([#1243](https://github.com/widgetbook/widgetbook/pull/1243))
 - **FEAT**: Allow changing Widgetbook's theme and mode. ([#1225](https://github.com/widgetbook/widgetbook/pull/1225) - by [@Mastersam07](https://github.com/Mastersam07))
+- **REFACTOR**: Use `MediaQuery.textScaler` instead of `MediaQuery.textScaleFactor` for `TextScaleAddon`. ([#1244](https://github.com/widgetbook/widgetbook/pull/1244))
 - **FIX**: Skip decoding non-ascii characters in URLs. ([#1218](https://github.com/widgetbook/widgetbook/pull/1218) - by [@shigomany](https://github.com/shigomany))
 - **FIX**: Encode all fields values to allow reserved characters (e.g. commas, colons and curly brackets). ([#1214](https://github.com/widgetbook/widgetbook/pull/1214))
 - **FIX**: Remove default value (i.e. first item) from `listOrNull` knob. ([#1233](https://github.com/widgetbook/widgetbook/pull/1233))

--- a/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
+++ b/packages/widgetbook/lib/src/addons/text_scale_addon/text_scale_addon.dart
@@ -1,14 +1,9 @@
-// [MediaQuery.textScaleFactor] is deprecated in Flutter 3.16.0,
-// Since our minimum Flutter version is 3.7.0, we cannot use [TextScaler] yet.
-// More info: https://docs.flutter.dev/release/breaking-changes/deprecate-textscalefactor
-// ignore_for_file: deprecated_member_use
-
 import 'package:flutter/material.dart';
 
 import '../../fields/fields.dart';
 import '../common/common.dart';
 
-/// A [WidgetbookAddon] for changing the active [MediaQueryData.textScaleFactor]
+/// A [WidgetbookAddon] for changing the active [MediaQueryData.textScaler]
 /// via [MediaQuery].
 class TextScaleAddon extends WidgetbookAddon<double> {
   TextScaleAddon({
@@ -54,7 +49,7 @@ class TextScaleAddon extends WidgetbookAddon<double> {
   ) {
     return MediaQuery(
       data: MediaQuery.of(context).copyWith(
-        textScaleFactor: setting,
+        textScaler: TextScaler.linear(setting),
       ),
       child: child,
     );

--- a/packages/widgetbook/lib/src/next/addons/text_scale_addon.dart
+++ b/packages/widgetbook/lib/src/next/addons/text_scale_addon.dart
@@ -1,8 +1,3 @@
-// [MediaQuery.textScaleFactor] is deprecated in Flutter 3.16.0,
-// Since our minimum Flutter version is 3.7.0, we cannot use [TextScaler] yet.
-// More info: https://docs.flutter.dev/release/breaking-changes/deprecate-textscalefactor
-// ignore_for_file: deprecated_member_use
-
 import 'package:flutter/widgets.dart';
 
 import '../../fields/fields.dart';
@@ -16,7 +11,7 @@ class TextScaleMode extends Mode<double> {
   Widget build(BuildContext context, Widget child) {
     return MediaQuery(
       data: MediaQuery.of(context).copyWith(
-        textScaleFactor: value,
+        textScaler: TextScaler.linear(value),
       ),
       child: child,
     );

--- a/packages/widgetbook/test/src/addons/text_scale_factor_test.dart
+++ b/packages/widgetbook/test/src/addons/text_scale_factor_test.dart
@@ -42,9 +42,8 @@ void main() {
           );
 
           expect(
-            // ignore: deprecated_member_use
-            mediaQuery.textScaleFactor,
-            equals(factor),
+            mediaQuery.textScaler,
+            equals(const TextScaler.linear(factor)),
           );
         },
       );


### PR DESCRIPTION
`MediaQuery.textScaleFactor` was deprecated in Flutter 3.16.0.
Since we have bumped our minimum Flutter version to 3.16.0, we can now use `TextScaler`.

More info: https://docs.flutter.dev/release/breaking-changes/deprecate-textscalefactor