### PR TITLE
fix(example): pin `flutter_screenutil` version

### DIFF
--- a/examples/screen_util_example/lib/widgetbook.dart
+++ b/examples/screen_util_example/lib/widgetbook.dart
@@ -27,6 +27,8 @@ class WidgetbookApp extends StatelessWidget {
         BuilderAddon(
           name: 'ScreenUtil',
           builder: (context, child) {
+            // flutter_screenutil must be version 3.9.1 or lower
+            // to work properly with Widgetbook
             return ScreenUtilInit(
               designSize: const Size(375, 812),
               minTextAdapt: true,

--- a/examples/screen_util_example/pubspec.lock
+++ b/examples/screen_util_example/pubspec.lock
@@ -74,10 +74,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_screenutil
-      sha256: "8239210dd68bee6b0577aa4a090890342d04a136ce1c81f98ee513fc0ce891de"
+      sha256: b372c35a772a1dc84142a3b9c5ee89a390834bd258e5e6a450d9b975b985d1c9
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.3"
+    version: "5.9.1"
   flutter_test:
     dependency: transitive
     description: flutter

--- a/examples/screen_util_example/pubspec.yaml
+++ b/examples/screen_util_example/pubspec.yaml
@@ -10,7 +10,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_screenutil: ^5.7.0
+  # flutter_screenutil >= 5.9.2 doesn't work with widgetbook as
+  # they are using `View.of` instead of `MediaQuery.of`
+  # https://github.com/OpenFlutter/flutter_screenutil/commit/f7c551acd4cc82460c3a29ec5a7262d6ec678746
+  flutter_screenutil: 5.9.1
   widgetbook: ^3.10.2
 
 flutter:


### PR DESCRIPTION
`flutter_screenutil` >= 5.9.2 stopped using `MediaQuery.of` and started using `View.of` in OpenFlutter/flutter_screenutil@f7c551acd4cc82460c3a29ec5a7262d6ec678746.
This causes widgets to get misplaced/misaligned as we [wrap](https://github.com/widgetbook/widgetbook/blob/9b0542dc14879d3db28ce3e87fc81e919608c40b/packages/widgetbook/lib/src/workbench/safe_boundaries.dart#L19-L27) our workbench in a `MediaQuery` widget.