### PR TITLE
docs: fix cloud access link

### DIFF
--- a/docs/cloud/index.mdx
+++ b/docs/cloud/index.mdx
@@ -4,7 +4,7 @@ Widgetbook Cloud is a review platform that simplifies UI reviews among designers
 
 <Info>
   Get free access to Widgetbook Cloud
-  [here](https://ic7614zmz3s.typeform.com/to/bqG82ECS).
+  [here](https://app.widgetbook.io).
 </Info>
 
 <YouTube id="gCTSc99V-KI" />


### PR DESCRIPTION
We had an incorrect get access link that did not lead to the product. 