### PR TITLE
refactor: use `device_frame_plus`

### DIFF
--- a/examples/full_example/pubspec.lock
+++ b/examples/full_example/pubspec.lock
@@ -182,14 +182,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.6"
-  device_frame:
+  device_frame_plus:
     dependency: transitive
     description:
-      name: device_frame
-      sha256: d031a06f5d6f4750009672db98a5aa1536aa4a231713852469ce394779a23d75
+      name: device_frame_plus
+      sha256: "064e86f71f2721e66e4282c98d475cf9cd1e55d51eca6100183b7f6f2d237463"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   fake_async:
     dependency: transitive
     description:
@@ -233,10 +233,10 @@ packages:
     dependency: transitive
     description:
       name: freezed_annotation
-      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      sha256: c87ff004c8aa6af2d531668b46a4ea379f7191dc6dfa066acd53d506da6e044b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "3.0.0"
   frontend_server_client:
     dependency: transitive
     description:

--- a/examples/knobs_example/pubspec.lock
+++ b/examples/knobs_example/pubspec.lock
@@ -49,14 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
-  device_frame:
+  device_frame_plus:
     dependency: transitive
     description:
-      name: device_frame
-      sha256: d031a06f5d6f4750009672db98a5aa1536aa4a231713852469ce394779a23d75
+      name: device_frame_plus
+      sha256: "064e86f71f2721e66e4282c98d475cf9cd1e55d51eca6100183b7f6f2d237463"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   fake_async:
     dependency: transitive
     description:
@@ -84,10 +84,10 @@ packages:
     dependency: transitive
     description:
       name: freezed_annotation
-      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      sha256: c87ff004c8aa6af2d531668b46a4ea379f7191dc6dfa066acd53d506da6e044b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "3.0.0"
   inspector:
     dependency: transitive
     description:

--- a/examples/monorepo_example/widgetbook/pubspec.lock
+++ b/examples/monorepo_example/widgetbook/pubspec.lock
@@ -182,14 +182,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.6"
-  device_frame:
+  device_frame_plus:
     dependency: transitive
     description:
-      name: device_frame
-      sha256: d031a06f5d6f4750009672db98a5aa1536aa4a231713852469ce394779a23d75
+      name: device_frame_plus
+      sha256: "064e86f71f2721e66e4282c98d475cf9cd1e55d51eca6100183b7f6f2d237463"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   fake_async:
     dependency: transitive
     description:
@@ -233,10 +233,10 @@ packages:
     dependency: transitive
     description:
       name: freezed_annotation
-      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      sha256: c87ff004c8aa6af2d531668b46a4ea379f7191dc6dfa066acd53d506da6e044b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "3.0.0"
   frontend_server_client:
     dependency: transitive
     description:

--- a/examples/screen_util_example/pubspec.lock
+++ b/examples/screen_util_example/pubspec.lock
@@ -49,14 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
-  device_frame:
+  device_frame_plus:
     dependency: transitive
     description:
-      name: device_frame
-      sha256: d031a06f5d6f4750009672db98a5aa1536aa4a231713852469ce394779a23d75
+      name: device_frame_plus
+      sha256: "064e86f71f2721e66e4282c98d475cf9cd1e55d51eca6100183b7f6f2d237463"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   fake_async:
     dependency: transitive
     description:
@@ -92,10 +92,10 @@ packages:
     dependency: transitive
     description:
       name: freezed_annotation
-      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      sha256: c87ff004c8aa6af2d531668b46a4ea379f7191dc6dfa066acd53d506da6e044b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "3.0.0"
   inspector:
     dependency: transitive
     description:

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -4,6 +4,8 @@
 - **FEAT**: Add a banner to the bottom of the navigation panel that shows the total number of components and use-cases. ([#1405](https://github.com/widgetbook/widgetbook/pull/1405))
 - **REFACTOR**: Allow [`inspector`](https://pub.dev/packages/inspector) v3. ([#1407](https://github.com/widgetbook/widgetbook/pull/1407))
 - **FIX**: Remove `ExcludeSemantics` from Widgetbook UI; to allow screen readers. ([#1401](https://github.com/widgetbook/widgetbook/pull/1401) - by [@Goddchen](https://github.com/Goddchen))
+- **REFACTOR**: Replace [`device_frame`](https://pub.dev/packages/device_frame) with [`device_frame_plus`](https://pub.dev/packages/device_frame_plus). ([#1411](https://github.com/widgetbook/widgetbook/pull/1411))
+
 
 ## 3.12.0
 

--- a/packages/widgetbook/lib/src/addons/device_frame_addon/addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/addon.dart
@@ -1,4 +1,4 @@
-export 'package:device_frame/device_frame.dart';
+export 'package:device_frame_plus/device_frame_plus.dart';
 
 export 'device_frame_addon.dart';
 export 'device_frame_setting.dart';

--- a/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
@@ -1,4 +1,4 @@
-import 'package:device_frame/device_frame.dart';
+import 'package:device_frame_plus/device_frame_plus.dart';
 import 'package:flutter/material.dart';
 
 import '../../fields/fields.dart';

--- a/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_setting.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_setting.dart
@@ -1,4 +1,4 @@
-import 'package:device_frame/device_frame.dart';
+import 'package:device_frame_plus/device_frame_plus.dart';
 import 'package:flutter/material.dart';
 
 class DeviceFrameSetting {

--- a/packages/widgetbook/lib/src/addons/device_frame_addon/none_device.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/none_device.dart
@@ -1,4 +1,4 @@
-import 'package:device_frame/device_frame.dart';
+import 'package:device_frame_plus/device_frame_plus.dart';
 import 'package:flutter/widgets.dart';
 
 class NoneDevice implements DeviceInfo {

--- a/packages/widgetbook/lib/src/next/addons/device_frame_addon.dart
+++ b/packages/widgetbook/lib/src/next/addons/device_frame_addon.dart
@@ -1,4 +1,4 @@
-import 'package:device_frame/device_frame.dart';
+import 'package:device_frame_plus/device_frame_plus.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../addons/device_frame_addon/none_device.dart';

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
 dependencies:
   accessibility_tools: ^2.0.0
   collection: ^1.15.0
-  device_frame: ^1.1.0
+  device_frame_plus: ^1.2.1
   flutter:
     sdk: flutter
   inspector: ">=2.1.0 <4.0.0"

--- a/sandbox/pubspec.lock
+++ b/sandbox/pubspec.lock
@@ -190,14 +190,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.6"
-  device_frame:
+  device_frame_plus:
     dependency: transitive
     description:
-      name: device_frame
-      sha256: d031a06f5d6f4750009672db98a5aa1536aa4a231713852469ce394779a23d75
+      name: device_frame_plus
+      sha256: "064e86f71f2721e66e4282c98d475cf9cd1e55d51eca6100183b7f6f2d237463"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   equatable:
     dependency: transitive
     description:
@@ -249,10 +249,10 @@ packages:
     dependency: transitive
     description:
       name: freezed_annotation
-      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      sha256: c87ff004c8aa6af2d531668b46a4ea379f7191dc6dfa066acd53d506da6e044b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "3.0.0"
   frontend_server_client:
     dependency: transitive
     description:


### PR DESCRIPTION
Since `device_frame` is no longer maintained. We will be using `device_frame_plus` before we deprecate the addon in the upcoming releases.