### PR TITLE
fix(cli): update gitlab context defaults

### DIFF
--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Provide default values for arguments when running in GitLab CI/CD. ([#1277](https://github.com/widgetbook/widgetbook/pull/1277))
+
 ## 3.4.1
 
 - **FIX**: Provide default values for arguments when running in Azure Pipelines. ([#1271](https://github.com/widgetbook/widgetbook/pull/1271))

--- a/packages/widgetbook_cli/lib/src/core/context_manager.dart
+++ b/packages/widgetbook_cli/lib/src/core/context_manager.dart
@@ -76,8 +76,10 @@ class ContextManager {
         name: 'GitLab',
         repository: repository,
         environment: environment,
-        user: platform.environment['GITLAB_USER_NAME'],
-        project: platform.environment['CI_PROJECT_NAME'],
+        user: platform.environment['GITLAB_USER_LOGIN'],
+        project: platform.environment['CI_PROJECT_PATH'],
+        providerBranch: platform.environment['CI_COMMIT_BRANCH'],
+        providerSha: platform.environment['CI_COMMIT_SHA'],
       );
     }
 

--- a/packages/widgetbook_cli/test/src/core/context_manager_test.dart
+++ b/packages/widgetbook_cli/test/src/core/context_manager_test.dart
@@ -129,8 +129,10 @@ void main() {
     test('GitLab', () {
       ciManager.mock(isGitLab: true);
       when(() => platform.environment).thenReturn({
-        'GITLAB_USER_NAME': userName,
-        'CI_PROJECT_NAME': repoName,
+        'GITLAB_USER_LOGIN': userName,
+        'CI_PROJECT_PATH': repoName,
+        'CI_COMMIT_BRANCH': 'main',
+        'CI_COMMIT_SHA': sha,
       });
 
       expectLater(
@@ -142,6 +144,8 @@ void main() {
             environment: environment,
             user: userName,
             project: repoName,
+            providerBranch: 'main',
+            providerSha: sha,
           ),
         ),
       );


### PR DESCRIPTION
The following CLI arguments will now have defaults from GitLab Pipelines:

| Argument | Default |
| :----- | :----- |
| `--commit` | `CI_COMMIT_SHA` | 
| `--branch` | `CI_COMMIT_BRANCH` |
| `--repository` | `CI_PROJECT_PATH` |
| `--actor` | `GITLAB_USER_LOGIN` |
