### PR TITLE
docs: update `TextScaleAddon` deprecated usage

### DIFF
--- a/docs/addons/index.mdx
+++ b/docs/addons/index.mdx
@@ -99,7 +99,8 @@ class WidgetbookApp extends StatelessWidget {
           ],
         ),
         TextScaleAddon(
-          scales: [1.0, 2.0],
+          min: 1.0,
+          max: 2.0,
         ),
         LocalizationAddon(
           locales: [


### PR DESCRIPTION
Was copying some code from the docs and noticed a deprecation.