### PR TITLE
fix: resolve flutter 3.27 deprecations

### DIFF
--- a/examples/knobs_example/lib/widgetbook.dart
+++ b/examples/knobs_example/lib/widgetbook.dart
@@ -89,7 +89,7 @@ class WidgetbookApp extends StatelessWidget {
                   KnobEntry<Color>(
                     name: 'Color',
                     builder: (color) => Text(
-                      color.value.toRadixString(16),
+                      '${color}',
                       style: TextStyle(
                         color: color,
                       ),

--- a/packages/widgetbook/lib/src/addons/grid_addon/grid_addon.dart
+++ b/packages/widgetbook/lib/src/addons/grid_addon/grid_addon.dart
@@ -28,7 +28,7 @@ class GridAddon extends WidgetbookAddon<int> {
     return Stack(
       children: [
         GridPaper(
-          color: Colors.grey.withOpacity(0.5),
+          color: Colors.grey.withAlpha(255 ~/ 2),
           interval: setting.toDouble(),
           subdivisions: 2,
           child: Container(),

--- a/packages/widgetbook/lib/src/fields/color_field/color_field.dart
+++ b/packages/widgetbook/lib/src/fields/color_field/color_field.dart
@@ -19,6 +19,10 @@ class ColorField extends Field<Color> {
   }) : super(
           type: FieldType.color,
           codec: FieldCodec(
+            // Color.value was deprecated in Flutter 3.27.0, the alternative
+            // apis (.r, .g, .b, .a) are not available in Color for our minimum
+            // Flutter version (3.16.0), as they were also introduced in 3.27.0.
+            // ignore: deprecated_member_use
             toParam: (color) => color.value.toRadixString(16),
             toValue: (param) {
               if (param == null) return null;

--- a/packages/widgetbook/lib/src/fields/color_field/color_picker.dart
+++ b/packages/widgetbook/lib/src/fields/color_field/color_picker.dart
@@ -22,26 +22,30 @@ class ColorPicker extends StatefulWidget {
 }
 
 class _ColorPickerState extends State<ColorPicker> {
-  late int opacity;
+  late int alpha;
   late ColorSpace colorSpace;
   late OpaqueColor opaqueColor;
 
   @override
   void initState() {
     super.initState();
-    opacity = widget.value.alpha ~/ 2.55;
+    // Color.alpha was deprecated in Flutter 3.27.0, the alternative
+    // api (.a) is not available in Color for our minimum
+    // Flutter version (3.16.0), as they were also introduced in 3.27.0.
+    // ignore: deprecated_member_use
+    alpha = widget.value.alpha;
     colorSpace = widget.colorSpace;
     opaqueColor = OpaqueColor.fromColor(widget.value);
   }
 
-  void onChange(int newOpacity, OpaqueColor newColor) {
+  void onChange(int newAlpha, OpaqueColor newColor) {
     setState(() {
-      opacity = newOpacity;
+      alpha = newAlpha;
       opaqueColor = newColor;
     });
 
     widget.onChanged.call(
-      newColor.toColor().withOpacity(newOpacity / 100),
+      newColor.toColor().withAlpha(newAlpha),
     );
   }
 
@@ -58,7 +62,7 @@ class _ColorPickerState extends State<ColorPicker> {
             Container(
               padding: const EdgeInsets.all(12),
               decoration: BoxDecoration(
-                color: Colors.white.withOpacity(0.18),
+                color: Colors.white.withAlpha(46),
                 borderRadius: BorderRadius.circular(4),
               ),
               child: Icon(
@@ -84,10 +88,11 @@ class _ColorPickerState extends State<ColorPicker> {
             SizedBox(
               width: 80,
               child: NumberTextField.percentage(
-                value: opacity,
+                value: alpha ~/ 255 * 100,
                 onChanged: (value) {
-                  setState(() => this.opacity = value);
-                  onChange(value, opaqueColor);
+                  final newValue = (value / 100 * 255).round();
+                  setState(() => this.alpha = newValue);
+                  onChange(newValue, opaqueColor);
                 },
               ),
             ),
@@ -101,7 +106,7 @@ class _ColorPickerState extends State<ColorPicker> {
           value: opaqueColor,
           onChanged: (value) {
             setState(() => this.opaqueColor = value);
-            onChange(opacity, value);
+            onChange(alpha, value);
           },
         ),
       ],

--- a/packages/widgetbook/lib/src/fields/color_field/opaque_color.dart
+++ b/packages/widgetbook/lib/src/fields/color_field/opaque_color.dart
@@ -12,7 +12,12 @@ class OpaqueColor {
 
   OpaqueColor.fromColor(
     Color color,
-  ) : value = color.value & 0xffffff;
+  ) :
+        // Color.value was deprecated in Flutter 3.27.0, the alternative
+        // apis (.r, .g, .b, .a) are not available in Color for our minimum
+        // Flutter version (3.16.0), as they were also introduced in 3.27.0.
+        // ignore: deprecated_member_use
+        value = color.value & 0xffffff;
 
   final int value;
 

--- a/packages/widgetbook/lib/src/navigation/widgets/search_field.dart
+++ b/packages/widgetbook/lib/src/navigation/widgets/search_field.dart
@@ -64,7 +64,7 @@ class _SearchFieldState extends State<SearchField> {
                     focusNode.unfocus();
                     widget.onCleared?.call();
                   },
-                  hoverColor: Colors.white.withOpacity(0.2),
+                  hoverColor: Colors.white.withAlpha(25),
                   icon: const Icon(Icons.close),
                 ),
               )

--- a/packages/widgetbook/lib/src/next/addons/grid_addon.dart
+++ b/packages/widgetbook/lib/src/next/addons/grid_addon.dart
@@ -11,7 +11,7 @@ class GridAddon extends BuilderAddon {
             return Stack(
               children: [
                 GridPaper(
-                  color: Colors.grey.withOpacity(0.5),
+                  color: Colors.grey.withAlpha(255 ~/ 2),
                   interval: dimension.toDouble(),
                   subdivisions: 2,
                   child: Container(),

--- a/packages/widgetbook/lib/src/next/args/story_args.dart
+++ b/packages/widgetbook/lib/src/next/args/story_args.dart
@@ -1,5 +1,3 @@
-import 'package:collection/collection.dart';
-
 import 'arg.dart';
 import 'const_arg.dart';
 
@@ -10,6 +8,6 @@ abstract class StoryArgs<T> {
 
   /// Non-nullable and non-const args
   List<Arg> get safeList {
-    return list.whereNotNull().where((arg) => arg is! ConstArg).toList();
+    return list.nonNulls.where((arg) => arg is! ConstArg).toList();
   }
 }

--- a/packages/widgetbook/lib/src/themes.dart
+++ b/packages/widgetbook/lib/src/themes.dart
@@ -111,7 +111,7 @@ class Themes {
     brightness: Brightness.dark,
     fontFamily: 'Poppins',
     colorScheme: _darkColorScheme,
-    hoverColor: const Color(0xFFE3E2E6).withOpacity(0.08),
+    hoverColor: const Color(0xFFE3E2E6).withAlpha(20),
     tabBarTheme: TabBarTheme(
       dividerColor: _darkColorScheme.outline,
     ),
@@ -138,7 +138,7 @@ class Themes {
     brightness: Brightness.light,
     fontFamily: 'Poppins',
     colorScheme: _lightColorScheme,
-    hoverColor: const Color(0xFF1A1C1E).withOpacity(0.08),
+    hoverColor: const Color(0xFF1A1C1E).withAlpha(20),
     tabBarTheme: TabBarTheme(
       dividerColor: _darkColorScheme.outline,
     ),


### PR DESCRIPTION
- There was a lot of `Color`-related deprecation, because of [wide gamut Color](https://docs.flutter.dev/release/breaking-changes/wide-gamut-framework).
- `whereNotNull` was deprecated in `package:collection`, in favor of Dart's `nonNulls`.