### PR TITLE
Update docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -45,7 +45,7 @@
   "tabs": [
     {
       "id": "docs",
-      "title": "Docs",
+      "title": "Open Source",
       "href": "/"
     },
     {


### PR DESCRIPTION
Changed the `Docs` tab to `Open Source` to increase the visual difference between the OSS and Widgetbook Cloud. We still have users that use the OSS, and read our docs, that don't know that there is Widgetbook Cloud.