### PR TITLE
feat: Add documentation addon

### DIFF
--- a/docs/addons/documentation-addon.mdx
+++ b/docs/addons/documentation-addon.mdx
@@ -1,0 +1,77 @@
+# Documentation Addon
+
+This addon allows you to easily add documentation to your widgets by integrating Markdown files located in the `assets/markdown` directory.
+
+## Features
+
+- **Contextual Documentation**: Displays the documentation associated with each of your widgets.
+- **Dynamic Loading**: The Markdown content is loaded dynamically based on the widget’s path.
+- **Advanced Formatting**: Thanks to `flutter_markdown` and `flutter_highlighter`, you enjoy elegant formatting and syntax highlighting for code blocks.
+- **Resizable Layout**: The documentation is displayed in a resizable view, allowing you to compare the widget and its documentation comfortably.
+
+## How It Works
+
+1. **Activating Assets**  
+   To allow the addon to load your documentation, ensure that assets are enabled in your Flutter project.
+
+2. **Organizing Markdown Files**  
+   Place your Markdown files in the `/assets/markdown/` folder. The filename must correspond to the full widget path (provided via query parameters) followed by the `.md` extension.
+   
+   **Example:**  
+   If the widget path is `components/button`, the file should be placed as:
+```
+/assets/markdown/components/button.md
+```
+
+3. **Addon Configuration**  
+   The addon is enabled via the `documentation` parameter (a boolean value). By default, it is initialized to `true`. You can control its state via query parameters or by configuring it in the Widgetbook addons panel.
+
+## Integration Example
+
+```dart
+@widgetbook.App()
+class HotReload extends StatelessWidget {
+  const HotReload({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    Map<String, String> params =
+        Map.fromEntries(Uri.base.queryParameters.entries);
+    var path = params["path"] ?? 'accueil%2Freadme';
+    var knobs = params["knobs"] ?? '{}';
+    var device = params["device"] ?? '{name:None}';
+    return Widgetbook.material(
+      initialRoute: "/?path=$path&knobs=$knobs&device=$device",
+      themeMode: ThemeMode.light,
+      addons: [
+        DocumentationAddon(),
+        DeviceFrameAddon(devices: [
+          ...Devices.android.all,
+          ...Devices.ios.all,
+          Devices.linux.laptop,
+          Devices.windows.wideMonitor,
+        ]),
+      ],
+      directories: [
+        WidgetbookComponent(name: "Accueil", useCases: [
+          usercaseWithMarkdown(
+            "README",
+            null,
+            "markdown/introduction.md",
+          ),
+        ]),
+        ...directories,
+      ],
+    );
+  }
+}
+
+@widgetbook.UseCase(
+  name: 'TextDynamicInput.percent',
+  type: TextDynamicInput,
+  path: 'components/text_dynamic_input',
+) // with this configuration, you have to add a markdown file in the assets/markdown/components/text_dynamic_input/textdynamicinput.percent.md
+Widget buildPercentTextDynamicInputUseCase(BuildContext context) {
+  return Percent();
+}
+```

--- a/packages/widgetbook/lib/src/addons/documentation_addon/addon.dart
+++ b/packages/widgetbook/lib/src/addons/documentation_addon/addon.dart
@@ -1,0 +1,1 @@
+export 'documentation_addon.dart';

--- a/packages/widgetbook/lib/src/addons/documentation_addon/documentation_addon.dart
+++ b/packages/widgetbook/lib/src/addons/documentation_addon/documentation_addon.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_highlighter/flutter_highlighter.dart';
+import 'package:flutter_highlighter/themes/atom-one-dark.dart';
+import 'package:flutter_highlighter/themes/atom-one-light.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_resizable_container/flutter_resizable_container.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:markdown/markdown.dart' as md;
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../fields/fields.dart';
+import '../common/common.dart';
+
+class DocumentationAddon extends WidgetbookAddon<bool> {
+  DocumentationAddon({
+    this.initialBool = true,
+  }) : super(name: 'Documentation');
+  final bool initialBool;
+
+  @override
+  Widget buildUseCase(
+    BuildContext context,
+    Widget child,
+    bool setting,
+  ) {
+    if (!setting) {
+      return child.animate().fade();
+    }
+    return FutureBuilder(
+      future: loadMarkdown(),
+      builder: (context, snapshot) {
+        if (snapshot.hasData && snapshot.data != '') {
+          return ResizableContainer(
+            direction: Axis.vertical,
+            children: [
+              ResizableChild(
+                size: const ResizableSize.expand(flex: 2),
+                child: Card(
+                  color: Colors.white,
+                  child: Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: ListView(
+                      children: [
+                        Center(
+                          child: Text(
+                            'Widget Documentation',
+                            style: GoogleFonts.lato(
+                              fontSize: 20,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                        child,
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              ResizableChild(
+                child: (snapshot.hasData)
+                    ? Card(
+                        color: Colors.white,
+                        child: Padding(
+                          padding: const EdgeInsets.all(8.0),
+                          child: MarkdownWithHighlight(
+                                  markdown: snapshot.data ?? "")
+                              .animate()
+                              .fade(),
+                        ),
+                      )
+                    : SizedBox(),
+              ),
+            ],
+          ).animate().fade();
+        }
+        return Card(
+          color: Colors.white,
+          child: Padding(padding: const EdgeInsets.all(8.0), child: child),
+        ).animate().fade();
+      },
+    );
+  }
+
+  Future<String> loadMarkdown() async {
+    try {
+      return await rootBundle.loadString(
+        "${kDebugMode ? "" : "assets/"}markdown/${Uri.base.queryParameters['path']}.md",
+      );
+    } catch (_) {
+      return "";
+    }
+  }
+
+  @override
+  List<Field<bool>> get fields {
+    return [
+      BooleanField(
+        name: 'documentation',
+        initialValue: initialBool,
+      ),
+    ];
+  }
+
+  @override
+  bool valueFromQueryGroup(Map<String, String> group) {
+    return valueOf<bool>('documentation', group)!;
+  }
+}
+
+class MarkdownWithHighlight extends StatelessWidget {
+  const MarkdownWithHighlight({
+    super.key,
+    required this.markdown,
+  });
+  final String markdown;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context).textTheme;
+    return Markdown(
+      shrinkWrap: true,
+      data: markdown,
+      builders: {
+        'code': _CodeElementBuilder(),
+      },
+      styleSheet: MarkdownStyleSheet(
+        p: theme.bodySmall,
+        strong: theme.bodySmall?.copyWith(fontWeight: FontWeight.bold),
+        code: GoogleFonts.lato(
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          color: Colors.white,
+          backgroundColor: const Color(0xff282c34),
+        ),
+        codeblockDecoration: BoxDecoration(
+          color: const Color(0xff282c34),
+          borderRadius: BorderRadius.circular(5.0),
+        ),
+        checkbox: theme.bodySmall?.copyWith(fontWeight: FontWeight.bold),
+        h1: theme.headlineMedium,
+        h2: theme.bodyLarge?.copyWith(fontWeight: FontWeight.bold),
+        h3: theme.bodyLarge,
+        h4: theme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
+        h5: theme.bodyMedium,
+        h6: theme.bodySmall?.copyWith(fontWeight: FontWeight.bold),
+        listBullet: theme.bodySmall,
+      ),
+      onTapLink: (text, url, title) {
+        if (url != null) {
+          launchUrl(
+            Uri.parse(url),
+          );
+        }
+      },
+      selectable: true,
+    );
+  }
+}
+
+class _CodeElementBuilder extends MarkdownElementBuilder {
+  @override
+  Widget? visitElementAfter(md.Element element, TextStyle? preferredStyle) {
+    var language = '';
+
+    if (element.attributes['class'] != null) {
+      String lg = element.attributes['class'] as String;
+      language = lg.substring(9);
+    }
+    return HighlightView(
+      element.textContent,
+      language: language,
+      theme: MediaQueryData.fromView(
+                      RendererBinding.instance.renderViews.first.flutterView)
+                  .platformBrightness ==
+              Brightness.light
+          ? atomOneLightTheme
+          : atomOneDarkTheme,
+      padding: const EdgeInsets.all(8.0),
+      textStyle: preferredStyle ?? GoogleFonts.robotoMono(),
+    );
+  }
+}


### PR DESCRIPTION
A new addon allows you to easily add documentation to your widgets by integrating Markdown files located in the `assets/markdown` directory.

### List of issues which are fixed by the PR
No issue

### Screenshots
![image](https://github.com/user-attachments/assets/85840ee1-3dc6-48a4-b95e-708bee73b678)


<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
