### PR TITLE
fix: `base href` replacement

### DIFF
--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+- **FIX**: `base href` replacement for older Flutter versions ([#1247](https://github.com/widgetbook/widgetbook/pull/1247))
+
 ## 3.3.0
 
 - **REFACTOR**: Speed up the creation of build drafts, by reducing the payload size. ([#1232](https://github.com/widgetbook/widgetbook/pull/1232))

--- a/packages/widgetbook_cli/lib/src/commands/build_push.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push.dart
@@ -190,7 +190,7 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
         // Modify index.html to include the correct base href
         final content = file.readAsStringSync();
         final modifiedContent = content.replaceFirst(
-          RegExp('<base href=".*">'),
+          RegExp('<base href=".*" ?\/?>'),
           '<base href="${buildDraft.baseHref}">',
         );
 


### PR DESCRIPTION
Fixes the RegEx pattern not matching the `<base href>` tag for older Flutter version as those end on ` />` instead of the expected `>`
