### PR TITLE
fix: allow special characters in search query

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Allow special characters in search query. ([#1293](https://github.com/widgetbook/widgetbook/pull/1293) - by [@07Abhinavkapoor](https://github.com/07Abhinavkapoor))
+
 ## 3.10.0
 
 - **REFACTOR**: Use a slider instead of a dropdown for `TextScaleAddon`. The `scales` parameter is deprecated, and can be removed or replaced with a combination of `min`, `max` and `divisions` parameters if the default values are not sufficient. ([#1224](https://github.com/widgetbook/widgetbook/pull/1224) - by [@ash14](https://github.com/ash14))

--- a/packages/widgetbook/lib/src/navigation/widgets/navigation_panel.dart
+++ b/packages/widgetbook/lib/src/navigation/widgets/navigation_panel.dart
@@ -25,7 +25,13 @@ class _NavigationPanelState extends State<NavigationPanel> {
   WidgetbookNode? selectedNode;
 
   bool filterNode(WidgetbookNode node, String query) {
-    final regex = RegExp(query, caseSensitive: false);
+    // Escapes all the special character which are treated differently in regex
+    final regexString =
+        query.replaceAllMapped(RegExp(r'[-[\]{}()*+?.,\\^$|#\s]'), (match) {
+      return '\\${match[0]}';
+    });
+
+    final regex = RegExp(regexString, caseSensitive: false);
     return node.name.contains(regex);
   }
 

--- a/packages/widgetbook/lib/src/navigation/widgets/navigation_panel.dart
+++ b/packages/widgetbook/lib/src/navigation/widgets/navigation_panel.dart
@@ -26,12 +26,8 @@ class _NavigationPanelState extends State<NavigationPanel> {
 
   bool filterNode(WidgetbookNode node, String query) {
     // Escapes all the special character which are treated differently in regex
-    final regexString =
-        query.replaceAllMapped(RegExp(r'[-[\]{}()*+?.,\\^$|#\s]'), (match) {
-      return '\\${match[0]}';
-    });
-
-    final regex = RegExp(regexString, caseSensitive: false);
+    final escapedQuery = RegExp.escape(query);
+    final regex = RegExp(escapedQuery, caseSensitive: false);
     return node.name.contains(regex);
   }
 

--- a/packages/widgetbook/test/src/navigation/widgets/navigation_panel_test.dart
+++ b/packages/widgetbook/test/src/navigation/widgets/navigation_panel_test.dart
@@ -60,8 +60,8 @@ void main() {
     );
 
     testWidgets(
-      'when search for query which has no match, '
-      'then the full tree is shown',
+      'when search for query that has special characters, '
+      'then the query is handled properly',
       (tester) async {
         await tester.pumpWidgetWithQueryParams(
           queryParams: {},

--- a/packages/widgetbook/test/src/navigation/widgets/navigation_panel_test.dart
+++ b/packages/widgetbook/test/src/navigation/widgets/navigation_panel_test.dart
@@ -58,5 +58,28 @@ void main() {
         );
       },
     );
+
+    testWidgets(
+      'when search for query which has no match, '
+      'then the full tree is shown',
+      (tester) async {
+        await tester.pumpWidgetWithQueryParams(
+          queryParams: {},
+          builder: (_) => NavigationPanel(
+            root: treeRoot,
+          ),
+        );
+
+        await tester.findAndEnter(
+          find.byType(TextFormField),
+          '[',
+        );
+
+        expect(
+          find.byType(NavigationTreeTile),
+          findsNWidgets(treeRoot.count - 1), // exclude root node
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
Escapes all special characters received as a part of search string which are treated differently in RegExp. 

### List of issues which are fixed by the PR
- [1276](https://github.com/widgetbook/widgetbook/issues/1276)

### Screenshots


### Checklist




- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
