### PR TITLE
refactor: remove router deprecated code

### DIFF
--- a/packages/widgetbook/lib/src/routing/app_route_parser.dart
+++ b/packages/widgetbook/lib/src/routing/app_route_parser.dart
@@ -5,29 +5,12 @@ import 'app_route_config.dart';
 
 @internal
 class AppRouteParser extends RouteInformationParser<AppRouteConfig> {
-  /// This allows a value of type T or T?
-  /// to be treated as a value of type T?.
-  ///
-  /// We use this so that APIs that have become
-  /// non-nullable can still be used with `!` and `?`
-  /// to support older versions of the API as well.
-  T? _ambiguate<T>(T? value) => value;
-
   @override
   Future<AppRouteConfig> parseRouteInformation(
     RouteInformation routeInformation,
   ) async {
-    // Not backwards compatible with Flutter < 3.13.0
-    // ignore: deprecated_member_use
-    final location = routeInformation.location;
-
-    // We use [_ambiguate] to support older versions of Flutter,
-    // since [RouteInformation.location] has changed to be non-nullable
-    // in Flutter 3.13.0.
-    final ambiguousLocation = _ambiguate(location);
-
     return AppRouteConfig(
-      uri: Uri.parse(ambiguousLocation ?? '/'),
+      uri: routeInformation.uri,
     );
   }
 
@@ -36,9 +19,7 @@ class AppRouteParser extends RouteInformationParser<AppRouteConfig> {
     AppRouteConfig configuration,
   ) {
     return RouteInformation(
-      // Not backwards compatible with Flutter < 3.13.0
-      // ignore: deprecated_member_use
-      location: configuration.uri.toString(),
+      uri: configuration.uri,
     );
   }
 }

--- a/packages/widgetbook/lib/src/routing/app_router.dart
+++ b/packages/widgetbook/lib/src/routing/app_router.dart
@@ -9,19 +9,17 @@ import 'app_router_delegate.dart';
 @internal
 class AppRouter extends RouterConfig<AppRouteConfig> {
   AppRouter({
-    String initialRoute = '/',
+    required Uri uri,
     required WidgetbookState state,
   }) : super(
           routeInformationParser: AppRouteParser(),
           routeInformationProvider: PlatformRouteInformationProvider(
             initialRouteInformation: RouteInformation(
-              // Not backwards compatible with Flutter < 3.13.0
-              // ignore: deprecated_member_use
-              location: initialRoute,
+              uri: uri,
             ),
           ),
           routerDelegate: AppRouterDelegate(
-            initialRoute: initialRoute,
+            uri: uri,
             state: state,
           ),
         );

--- a/packages/widgetbook/lib/src/routing/app_router_delegate.dart
+++ b/packages/widgetbook/lib/src/routing/app_router_delegate.dart
@@ -10,14 +10,14 @@ import 'app_route_config.dart';
 class AppRouterDelegate extends RouterDelegate<AppRouteConfig>
     with ChangeNotifier, PopNavigatorRouterDelegateMixin<AppRouteConfig> {
   AppRouterDelegate({
-    this.initialRoute = '/',
+    required this.uri,
     required this.state,
   })  : _navigatorKey = GlobalKey<NavigatorState>(),
         _configuration = AppRouteConfig(
-          uri: Uri.parse(initialRoute),
+          uri: uri,
         );
 
-  final String initialRoute;
+  final Uri uri;
   final WidgetbookState state;
   final GlobalKey<NavigatorState> _navigatorKey;
   AppRouteConfig _configuration;
@@ -39,7 +39,7 @@ class AppRouterDelegate extends RouterDelegate<AppRouteConfig>
   Widget build(BuildContext context) {
     return Navigator(
       key: navigatorKey,
-      // The onPopPage parameter is deprecated after Flutter 3.16.0,
+      // The onPopPage parameter is deprecated in Flutter 3.24.0,
       // But we cannot migrate it because our minimum version is 3.16.0.
       // ignore: deprecated_member_use
       onPopPage: (route, result) => route.didPop(result),

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -99,9 +99,7 @@ class WidgetbookState extends ChangeNotifier {
   /// Syncs this with the router's location using [SystemNavigator].
   void _syncRouteInformation() {
     SystemNavigator.routeInformationUpdated(
-      // Not backwards compatible with Flutter < 3.13.0
-      // ignore: deprecated_member_use
-      location: uri.toString(),
+      uri: uri,
     );
   }
 

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -118,10 +118,13 @@ class _WidgetbookState extends State<Widgetbook> {
     );
 
     router = AppRouter(
-      initialRoute: Uri.base.fragment.isNotEmpty
-          ? Uri.base.fragment
-          : widget.initialRoute,
       state: state,
+      // Do not use the initial route if there is an existing URL fragment.
+      // That means that the user has navigated to a different route then
+      // they restarted the app, so we should not override that.
+      uri: Uri.base.fragment.isNotEmpty
+          ? Uri.parse(Uri.base.fragment)
+          : Uri.parse(widget.initialRoute),
     );
 
     widget.integrations?.forEach(

--- a/packages/widgetbook/test/src/routing/app_router_delegate_test.dart
+++ b/packages/widgetbook/test/src/routing/app_router_delegate_test.dart
@@ -15,16 +15,16 @@ void main() {
         'given an initial route, '
         'then the current configuration has the exact location',
         () {
-          const initialLocation = '/?path=use-case';
+          final uri = Uri.parse('/?path=use-case');
 
           final delegate = AppRouterDelegate(
-            initialRoute: initialLocation,
+            uri: uri,
             state: MockWidgetbookState(),
           );
 
           expect(
-            delegate.currentConfiguration!.uri.toString(),
-            initialLocation,
+            delegate.currentConfiguration!.uri,
+            uri,
           );
         },
       );
@@ -40,6 +40,7 @@ void main() {
           );
 
           final delegate = AppRouterDelegate(
+            uri: Uri.parse('/'),
             state: state,
           );
 
@@ -63,7 +64,7 @@ void main() {
           );
 
           final delegate = AppRouterDelegate(
-            initialRoute: '/?preview',
+            uri: Uri.parse('/?preview'),
             state: state,
           );
 


### PR DESCRIPTION
A lot of code was there to get around the deprecation of `location` in Flutter 3.13.
This code now can be safely remove after we have bumped the minimum Flutter version 3.16.