### PR TITLE
docs: fix indentation in assets guide

### DIFF
--- a/docs/guides/assets.mdx
+++ b/docs/guides/assets.mdx
@@ -23,7 +23,7 @@ But doing so will make the image not display in your app. To fix this, you need 
    publish_to: none
 
    environment:
-   sdk: ">=3.1.0 <4.0.0"
+     sdk: ">=3.1.0 <4.0.0"
 
    flutter:
      assets:


### PR DESCRIPTION
In the docs, fix for the `pubspec.yaml` example file for the assets folder

### List of issues which are fixed by the PR
The `sdk` version line needs to be indented under `environment`. When copying and pasting the code as it is, the `pubspec.yaml` file is not valid.

### Screenshots
<img width="981" alt="Screenshot 2024-08-30 at 15 31 10" src="https://github.com/user-attachments/assets/08eb51e4-809f-4ccb-b47e-7eff704bd040">


### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- N/A I added new tests to check the change I am making.
- [x] All existing and new tests are passing.

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
