### PR TITLE
chore(cli): relax 0.x packages constraint

### DIFF
--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -20,14 +20,14 @@ dependencies:
   collection: ^1.18.0
   dio: ^5.7.0
   file: ^7.0.0
-  mason_logger: ^0.2.16
+  mason_logger: ">=0.2.16 <1.0.0"
   meta: ^1.16.0
   mime: ^2.0.0
   path: ^1.9.0
   platform: ^3.1.0
   pool: ^1.5.1
   process: ^5.0.3
-  pub_updater: ^0.4.0
+  pub_updater: ">=0.4.0 <1.0.0"
   retry: ^3.1.2
   yaml: ^3.1.2
 


### PR DESCRIPTION
The packages `mason_logger` and `pub_updater` had a `^0.x.y` constraint which did not allow new versions (0.x+1.0), thus the constraint is widened to allow those releases, and earn the lost pub points.