### PR TITLE
fix(cli): convert windows paths to posix

### DIFF
--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **FIX**: Convert Windows paths to POSIX paths when uploading files. ([#1294](https://github.com/widgetbook/widgetbook/pull/1294))
 - **FIX**: Show an error when no git repository is found. ([#1286](https://github.com/widgetbook/widgetbook/pull/1286))
 
 ## 3.4.2

--- a/packages/widgetbook_cli/lib/src/storage/storage_object.dart
+++ b/packages/widgetbook_cli/lib/src/storage/storage_object.dart
@@ -2,14 +2,19 @@ import 'package:mime/mime.dart';
 
 class StorageObject {
   StorageObject({
-    required this.key,
+    required String key,
     required this.size,
     required this.reader,
-  });
+  }) : rawKey = key;
 
-  final String key;
+  final String rawKey;
   final int size;
   final Stream<List<int>> Function() reader;
+
+  // Keys need to be in POSIX format in the storage,
+  // Since they are derive from paths, that means they can
+  // be in Windows format, so we convert them to POSIX format
+  String get key => rawKey.replaceAll('\\', '/');
 
   String get mimeType => lookupMimeType(key) ?? 'application/octet-stream';
 }


### PR DESCRIPTION
When the files are uploaded to storage from a windows, they are created as root files instead of files within folders. This is because our storage only supports POSIX paths.