### PR TITLE
fix: expose `WidgetbookScope`

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **FIX**: Expose `WidgetbookScope` to allow importing it in tests. ([#1325](https://github.com/widgetbook/widgetbook/pull/1325))
 - **FIX**: Allow special characters in search query. ([#1293](https://github.com/widgetbook/widgetbook/pull/1293) - by [@07Abhinavkapoor](https://github.com/07Abhinavkapoor))
 
 ## 3.10.0

--- a/packages/widgetbook/lib/src/state/widgetbook_scope.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_scope.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/widgets.dart';
-import 'package:meta/meta.dart';
 
 import 'widgetbook_state.dart';
 
-@internal
 class WidgetbookScope extends InheritedNotifier<WidgetbookState> {
   WidgetbookScope({
     super.key,

--- a/packages/widgetbook/lib/widgetbook.dart
+++ b/packages/widgetbook/lib/widgetbook.dart
@@ -18,5 +18,5 @@ export 'src/knobs/knobs.dart'
         ListKnob,
         StringKnob;
 export 'src/navigation/nodes/nodes.dart';
-export 'src/state/state.dart' hide WidgetbookScope;
+export 'src/state/state.dart';
 export 'src/widgetbook.dart';

--- a/packages/widgetbook/test/helper/tester_extension.dart
+++ b/packages/widgetbook/test/helper/tester_extension.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:widgetbook/src/state/widgetbook_scope.dart';
 import 'package:widgetbook/src/themes.dart';
 import 'package:widgetbook/widgetbook.dart';
 


### PR DESCRIPTION
Expose the internal `WidgetbookScope` class as some users are using it for testing. The class was imported in `test/` directory as follows:

```dart
# test/some_test.dart
import 'package:widgetbook/src/state/widgetbook_scope.dart';
```

After this PR, the following import should be possible

```dart
# test/some_test.dart
import 'package:widgetbook/widgetbook.dart';
```