### PR TITLE
deps: bump sdk to 3.3 & flutter to 3.19

### DIFF
--- a/.github/workflows/widgetbook-annotation.yaml
+++ b/.github/workflows/widgetbook-annotation.yaml
@@ -17,4 +17,4 @@ jobs:
     uses: ./.github/workflows/_package.yml
     with:
       working_directory: packages/widgetbook_annotation
-      min_flutter_version: 3.16.0
+      min_flutter_version: 3.19.0

--- a/.github/workflows/widgetbook-cli.yaml
+++ b/.github/workflows/widgetbook-cli.yaml
@@ -17,4 +17,4 @@ jobs:
     uses: ./.github/workflows/_package.yml
     with:
       working_directory: packages/widgetbook_cli
-      min_flutter_version: 3.10.0
+      min_flutter_version: 3.19.0

--- a/.github/workflows/widgetbook-generator.yaml
+++ b/.github/workflows/widgetbook-generator.yaml
@@ -17,4 +17,4 @@ jobs:
     uses: ./.github/workflows/_package.yml
     with:
       working_directory: packages/widgetbook_generator
-      min_flutter_version: 3.16.0
+      min_flutter_version: 3.19.0

--- a/.github/workflows/widgetbook-test.yaml
+++ b/.github/workflows/widgetbook-test.yaml
@@ -17,4 +17,4 @@ jobs:
     uses: ./.github/workflows/_package.yml
     with:
       working_directory: packages/widgetbook_test
-      min_flutter_version: 3.10.0
+      min_flutter_version: 3.19.0

--- a/.github/workflows/widgetbook.yaml
+++ b/.github/workflows/widgetbook.yaml
@@ -17,4 +17,4 @@ jobs:
     uses: ./.github/workflows/_package.yml
     with:
       working_directory: packages/widgetbook
-      min_flutter_version: 3.16.0
+      min_flutter_version: 3.19.0

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **BREAKING**: Set minimum SDK version to 3.3.0 & minimum Flutter version to 3.19.0. ([#1349](https://github.com/widgetbook/widgetbook/pull/1349))
+
 ## 3.10.2
 
 - **FEAT**: Add `WidgetbookState.maybeOf`. ([#1342](https://github.com/widgetbook/widgetbook/pull/1342) - by [@ABausG](https://github.com/ABausG))

--- a/packages/widgetbook/lib/src/fields/color_field/color_field.dart
+++ b/packages/widgetbook/lib/src/fields/color_field/color_field.dart
@@ -21,7 +21,7 @@ class ColorField extends Field<Color> {
           codec: FieldCodec(
             // Color.value was deprecated in Flutter 3.27.0, the alternative
             // apis (.r, .g, .b, .a) are not available in Color for our minimum
-            // Flutter version (3.16.0), as they were also introduced in 3.27.0.
+            // Flutter version (3.19.0), as they were also introduced in 3.27.0.
             // ignore: deprecated_member_use
             toParam: (color) => color.value.toRadixString(16),
             toValue: (param) {

--- a/packages/widgetbook/lib/src/fields/color_field/color_picker.dart
+++ b/packages/widgetbook/lib/src/fields/color_field/color_picker.dart
@@ -31,7 +31,7 @@ class _ColorPickerState extends State<ColorPicker> {
     super.initState();
     // Color.alpha was deprecated in Flutter 3.27.0, the alternative
     // api (.a) is not available in Color for our minimum
-    // Flutter version (3.16.0), as they were also introduced in 3.27.0.
+    // Flutter version (3.19.0), as they were also introduced in 3.27.0.
     // ignore: deprecated_member_use
     alpha = widget.value.alpha;
     colorSpace = widget.colorSpace;

--- a/packages/widgetbook/lib/src/fields/color_field/opaque_color.dart
+++ b/packages/widgetbook/lib/src/fields/color_field/opaque_color.dart
@@ -15,7 +15,7 @@ class OpaqueColor {
   ) :
         // Color.value was deprecated in Flutter 3.27.0, the alternative
         // apis (.r, .g, .b, .a) are not available in Color for our minimum
-        // Flutter version (3.16.0), as they were also introduced in 3.27.0.
+        // Flutter version (3.19.0), as they were also introduced in 3.27.0.
         // ignore: deprecated_member_use
         value = color.value & 0xffffff;
 

--- a/packages/widgetbook/lib/src/routing/app_router_delegate.dart
+++ b/packages/widgetbook/lib/src/routing/app_router_delegate.dart
@@ -40,7 +40,7 @@ class AppRouterDelegate extends RouterDelegate<AppRouteConfig>
     return Navigator(
       key: navigatorKey,
       // The onPopPage parameter is deprecated in Flutter 3.24.0,
-      // But we cannot migrate it because our minimum version is 3.16.0.
+      // But we cannot migrate it because our minimum version is 3.19.0.
       // ignore: deprecated_member_use
       onPopPage: (route, result) => route.didPop(result),
       pages: [

--- a/packages/widgetbook/lib/src/themes.dart
+++ b/packages/widgetbook/lib/src/themes.dart
@@ -31,7 +31,7 @@ class Themes {
     surfaceTint: Color(0xFFA1C9FF),
 
     // The following parameters are deprecated in Flutter 3.22.0,
-    // But we cannot remove them because our minimum version is 3.16.0,
+    // But we cannot remove them because our minimum version is 3.19.0,
     // and these parameters are required there.
 
     // ignore: deprecated_member_use
@@ -71,7 +71,7 @@ class Themes {
     surfaceTint: Color(0xFF0060A7),
 
     // The following parameters are deprecated in Flutter 3.22.0,
-    // But we cannot remove them because our minimum version is 3.16.0,
+    // But we cannot remove them because our minimum version is 3.19.0,
     // and these parameters are required there.
 
     // ignore: deprecated_member_use
@@ -90,7 +90,7 @@ class Themes {
       isDense: true,
       // By default, this is [ColorScheme.surfaceContainerHighest], but we
       // need to override it to [ColorScheme.surfaceVariant] due to the minimum
-      // Flutter version being 3.16.0, which does not have the new parameter.
+      // Flutter version being 3.19.0, which does not have the new parameter.
       // ignore: deprecated_member_use
       fillColor: colorScheme.surfaceVariant,
       focusedBorder: OutlineInputBorder(
@@ -119,7 +119,7 @@ class Themes {
       overlayShape: SliderComponentShape.noThumb,
       // By default, this is [ColorScheme.surfaceContainerHighest], but we
       // need to override it to [ColorScheme.surfaceVariant] due to the minimum
-      // Flutter version being 3.16.0, which does not have the new parameter.
+      // Flutter version being 3.19.0, which does not have the new parameter.
       // ignore: deprecated_member_use
       inactiveTrackColor: _darkColorScheme.surfaceVariant,
     ),
@@ -146,7 +146,7 @@ class Themes {
       overlayShape: SliderComponentShape.noThumb,
       // By default, this is [ColorScheme.surfaceContainerHighest], but we
       // need to override it to [ColorScheme.surfaceVariant] due to the minimum
-      // Flutter version being 3.16.0, which does not have the new parameter.
+      // Flutter version being 3.19.0, which does not have the new parameter.
       // ignore: deprecated_member_use
       inactiveTrackColor: _lightColorScheme.surfaceVariant,
     ),

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -12,8 +12,8 @@ screenshots:
     path: assets/logo.png
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.16.0"
+  sdk: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"
 
 dependencies:
   accessibility_tools: ^2.0.0

--- a/packages/widgetbook_annotation/CHANGELOG.md
+++ b/packages/widgetbook_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **BREAKING**: Set minimum SDK version to 3.3.0. ([#1349](https://github.com/widgetbook/widgetbook/pull/1349))
+
 ## 3.2.0
 
 - **BREAKING**: Set minimum SDK version to 3.0.0. ([#1243](https://github.com/widgetbook/widgetbook/pull/1243))

--- a/packages/widgetbook_annotation/pubspec.yaml
+++ b/packages/widgetbook_annotation/pubspec.yaml
@@ -12,7 +12,7 @@ screenshots:
     path: assets/logo.png
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dev_dependencies:
   test: ^1.24.1

--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **BREAKING**: Set minimum SDK version to 3.3.0. ([#1349](https://github.com/widgetbook/widgetbook/pull/1349))
+
 ## 3.5.0
 
 - **FEAT**: Add support for [GitLab Merged Results Pipelines](https://docs.gitlab.com/ee/ci/pipelines/merged_results_pipelines.html) via the `cloud build push` command. Check [our docs](https://docs.widgetbook.io/cloud/setup/gitlab#gitlab-merged-result-pipelines) for more info. ([#1312](https://github.com/widgetbook/widgetbook/pull/1312))

--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -12,7 +12,7 @@ screenshots:
     path: assets/logo.png
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   args: ^2.3.0

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **BREAKING**: Set minimum SDK version to 3.3.0. ([#1349](https://github.com/widgetbook/widgetbook/pull/1349))
+
 ## 3.9.1
 
 - **FIX**: Escape path resolution if `pubspec.lock` is not found. This bug was affecting running the generator in [Pub Workspaces](https://dart.dev/tools/pub/workspaces). ([#1327](https://github.com/widgetbook/widgetbook/pull/1327))

--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -12,7 +12,7 @@ screenshots:
     path: assets/logo.png
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   analyzer: ^6.0.0

--- a/packages/widgetbook_test/pubspec.yaml
+++ b/packages/widgetbook_test/pubspec.yaml
@@ -12,7 +12,7 @@ screenshots:
     path: assets/logo.png
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dev_dependencies:
   test: ^1.24.1

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -314,4 +314,4 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.3.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: widgetbook_workspace
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dev_dependencies:
   melos: ^6.0.0


### PR DESCRIPTION
Starting from today, we keep our minimum SDK/Flutter versions to the fourth latest one.
As of today, the four latest Flutter releases are:

1. Flutter v3.27 + Dart v3.6
2. Flutter v3.24 + Dart v3.5
3. Flutter v3.22 + Dart v3.4
4. Flutter v3.19 + Dart v3.3 (our minimum versions)
