### PR TITLE
refactor: adjust mobile breakpoint

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -5,7 +5,7 @@
 - **REFACTOR**: Allow [`inspector`](https://pub.dev/packages/inspector) v3. ([#1407](https://github.com/widgetbook/widgetbook/pull/1407))
 - **FIX**: Remove `ExcludeSemantics` from Widgetbook UI; to allow screen readers. ([#1401](https://github.com/widgetbook/widgetbook/pull/1401) - by [@Goddchen](https://github.com/Goddchen))
 - **REFACTOR**: Replace [`device_frame`](https://pub.dev/packages/device_frame) with [`device_frame_plus`](https://pub.dev/packages/device_frame_plus). ([#1411](https://github.com/widgetbook/widgetbook/pull/1411))
-
+- **REFACTOR**: Change mobile breakpoint to 840px. ([#1416](https://github.com/widgetbook/widgetbook/pull/1416) - by [@Goddchen](https://github.com/Goddchen))
 
 ## 3.12.0
 

--- a/packages/widgetbook/lib/src/layout/responsive_layout.dart
+++ b/packages/widgetbook/lib/src/layout/responsive_layout.dart
@@ -60,7 +60,10 @@ class ResponsiveLayout extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // MediaQuery.sizeOf is not backwards compatible with Flutter < 3.10.0
-    final isMobile = MediaQuery.of(context).size.width < 800;
+    //
+    // 840 is "Expanded" or "Tablet in landscape", "Desktop", ...
+    // See: https://m3.material.io/foundations/layout/applying-layout/window-size-classes#2bb70e22-d09b-4b73-9c9f-9ef60311ccc8
+    final isMobile = MediaQuery.of(context).size.width < 840;
 
     return isMobile
         ? MobileLayout(

--- a/packages/widgetbook/test/src/layout/responsive_layout_test.dart
+++ b/packages/widgetbook/test/src/layout/responsive_layout_test.dart
@@ -35,7 +35,7 @@ void main() {
         'given a large screen, '
         'then $DesktopLayout is used',
         (tester) async {
-          tester.view.physicalSize = const Size(1200, 800);
+          tester.view.physicalSize = const Size(840, 800);
           tester.view.devicePixelRatio = 1.0;
 
           await tester.pumpWidget(


### PR DESCRIPTION
The desktop layout does not really work on a tablet in portrait orientation. The navigation has many overflows and is generally too small to actually read any use case names, etc. The same applies to the knobs and addons UI on the right.
According to https://m3.material.io/foundations/layout/applying-layout/window-size-classes#2bb70e22-d09b-4b73-9c9f-9ef60311ccc8 the limit for desktop, landscape tablet, etc. is 840, not 800. With 840, our tablets also now correctly switch between desktop for landscape and mobile for portrait.

### List of issues which are fixed by the PR
https://github.com/widgetbook/widgetbook/issues/1415

### Screenshots


### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
