### PR TITLE
docs: fix typo

### DIFF
--- a/docs/guides/quick-start.mdx
+++ b/docs/guides/quick-start.mdx
@@ -44,11 +44,11 @@ After finishing the setup, the folder structure should look something like this:
 
 ```tree
 your_app/
-├── pubsepc.yaml
+├── pubspec.yaml
 ├── lib/
 ├── ...
 └── widgetbook/
-    ├── pubsepc.yaml
+    ├── pubspec.yaml
     ├── lib/
     └── ...
 ```


### PR DESCRIPTION
Fix a typo in the docs from `pubsepc.yaml` to `pubspec.yaml`

### List of issues which are fixed by the PR
- Typo

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
