### PR TITLE
docs: fix typo

### DIFF
--- a/docs/cloud/security/overview.mdx
+++ b/docs/cloud/security/overview.mdx
@@ -13,7 +13,7 @@ By following this approach, the components in Widgetbook as well as Widgetbook C
 
 Besides builds, Widgetbook Cloud does not store any source code. 
 Builds are compiled on your machine and sent as a compiled binary to Widgetbook Cloud servers. 
-**The original source code is in your full control and not send or stored.**
+**The original source code is in your full control and not sent or stored.**
 
 We store the following Git metadata:
 - Git commit hash and message


### PR DESCRIPTION
Fixed a small typo in the security page of the docs.