### PR TITLE
docs: Update Telemetry Documentation

### DIFF
--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -32,7 +32,7 @@ We send the following information, which **has no personal data**:
 1. Information about Widgetbook Components like:
    - The number of components.
    - The number of components with various counts of use-cases.
-   - The packages names where the components were defined.
+   - The names of the packages in which the components were defined.
 
 ## Further Notice
 

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -32,7 +32,7 @@ We send the following information, which **has no personal data**:
 1. Information about Widgetbook Components like:
    - The number of components.
    - The number of components with various counts of use-cases.
-   - The packages' names where the components were defined.
+   - The packages names where the components were defined.
 
 ## Further Notice
 


### PR DESCRIPTION
This removes the possessive and improves clarity.



### Changes Made
- Updated the line: 
  - **From:** "The packages' names where the components were defined."
  - **To:** "The names of the packages in which the components were defined."

## Impact
These changes enhance the understanding of telemetry within the Widgetbook Generator, making it easier for users to comprehend the data collection and opt-out processes.


