### PR TITLE
fix(generator): escape path resolution for missing resource

### DIFF
--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **FIX**: Escape path resolution if `pubspec.lock` is not found. This bug was affecting running the generator in [Pub Workspaces](https://dart.dev/tools/pub/workspaces). ([#1327](https://github.com/widgetbook/widgetbook/pull/1327))
 - **REFACTOR**: Send an owner URL for [telemetry](https://docs.widgetbook.io/telemetry). ([#1324](https://github.com/widgetbook/widgetbook/pull/1324))
 
 ## 3.9.0


### PR DESCRIPTION
In the generator, we used the `pubspec.lock` to resolve some paths in case of local packages. This logic will now be partially skipped if the lock file was not found.

The path resolution logic may be removed in the future, since we do not really use it.