### PR TITLE
fix: match semantics addon and config fields

### DIFF
--- a/packages/widgetbook/lib/src/addons/semantics_addon/semantics_addon.dart
+++ b/packages/widgetbook/lib/src/addons/semantics_addon/semantics_addon.dart
@@ -18,14 +18,14 @@ class SemanticsAddon extends WidgetbookAddon<bool> {
   @override
   List<Field> get fields => [
         BooleanField(
-          name: 'Enabled',
+          name: 'enabled',
           initialValue: enabled,
         ),
       ];
 
   @override
   bool valueFromQueryGroup(Map<String, String> group) {
-    return valueOf('Enabled', group) ?? false;
+    return valueOf('enabled', group) ?? false;
   }
 
   @override


### PR DESCRIPTION
The field name in `SemanticsAddon` and `SemanticsAddonConfig` was mismatching. 