### PR TITLE
feat: add `home` widget

### DIFF
--- a/docs/guides/customization.mdx
+++ b/docs/guides/customization.mdx
@@ -134,3 +134,20 @@ Widget build(BuildContext context) {
   );
 }
 ```
+
+## Home Widget
+
+The home widget is a widget that is shown on startup when no use-case is selected.
+This widget does not inherit from the `appBuilder` or the `addons`;
+Meaning that if `Theme.of(context)` is called inside this widget, then it will use Widgetbook's `lightTheme` or `darkTheme`,
+and not the `Theme` from the `appBuilder` or the `ThemeAddon`.
+
+```dart
+@override
+Widget build(BuildContext context) {
+  return Widgetbook(
+    home: const MyCustomHomeWidget(),
+    // ...
+  );
+}
+```

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **FEAT**: Add [Semantics Addon](https://docs.widgetbook.io/addons/semantics-addon). ([#1402](https://github.com/widgetbook/widgetbook/pull/1402))
 - **FEAT**: Add a banner to the bottom of the navigation panel that shows the total number of components and use-cases. ([#1405](https://github.com/widgetbook/widgetbook/pull/1405))
+- **FEAT**: Add [`home` widget](https://docs.widgetbook.io/guides/customization#home-widget) to customize the startup screen. ([#1418](https://github.com/widgetbook/widgetbook/pull/1418))
 - **REFACTOR**: Allow [`inspector`](https://pub.dev/packages/inspector) v3. ([#1407](https://github.com/widgetbook/widgetbook/pull/1407))
 - **FIX**: Remove `ExcludeSemantics` from Widgetbook UI; to allow screen readers. ([#1401](https://github.com/widgetbook/widgetbook/pull/1401) - by [@Goddchen](https://github.com/Goddchen))
 - **REFACTOR**: Replace [`device_frame`](https://pub.dev/packages/device_frame) with [`device_frame_plus`](https://pub.dev/packages/device_frame_plus). ([#1411](https://github.com/widgetbook/widgetbook/pull/1411))

--- a/packages/widgetbook/lib/src/state/default_home_builder.dart
+++ b/packages/widgetbook/lib/src/state/default_home_builder.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+
+Widget defaultHomeBuilder(BuildContext context) {
+  return const _DefaultHome();
+}
+
+class _Card extends StatelessWidget {
+  const _Card({
+    required this.title,
+    required this.description,
+    required this.url,
+  });
+
+  final String title;
+  final String description;
+  final String url;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(
+        maxWidth: 360,
+      ),
+      child: Card(
+        clipBehavior: Clip.hardEdge,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+          side:
+              BorderSide(color: Theme.of(context).dividerColor.withAlpha(100)),
+        ),
+        child: InkWell(
+          onTap: () {
+            // Handle URL launch logic here
+          },
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                RichText(
+                  text: TextSpan(
+                    style: Theme.of(context).textTheme.headlineSmall,
+                    children: [
+                      TextSpan(
+                        text: title,
+                      ),
+                      const TextSpan(text: ' '),
+                      const WidgetSpan(
+                        child: Icon(
+                          Icons.arrow_forward,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  description,
+                  style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                        color: Theme.of(context)
+                            .colorScheme
+                            .onSurface
+                            .withAlpha(120),
+                      ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DefaultHome extends StatelessWidget {
+  const _DefaultHome();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              'Welcome to Widgetbook',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.displayMedium,
+            ),
+            const SizedBox(height: 32),
+            const Wrap(
+              children: [
+                _Card(
+                  title: '📖 Docs',
+                  url: 'https://docs.widgetbook.io',
+                  description:
+                      'Learn more about knobs, addons, mocking, and more.',
+                ),
+                _Card(
+                  title: '📝 Examples',
+                  url:
+                      'https://github.com/widgetbook/widgetbook/tree/main/examples',
+                  description:
+                      'Explore the Widgetbook examples and learn how to use them.',
+                ),
+              ],
+            ),
+            const Wrap(
+              children: [
+                _Card(
+                  title: '🚀 Deploy',
+                  url: 'https://docs.widgetbook.io/cloud/builds/overview',
+                  description:
+                      'Deploy your Widgetbook with our managed-hosting solution.',
+                ),
+                _Card(
+                  title: '✨ Detect Changes',
+                  url: 'https://docs.widgetbook.io/cloud/reviews',
+                  description:
+                      'Detect visual changes in your PRs with Widgetbook Cloud.',
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/widgetbook/lib/src/state/default_home_page.dart
+++ b/packages/widgetbook/lib/src/state/default_home_page.dart
@@ -7,7 +7,7 @@ class DefaultHomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.all(24),
+      padding: const EdgeInsets.all(16),
       child: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -15,9 +15,9 @@ class DefaultHomePage extends StatelessWidget {
             Text(
               'Welcome to Widgetbook',
               textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.displayMedium,
+              style: Theme.of(context).textTheme.displaySmall,
             ),
-            const SizedBox(height: 32),
+            const SizedBox(height: 24),
             const Wrap(
               children: [
                 _Card(
@@ -93,7 +93,7 @@ class _Card extends StatelessWidget {
               children: [
                 RichText(
                   text: TextSpan(
-                    style: Theme.of(context).textTheme.headlineSmall,
+                    style: Theme.of(context).textTheme.titleMedium,
                     children: [
                       TextSpan(
                         text: title,
@@ -102,6 +102,7 @@ class _Card extends StatelessWidget {
                       const WidgetSpan(
                         child: Icon(
                           Icons.arrow_forward,
+                          size: 16,
                         ),
                       ),
                     ],

--- a/packages/widgetbook/lib/src/state/default_home_page.dart
+++ b/packages/widgetbook/lib/src/state/default_home_page.dart
@@ -1,7 +1,60 @@
 import 'package:flutter/material.dart';
 
-Widget defaultHomeBuilder(BuildContext context) {
-  return const _DefaultHome();
+class DefaultHomePage extends StatelessWidget {
+  const DefaultHomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              'Welcome to Widgetbook',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.displayMedium,
+            ),
+            const SizedBox(height: 32),
+            const Wrap(
+              children: [
+                _Card(
+                  title: '📖 Docs',
+                  url: 'https://docs.widgetbook.io',
+                  description:
+                      'Learn more about knobs, addons, mocking, and more.',
+                ),
+                _Card(
+                  title: '📝 Examples',
+                  url:
+                      'https://github.com/widgetbook/widgetbook/tree/main/examples',
+                  description:
+                      'Explore the Widgetbook examples and learn how to use them.',
+                ),
+              ],
+            ),
+            const Wrap(
+              children: [
+                _Card(
+                  title: '🚀 Deploy',
+                  url: 'https://docs.widgetbook.io/cloud/builds/overview',
+                  description:
+                      'Deploy your Widgetbook with our managed-hosting solution.',
+                ),
+                _Card(
+                  title: '✨ Detect Changes',
+                  url: 'https://docs.widgetbook.io/cloud/reviews',
+                  description:
+                      'Detect visual changes in your PRs with Widgetbook Cloud.',
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 class _Card extends StatelessWidget {
@@ -67,63 +120,6 @@ class _Card extends StatelessWidget {
               ],
             ),
           ),
-        ),
-      ),
-    );
-  }
-}
-
-class _DefaultHome extends StatelessWidget {
-  const _DefaultHome();
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(24),
-      child: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text(
-              'Welcome to Widgetbook',
-              textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.displayMedium,
-            ),
-            const SizedBox(height: 32),
-            const Wrap(
-              children: [
-                _Card(
-                  title: '📖 Docs',
-                  url: 'https://docs.widgetbook.io',
-                  description:
-                      'Learn more about knobs, addons, mocking, and more.',
-                ),
-                _Card(
-                  title: '📝 Examples',
-                  url:
-                      'https://github.com/widgetbook/widgetbook/tree/main/examples',
-                  description:
-                      'Explore the Widgetbook examples and learn how to use them.',
-                ),
-              ],
-            ),
-            const Wrap(
-              children: [
-                _Card(
-                  title: '🚀 Deploy',
-                  url: 'https://docs.widgetbook.io/cloud/builds/overview',
-                  description:
-                      'Deploy your Widgetbook with our managed-hosting solution.',
-                ),
-                _Card(
-                  title: '✨ Detect Changes',
-                  url: 'https://docs.widgetbook.io/cloud/reviews',
-                  description:
-                      'Detect visual changes in your PRs with Widgetbook Cloud.',
-                ),
-              ],
-            ),
-          ],
         ),
       ),
     );

--- a/packages/widgetbook/lib/src/state/default_home_page.dart
+++ b/packages/widgetbook/lib/src/state/default_home_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class DefaultHomePage extends StatelessWidget {
   const DefaultHomePage({super.key});
@@ -78,13 +79,12 @@ class _Card extends StatelessWidget {
         clipBehavior: Clip.hardEdge,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
-          side:
-              BorderSide(color: Theme.of(context).dividerColor.withAlpha(100)),
+          side: BorderSide(
+            color: Theme.of(context).dividerColor.withAlpha(100),
+          ),
         ),
         child: InkWell(
-          onTap: () {
-            // Handle URL launch logic here
-          },
+          onTap: () => launchUrl(Uri.parse(url)),
           child: Padding(
             padding: const EdgeInsets.all(16),
             child: Column(

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -10,9 +10,11 @@ import '../knobs/knobs.dart';
 import '../navigation/navigation.dart';
 import '../routing/routing.dart';
 import 'default_app_builders.dart';
+import 'default_home_builder.dart';
 import 'widgetbook_scope.dart';
 
 typedef AppBuilder = Widget Function(BuildContext context, Widget child);
+typedef HomeBuilder = Widget Function(BuildContext context);
 
 class WidgetbookState extends ChangeNotifier {
   WidgetbookState({
@@ -24,6 +26,7 @@ class WidgetbookState extends ChangeNotifier {
     this.addons,
     this.integrations,
     required this.root,
+    this.homeBuilder = defaultHomeBuilder,
   }) {
     this.knobs = KnobsRegistry(
       onLock: () {
@@ -48,6 +51,7 @@ class WidgetbookState extends ChangeNotifier {
   final List<WidgetbookAddon>? addons;
   final List<WidgetbookIntegration>? integrations;
   final WidgetbookRoot root;
+  final HomeBuilder homeBuilder;
 
   List<WidgetbookNode> get directories => root.children!;
 

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -10,11 +10,10 @@ import '../knobs/knobs.dart';
 import '../navigation/navigation.dart';
 import '../routing/routing.dart';
 import 'default_app_builders.dart';
-import 'default_home_builder.dart';
+import 'default_home_page.dart';
 import 'widgetbook_scope.dart';
 
 typedef AppBuilder = Widget Function(BuildContext context, Widget child);
-typedef HomeBuilder = Widget Function(BuildContext context);
 
 class WidgetbookState extends ChangeNotifier {
   WidgetbookState({
@@ -26,7 +25,7 @@ class WidgetbookState extends ChangeNotifier {
     this.addons,
     this.integrations,
     required this.root,
-    this.homeBuilder = defaultHomeBuilder,
+    this.home = const DefaultHomePage(),
   }) {
     this.knobs = KnobsRegistry(
       onLock: () {
@@ -51,7 +50,7 @@ class WidgetbookState extends ChangeNotifier {
   final List<WidgetbookAddon>? addons;
   final List<WidgetbookIntegration>? integrations;
   final WidgetbookRoot root;
-  final HomeBuilder homeBuilder;
+  final Widget home;
 
   List<WidgetbookNode> get directories => root.children!;
 

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -5,6 +5,7 @@ import 'addons/addons.dart';
 import 'integrations/integrations.dart';
 import 'navigation/navigation.dart';
 import 'routing/routing.dart';
+import 'state/default_home_builder.dart';
 import 'state/state.dart';
 import 'themes.dart';
 
@@ -28,6 +29,7 @@ class Widgetbook extends StatefulWidget {
     this.lightTheme,
     this.darkTheme,
     this.themeMode,
+    this.homeBuilder = defaultHomeBuilder,
   });
 
   /// A [Widgetbook] with [CupertinoApp] as an [appBuilder].
@@ -41,6 +43,7 @@ class Widgetbook extends StatefulWidget {
     this.lightTheme,
     this.darkTheme,
     this.themeMode,
+    this.homeBuilder = defaultHomeBuilder,
   });
 
   /// A [Widgetbook] with [MaterialApp] as an [appBuilder].
@@ -54,6 +57,7 @@ class Widgetbook extends StatefulWidget {
     this.lightTheme,
     this.darkTheme,
     this.themeMode,
+    this.homeBuilder = defaultHomeBuilder,
   });
 
   /// The initial route for that will be used on first startup.
@@ -94,6 +98,10 @@ class Widgetbook extends StatefulWidget {
   /// By default, it follows the system theme.
   final ThemeMode? themeMode;
 
+  /// A custom builder that builds the home widget, which is
+  /// shown on startup.
+  final HomeBuilder homeBuilder;
+
   @override
   State<Widgetbook> createState() => _WidgetbookState();
 }
@@ -108,6 +116,7 @@ class _WidgetbookState extends State<Widgetbook> {
 
     state = WidgetbookState(
       appBuilder: widget.appBuilder,
+      homeBuilder: widget.homeBuilder,
       addons: widget.addons,
       integrations: widget.integrations,
       root: WidgetbookRoot(

--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -5,7 +5,7 @@ import 'addons/addons.dart';
 import 'integrations/integrations.dart';
 import 'navigation/navigation.dart';
 import 'routing/routing.dart';
-import 'state/default_home_builder.dart';
+import 'state/default_home_page.dart';
 import 'state/state.dart';
 import 'themes.dart';
 
@@ -29,7 +29,7 @@ class Widgetbook extends StatefulWidget {
     this.lightTheme,
     this.darkTheme,
     this.themeMode,
-    this.homeBuilder = defaultHomeBuilder,
+    this.home = const DefaultHomePage(),
   });
 
   /// A [Widgetbook] with [CupertinoApp] as an [appBuilder].
@@ -43,7 +43,7 @@ class Widgetbook extends StatefulWidget {
     this.lightTheme,
     this.darkTheme,
     this.themeMode,
-    this.homeBuilder = defaultHomeBuilder,
+    this.home = const DefaultHomePage(),
   });
 
   /// A [Widgetbook] with [MaterialApp] as an [appBuilder].
@@ -57,7 +57,7 @@ class Widgetbook extends StatefulWidget {
     this.lightTheme,
     this.darkTheme,
     this.themeMode,
-    this.homeBuilder = defaultHomeBuilder,
+    this.home = const DefaultHomePage(),
   });
 
   /// The initial route for that will be used on first startup.
@@ -98,9 +98,12 @@ class Widgetbook extends StatefulWidget {
   /// By default, it follows the system theme.
   final ThemeMode? themeMode;
 
-  /// A custom builder that builds the home widget, which is
-  /// shown on startup.
-  final HomeBuilder homeBuilder;
+  /// The home widget is a widget that is shown on startup when no use-case is
+  /// selected. This widget does not inherit from the [appBuilder] or the
+  /// [addons]; meaning that if `Theme.of(context)` is called inside this
+  /// widget, then it will use Widgetbook's [lightTheme] or [darkTheme] and
+  /// not the [Theme] from the [appBuilder] or the [ThemeAddon].
+  final Widget home;
 
   @override
   State<Widgetbook> createState() => _WidgetbookState();
@@ -116,7 +119,7 @@ class _WidgetbookState extends State<Widgetbook> {
 
     state = WidgetbookState(
       appBuilder: widget.appBuilder,
-      homeBuilder: widget.homeBuilder,
+      home: widget.home,
       addons: widget.addons,
       integrations: widget.integrations,
       root: WidgetbookRoot(

--- a/packages/widgetbook/lib/src/workbench/workbench.dart
+++ b/packages/widgetbook/lib/src/workbench/workbench.dart
@@ -12,6 +12,11 @@ class Workbench extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final state = WidgetbookState.of(context);
+    final useCase = state.useCase;
+
+    if (useCase == null) {
+      return state.homeBuilder(context);
+    }
 
     return Scaffold(
       // Some addons require a Scaffold to work properly.
@@ -46,10 +51,10 @@ class Workbench extends StatelessWidget {
                   UseCaseBuilder(
                     key: ValueKey(state.uri),
                     builder: (context) {
-                      return WidgetbookState.of(context)
-                              .useCase
-                              ?.build(context) ??
-                          const SizedBox.shrink();
+                      final state = WidgetbookState.of(context);
+                      final useCase = state.useCase;
+
+                      return useCase?.build(context) ?? const SizedBox.shrink();
                     },
                   ),
                 ],

--- a/packages/widgetbook/lib/src/workbench/workbench.dart
+++ b/packages/widgetbook/lib/src/workbench/workbench.dart
@@ -15,7 +15,7 @@ class Workbench extends StatelessWidget {
     final useCase = state.useCase;
 
     if (useCase == null) {
-      return state.homeBuilder(context);
+      return state.home;
     }
 
     return Scaffold(

--- a/packages/widgetbook/test/src/workbench/workbench_test.dart
+++ b/packages/widgetbook/test/src/workbench/workbench_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/src/workbench/workbench.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import '../../helper/helper.dart';
+
+void main() {
+  group(
+    '$Workbench',
+    () {
+      testWidgets(
+        'given a home widget, '
+        'then it is displayed when no use case is selected',
+        (tester) async {
+          final state = WidgetbookState(
+            appBuilder: materialAppBuilder,
+            home: const Placeholder(),
+            root: WidgetbookRoot(
+              children: [],
+            ),
+          );
+
+          await tester.pumpWidgetWithState(
+            state: state,
+            builder: (_) => const Workbench(),
+          );
+
+          expect(
+            find.byType(Placeholder),
+            findsOne,
+          );
+        },
+      );
+
+      testWidgets(
+        'given a home widget, '
+        'then it is not displayed when a use case is selected',
+        (tester) async {
+          const useCaseName = 'use-case';
+          final state = WidgetbookState(
+            appBuilder: materialAppBuilder,
+            home: const Placeholder(),
+            path: useCaseName,
+            root: WidgetbookRoot(
+              children: [
+                WidgetbookUseCase(
+                  name: useCaseName,
+                  builder: (context) => const Text(useCaseName),
+                ),
+              ],
+            ),
+          );
+
+          await tester.pumpWidgetWithState(
+            state: state,
+            builder: (_) => const Workbench(),
+          );
+
+          await tester.pumpAndSettle();
+
+          expect(
+            find.byType(Placeholder),
+            findsNothing,
+          );
+
+          expect(
+            find.text(useCaseName),
+            findsOneWidget,
+          );
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
The home widget is a widget that is shown on startup when no use-case is selected. This widget does not inherit from the `appBuilder` or the `addons`; Meaning that if `Theme.of(context)` is called inside this widget, then it will use Widgetbook's `lightTheme` or `darkTheme`, and not the Theme from the `appBuilder` or the `ThemeAddon`.

![Screenshot 2025-04-17 at 4 16 26 PM](https://github.com/user-attachments/assets/9c66e7af-38af-4ed7-8ab6-c04e7d0952bc)

