### PR TITLE
refactor: expand `DropdownMenu` width

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **REFACTOR**: Use a slider instead of a dropdown for `TextScaleAddon`. The `scales` parameter is deprecated, and can be removed or replaced with a combination of `min`, `max` and `divisions` parameters if the default values are not sufficient. ([#1224](https://github.com/widgetbook/widgetbook/pull/1224) - by [@ash14](https://github.com/ash14))
+- **REFACTOR**: Expand `DropdownMenu` to the full width of the sidebar. ([#1287](https://github.com/widgetbook/widgetbook/pull/1287))
 
 ## 3.9.0
 

--- a/packages/widgetbook/lib/src/fields/list_field.dart
+++ b/packages/widgetbook/lib/src/fields/list_field.dart
@@ -35,6 +35,7 @@ class ListField<T> extends Field<T> {
   @override
   Widget toWidget(BuildContext context, String group, T? value) {
     return DropdownMenu<T>(
+      expandedInsets: EdgeInsets.zero,
       trailingIcon: const Icon(Icons.keyboard_arrow_down_rounded),
       selectedTrailingIcon: const Icon(Icons.keyboard_arrow_up_rounded),
       initialSelection: value,

--- a/packages/widgetbook/test/src/knobs/list_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/list_knob_test.dart
@@ -26,7 +26,7 @@ void main() {
 
           expect(
             find.textWidget(value),
-            findsNWidgets(2),
+            findsOneWidget,
           );
         },
       );
@@ -50,7 +50,7 @@ void main() {
 
           expect(
             find.textWidget(value),
-            findsNWidgets(2),
+            findsOneWidget,
           );
         },
       );
@@ -112,7 +112,7 @@ void main() {
 
           expect(
             find.textWidget(value),
-            findsNWidgets(2),
+            findsOneWidget,
           );
         },
       );
@@ -138,7 +138,7 @@ void main() {
           await tester.findAndTap(find.text(value).last);
           expect(
             find.textWidget(value),
-            findsNWidgets(2),
+            findsOneWidget,
           );
 
           await tester.findAndTap(find.byType(Checkbox));
@@ -147,7 +147,7 @@ void main() {
           await tester.findAndTap(find.byType(Checkbox));
           expect(
             find.textWidget(value),
-            findsNWidgets(2),
+            findsOneWidget,
           );
         },
       );


### PR DESCRIPTION
`DropdownMenu` now takes the width of its parent.

<img width="1920" alt="Screenshot 2024-10-15 at 11 10 33 AM" src="https://github.com/user-attachments/assets/c5bb8237-730b-476c-826b-548bf9f2de7a">
