### PR TITLE
fix(cli): update azure context defaults

### DIFF
--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Provide default values for arguments when running in Azure Pipelines. ([#1271](https://github.com/widgetbook/widgetbook/pull/1271))
+
 ## 3.4.0
 
 - **FEAT**: Support Multi Snapshot for addons. For more information, check our [docs](https://docs.widgetbook.io/widgetbook-cloud/multi-snapshot). ([#1239](https://github.com/widgetbook/widgetbook/pull/1239))

--- a/packages/widgetbook_cli/lib/src/commands/build_push.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push.dart
@@ -78,7 +78,11 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
 
     final repository = context.repository!;
     final currentBranch = await repository.currentBranch;
-    final branch = results['branch'] as String? ?? currentBranch.name;
+
+    final branch = results['branch'] as String? ??
+        context.providerBranch ??
+        currentBranch.name;
+
     final commit = results['commit'] as String? ??
         context.providerSha ??
         currentBranch.sha;

--- a/packages/widgetbook_cli/lib/src/core/context.dart
+++ b/packages/widgetbook_cli/lib/src/core/context.dart
@@ -10,6 +10,7 @@ class Context {
     required this.environment,
     required this.user,
     required this.project,
+    this.providerBranch,
     this.providerSha,
   });
 
@@ -18,6 +19,7 @@ class Context {
   final Environment environment;
   final String? user;
   final String? project;
+  final String? providerBranch;
   final String? providerSha;
 
   @override
@@ -29,6 +31,7 @@ class Context {
         other.environment == environment &&
         other.user == user &&
         other.project == project &&
+        other.providerBranch == providerBranch &&
         other.providerSha == providerSha;
   }
 
@@ -39,6 +42,7 @@ class Context {
         environment.hashCode ^
         user.hashCode ^
         project.hashCode ^
+        providerBranch.hashCode ^
         providerSha.hashCode;
   }
 }

--- a/packages/widgetbook_cli/lib/src/core/context_manager.dart
+++ b/packages/widgetbook_cli/lib/src/core/context_manager.dart
@@ -26,8 +26,8 @@ class ContextManager {
         name: 'Azure',
         repository: repository,
         environment: environment,
-        user: platform.environment['Agent.Name'],
-        project: platform.environment['Build.Repository.Name'],
+        user: platform.environment['BUILD_SOURCEVERSIONAUTHOR'],
+        project: platform.environment['BUILD_REPOSITORY_NAME'],
       );
     }
 

--- a/packages/widgetbook_cli/lib/src/core/context_manager.dart
+++ b/packages/widgetbook_cli/lib/src/core/context_manager.dart
@@ -22,12 +22,20 @@ class ContextManager {
     Environment environment,
   ) async {
     if (ciManager.isAzure) {
+      final sourceBranch = platform.environment['BUILD_SOURCEBRANCH'];
+      final prSourceBranch =
+          platform.environment['SYSTEM_PULLREQUEST_SOURCEBRANCH'];
+
+      final isPr = sourceBranch?.contains('refs/pull/') ?? false;
+      final branch = isPr ? prSourceBranch : sourceBranch;
+
       return Context(
         name: 'Azure',
         repository: repository,
         environment: environment,
         user: platform.environment['BUILD_SOURCEVERSIONAUTHOR'],
         project: platform.environment['BUILD_REPOSITORY_NAME'],
+        providerBranch: branch != null ? Reference.nameOf(branch) : null,
       );
     }
 

--- a/packages/widgetbook_cli/lib/src/git/reference.dart
+++ b/packages/widgetbook_cli/lib/src/git/reference.dart
@@ -18,6 +18,14 @@ class Reference {
   final String sha;
   final String fullName;
 
+  /// Returns the [fullName] without the `refs/*/` prefix.
+  static String nameOf(String fullName) {
+    return fullName.replaceFirst(
+      RegExp(r'^refs/.+?/'),
+      '',
+    );
+  }
+
   bool get isHEAD => fullName == 'HEAD';
   bool get isTag => fullName.startsWith('refs/tags/');
   bool get isHead => fullName.startsWith('refs/heads/');
@@ -25,12 +33,7 @@ class Reference {
   bool get isBranch => isHead || isRemote;
 
   /// The [fullName] without the `refs/*/` prefix.
-  String get name {
-    return fullName.replaceFirst(
-      RegExp(r'^refs/.+?/'),
-      '',
-    );
-  }
+  String get name => nameOf(fullName);
 
   @override
   bool operator ==(covariant Reference other) {

--- a/packages/widgetbook_cli/test/src/core/context_manager_test.dart
+++ b/packages/widgetbook_cli/test/src/core/context_manager_test.dart
@@ -42,8 +42,8 @@ void main() {
     test('Azure', () {
       ciManager.mock(isAzure: true);
       when(() => platform.environment).thenReturn({
-        'Agent.Name': userName,
-        'Build.Repository.Name': repoName,
+        'BUILD_SOURCEVERSIONAUTHOR': userName,
+        'BUILD_REPOSITORY_NAME': repoName,
       });
 
       expectLater(


### PR DESCRIPTION
The following CLI arguments will now have defaults from Azure Pipelines:

| Argument | Default |
| :----- | :----- |
| `--branch` | `Build.SourceBranch` or `System.PullRequest.SourceBranch` |
| `--repository` | `Build.Repository.Name` |
| `--actor` | `Build.SourceVersionAuthor` |



