### PR TITLE
deps: bump `accessibility_tools` to v2

### DIFF
--- a/examples/full_example/pubspec.lock
+++ b/examples/full_example/pubspec.lock
@@ -18,10 +18,10 @@ packages:
     dependency: transitive
     description:
       name: accessibility_tools
-      sha256: deca88d9f181ad6fdd12df9c5fa952c763264da14336ca1c0e4124525725b174
+      sha256: "4627f89350b9997c68279b72b6cb3f262c83468a857956c6f8439215a727ab63"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "2.2.1"
   analyzer:
     dependency: transitive
     description:

--- a/examples/knobs_example/pubspec.lock
+++ b/examples/knobs_example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: accessibility_tools
-      sha256: deca88d9f181ad6fdd12df9c5fa952c763264da14336ca1c0e4124525725b174
+      sha256: "4627f89350b9997c68279b72b6cb3f262c83468a857956c6f8439215a727ab63"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "2.2.1"
   async:
     dependency: transitive
     description:

--- a/examples/monorepo_example/widgetbook/pubspec.lock
+++ b/examples/monorepo_example/widgetbook/pubspec.lock
@@ -18,10 +18,10 @@ packages:
     dependency: transitive
     description:
       name: accessibility_tools
-      sha256: deca88d9f181ad6fdd12df9c5fa952c763264da14336ca1c0e4124525725b174
+      sha256: "4627f89350b9997c68279b72b6cb3f262c83468a857956c6f8439215a727ab63"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "2.2.1"
   analyzer:
     dependency: transitive
     description:

--- a/examples/screen_util_example/pubspec.lock
+++ b/examples/screen_util_example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: accessibility_tools
-      sha256: deca88d9f181ad6fdd12df9c5fa952c763264da14336ca1c0e4124525725b174
+      sha256: "4627f89350b9997c68279b72b6cb3f262c83468a857956c6f8439215a727ab63"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "2.2.1"
   async:
     dependency: transitive
     description:

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
   flutter: ">=3.16.0"
 
 dependencies:
-  accessibility_tools: ">=0.2.0 <2.0.0"
+  accessibility_tools: ^2.0.0
   collection: ^1.15.0
   device_frame: ^1.1.0
   flutter:

--- a/sandbox/pubspec.lock
+++ b/sandbox/pubspec.lock
@@ -18,10 +18,10 @@ packages:
     dependency: transitive
     description:
       name: accessibility_tools
-      sha256: deca88d9f181ad6fdd12df9c5fa952c763264da14336ca1c0e4124525725b174
+      sha256: "4627f89350b9997c68279b72b6cb3f262c83468a857956c6f8439215a727ab63"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "2.2.1"
   alchemist:
     dependency: "direct dev"
     description:


### PR DESCRIPTION
Since our minimum flutter version is now 3.16 (#1243), we can now use `accessibility_tools` 2.x.x