### PR TITLE
feat: add `panels` query parameter

### DIFF
--- a/docs/guides/embedding.mdx
+++ b/docs/guides/embedding.mdx
@@ -1,9 +1,11 @@
 # Embedding
 
+## Preview Mode
+
 If you want to embed Widgetbook in your documentation, but you want to hide Widgetbook's UI, you can do so by adding the **`preview` query parameter** to the URL of your hosted Widgetbook.
 
 ```url
-https://widgetbook.acme.com/#/?path=my/us-case/path/default&preview
+https://widgetbook.acme.com/#/?path=my/use-case/path/default&preview
 ```
 
 For example here's an embedding of [our demo app](https://demo.widgetbook.io/):
@@ -24,3 +26,23 @@ https://demo.widgetbook.io/#/?path=features/about/aboutscreen/default&preview //
   You can host your Widgetbook using [Widgetbook Cloud
   Builds](/cloud/builds/overview).
 </Info>
+
+## Customizing Panels
+
+You may want to show or hide certain panels in the embedded Widgetbook. You can do this by adding the **`panels` query parameter** to the URL of your hosted Widgetbook.
+
+<Warning>
+  The `panels` query parameter is not compatible with the `preview` query
+  parameter. If you use both, the `panels` parameter will be ignored.
+</Warning>
+
+```url
+# Knobs panel only
+https://widgetbook.acme.com/#/?path=my/use-case/path/default&panels=knobs
+
+# Knobs and Addons panels
+https://widgetbook.acme.com/#/?path=my/use-case/path/default&panels=knobs,addons
+
+# Navigation panel only
+https://widgetbook.acme.com/#/?path=my/use-case/path/default&panels=navigation
+```

--- a/docs/guides/embedding.mdx
+++ b/docs/guides/embedding.mdx
@@ -39,10 +39,14 @@ You may want to show or hide certain panels in the embedded Widgetbook. You can 
 ```url
 # Knobs panel only
 https://widgetbook.acme.com/#/?path=my/use-case/path/default&panels=knobs
+```
 
+```url
 # Knobs and Addons panels
 https://widgetbook.acme.com/#/?path=my/use-case/path/default&panels=knobs,addons
+```
 
+```url
 # Navigation panel only
 https://widgetbook.acme.com/#/?path=my/use-case/path/default&panels=navigation
 ```

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **FEAT**: Add [`panels` query param](https://docs.widgetbook.io/guides/embedding#customizing-panels) to show/hide panels when embedding Widgetbook. ([#1439](https://github.com/widgetbook/widgetbook/pull/1439))
 - **FIX**: Ensure a fresh state is used when building the use-case. This prevented some rebuilds from happening, causing knobs to not be registered properly. ([#1441](https://github.com/widgetbook/widgetbook/pull/1441))
 
 ## 3.13.1

--- a/packages/widgetbook/lib/src/layout/desktop_layout.dart
+++ b/packages/widgetbook/lib/src/layout/desktop_layout.dart
@@ -5,6 +5,10 @@ import '../settings/settings.dart';
 import '../state/state.dart';
 import 'base_layout.dart';
 
+extension _BoolExtension on bool {
+  int toInt() => this ? 1 : 0;
+}
+
 class DesktopLayout extends StatelessWidget implements BaseLayout {
   const DesktopLayout({
     super.key,
@@ -25,41 +29,67 @@ class DesktopLayout extends StatelessWidget implements BaseLayout {
   Widget build(BuildContext context) {
     final state = WidgetbookState.of(context);
 
+    // Original percentages for panels and workbench
+    final originalPanelPercentage = 0.2;
+    final originalWorkbenchPercentage = 1 - (2 * originalPanelPercentage);
+
+    final showNavigationPanel = state.canShowPanel(LayoutPanel.navigation);
+    final showSettingsPanel = state.canShowPanel(LayoutPanel.addons) ||
+        state.canShowPanel(LayoutPanel.knobs);
+
+    // If some panels are missing, distribute the remaining percentage
+    // equally among the remaining panels and the workbench
+    final missingPanelsCount =
+        2 - showNavigationPanel.toInt() - showSettingsPanel.toInt();
+    final childrenCount = 1 + (2 - missingPanelsCount);
+
+    final remainingPercentage = missingPanelsCount * originalPanelPercentage;
+    final extraPercentage = remainingPercentage / childrenCount;
+
     return ColoredBox(
       key: ValueKey(state.isNext), // Rebuild when switching to next
       color: Theme.of(context).colorScheme.surface,
       child: ResizableWidget(
         separatorSize: 2,
-        percentages: [0.2, 0.6, 0.2],
+        percentages: [
+          if (showNavigationPanel) originalPanelPercentage + extraPercentage,
+          originalWorkbenchPercentage + extraPercentage,
+          if (showSettingsPanel) originalPanelPercentage + extraPercentage,
+        ],
         separatorColor: Colors.white24,
         children: [
-          Card(
-            child: navigationBuilder(context),
-          ),
-          workbench,
-          Card(
-            child: SettingsPanel(
-              settings: [
-                if (state.isNext) ...{
-                  SettingsPanelData(
-                    name: 'Args',
-                    builder: argsBuilder,
-                  ),
-                } else ...{
-                  SettingsPanelData(
-                    name: 'Knobs',
-                    builder: knobsBuilder,
-                  ),
-                },
-                if (state.addons != null) ...{
-                  SettingsPanelData(
-                    name: 'Addons',
-                    builder: addonsBuilder,
-                  ),
-                },
-              ],
+          if (showNavigationPanel)
+            Card(
+              child: navigationBuilder(context),
             ),
-          ),
+          workbench,
+          if (showSettingsPanel)
+            Card(
+              child: SettingsPanel(
+                settings: [
+                  if (state.canShowPanel(LayoutPanel.knobs)) ...{
+                    if (state.isNext) ...{
+                      SettingsPanelData(
+                        name: 'Args',
+                        builder: argsBuilder,
+                      ),
+                    } else ...{
+                      SettingsPanelData(
+                        name: 'Knobs',
+                        builder: knobsBuilder,
+                      ),
+                    },
+                  },
+                  if (state.canShowPanel(LayoutPanel.addons) &&
+                      state.addons != null) ...{
+                    SettingsPanelData(
+                      name: 'Addons',
+                      builder: addonsBuilder,
+                    ),
+                  },
+                ],
+              ),
+            ),
         ],
       ),
     );

--- a/packages/widgetbook/lib/src/routing/app_route_config.dart
+++ b/packages/widgetbook/lib/src/routing/app_route_config.dart
@@ -16,7 +16,7 @@ class AppRouteConfig {
 
   bool get previewMode => uri.queryParameters.containsKey('preview');
 
-  /// Example: `panels=navigation,settings`
+  /// Example: `panels=navigation,addons,knobs`
   Set<String>? get panels {
     return uri.queryParameters['panels']?.split(',').toSet();
   }

--- a/packages/widgetbook/lib/src/routing/app_route_config.dart
+++ b/packages/widgetbook/lib/src/routing/app_route_config.dart
@@ -6,7 +6,7 @@ class AppRouteConfig {
     required this.uri,
   });
 
-  static const reservedKeys = {'path', 'preview', 'q'};
+  static const reservedKeys = {'path', 'preview', 'q', 'panels'};
 
   final Uri uri;
 
@@ -16,8 +16,13 @@ class AppRouteConfig {
 
   bool get previewMode => uri.queryParameters.containsKey('preview');
 
-  /// Returns a modifiable copy of the query parameters without the
-  /// keys: `path` and `preview`.
+  /// Example: `panels=navigation,settings`
+  Set<String>? get panels {
+    return uri.queryParameters['panels']?.split(',').toSet();
+  }
+
+  /// Returns a modifiable copy of the query parameters
+  /// without the reserved keys.
   Map<String, String> get queryParams {
     return Map<String, String>.from(uri.queryParameters)
       ..removeWhere(

--- a/packages/widgetbook/lib/src/settings/settings_panel.dart
+++ b/packages/widgetbook/lib/src/settings/settings_panel.dart
@@ -25,6 +25,9 @@ class SettingsPanel extends StatelessWidget {
       length: settings.length,
       child: Column(
         children: [
+          // If only one tab (e.g. Knobs), is provided (because the other is
+          // hidden via `panels` query parameter), then we don't need to
+          // show the TabBar.
           if (settings.length > 1)
             TabBar(
               tabs: settings

--- a/packages/widgetbook/lib/src/settings/settings_panel.dart
+++ b/packages/widgetbook/lib/src/settings/settings_panel.dart
@@ -25,22 +25,23 @@ class SettingsPanel extends StatelessWidget {
       length: settings.length,
       child: Column(
         children: [
-          TabBar(
-            tabs: settings
-                .map(
-                  (setting) => Padding(
-                    padding: const EdgeInsets.symmetric(
-                      vertical: 16,
-                      horizontal: 8,
+          if (settings.length > 1)
+            TabBar(
+              tabs: settings
+                  .map(
+                    (setting) => Padding(
+                      padding: const EdgeInsets.symmetric(
+                        vertical: 16,
+                        horizontal: 8,
+                      ),
+                      child: Text(
+                        setting.name,
+                        overflow: TextOverflow.ellipsis,
+                      ),
                     ),
-                    child: Text(
-                      setting.name,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                )
-                .toList(),
-          ),
+                  )
+                  .toList(),
+            ),
           Expanded(
             child: TabBarView(
               children: settings.map(

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -15,6 +15,12 @@ import 'widgetbook_scope.dart';
 
 typedef AppBuilder = Widget Function(BuildContext context, Widget child);
 
+enum LayoutPanel {
+  navigation,
+  addons,
+  knobs,
+}
+
 class WidgetbookState extends ChangeNotifier {
   WidgetbookState({
     this.path,
@@ -26,6 +32,7 @@ class WidgetbookState extends ChangeNotifier {
     this.integrations,
     required this.root,
     this.home = const DefaultHomePage(),
+    this.panels = null,
   }) {
     this.knobs = KnobsRegistry(
       onLock: () {
@@ -44,6 +51,14 @@ class WidgetbookState extends ChangeNotifier {
   String? query;
   bool previewMode;
   Map<String, String> queryParams;
+
+  /// Determines which panels are shown.
+  /// - If `null`, all panels are shown.
+  /// - If empty, no panels are shown (similar to [previewMode]).
+  /// - If [previewMode] is `true`, the [panels] are ignored.
+  ///
+  /// NOTE: this only works in desktop mode.
+  Set<LayoutPanel>? panels;
 
   late final KnobsRegistry knobs;
   final AppBuilder appBuilder;
@@ -67,6 +82,8 @@ class WidgetbookState extends ChangeNotifier {
     final queryParameters = {
       if (path != null) 'path': path,
       if (query?.isNotEmpty ?? false) 'q': query,
+      if (panels?.isNotEmpty ?? false)
+        'panels': panels?.map((x) => x.name).join(','),
       ...queryParams,
     };
 
@@ -96,15 +113,23 @@ class WidgetbookState extends ChangeNotifier {
   void notifyListeners() {
     super.notifyListeners();
 
-    // Do not sync route in preview mode, since the widget state is already
-    // controlled by using the URL.
-    if (!previewMode) {
+    // Do not sync route if the panels are not showing up,
+    // since the widget state is already controlled by using the URL.
+    if (canShowPanel(LayoutPanel.navigation) ||
+        canShowPanel(LayoutPanel.addons) ||
+        canShowPanel(LayoutPanel.knobs)) {
       _syncRouteInformation();
     }
 
     integrations?.forEach(
       (integration) => integration.onChange(this),
     );
+  }
+
+  bool canShowPanel(LayoutPanel panel) {
+    if (previewMode) return false;
+    if (panels == null) return true;
+    return panels!.contains(panel);
   }
 
   /// Syncs this with the router's location using [SystemNavigator].
@@ -184,6 +209,10 @@ class WidgetbookState extends ChangeNotifier {
     query = routeConfig.query;
     previewMode = routeConfig.previewMode;
     queryParams = routeConfig.queryParams;
+    panels = previewMode
+        ? null // Panels are ignored in preview mode
+        : routeConfig.panels?.map(LayoutPanel.values.byName).toSet();
+
     notifyListeners();
   }
 

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -9,6 +9,7 @@ import '../integrations/widgetbook_integration.dart';
 import '../knobs/knobs.dart';
 import '../navigation/navigation.dart';
 import '../routing/routing.dart';
+import '../utils.dart';
 import 'default_app_builders.dart';
 import 'default_home_page.dart';
 import 'widgetbook_scope.dart';
@@ -211,7 +212,10 @@ class WidgetbookState extends ChangeNotifier {
     queryParams = routeConfig.queryParams;
     panels = previewMode
         ? null // Panels are ignored in preview mode
-        : routeConfig.panels?.map(LayoutPanel.values.byName).toSet();
+        : routeConfig.panels
+            ?.map(LayoutPanel.values.byNameOrNull)
+            .nonNulls
+            .toSet();
 
     notifyListeners();
   }

--- a/packages/widgetbook/lib/src/utils.dart
+++ b/packages/widgetbook/lib/src/utils.dart
@@ -1,0 +1,11 @@
+extension EnumByNameOrNull<T extends Enum> on Iterable<T> {
+  /// Finds the enum value in this list with name [name].
+  /// Returns `null` if no enum value with that name is found.
+  T? byNameOrNull(String name) {
+    try {
+      return byName(name);
+    } catch (e) {
+      return null;
+    }
+  }
+}

--- a/packages/widgetbook/test/src/layout/desktop_layout_test.dart
+++ b/packages/widgetbook/test/src/layout/desktop_layout_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/src/layout/desktop_layout.dart';
+import 'package:widgetbook/src/navigation/navigation.dart';
+import 'package:widgetbook/src/settings/settings_panel.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+void main() {
+  group(
+    '$DesktopLayout',
+    () {
+      testWidgets(
+        'given an empty panels query parameter, '
+        'then navigation and settings panels are not displayed',
+        (tester) async {
+          tester.view.physicalSize = const Size(1200, 800);
+          tester.view.devicePixelRatio = 1.0;
+
+          await tester.pumpWidget(
+            const Widgetbook.material(
+              directories: [],
+              initialRoute: '?panels=',
+            ),
+          );
+
+          await tester.pumpAndSettle();
+
+          expect(find.byType(NavigationPanel), findsNothing);
+          expect(find.byType(SettingsPanel), findsNothing);
+
+          addTearDown(tester.view.resetPhysicalSize);
+        },
+      );
+
+      testWidgets(
+        'given a panels query parameter with no navigation, '
+        'then navigation panel is not displayed',
+        (tester) async {
+          tester.view.physicalSize = const Size(1200, 800);
+          tester.view.devicePixelRatio = 1.0;
+
+          await tester.pumpWidget(
+            const Widgetbook.material(
+              directories: [],
+              initialRoute: '?panels=addons,knobs',
+            ),
+          );
+
+          await tester.pumpAndSettle();
+
+          expect(find.byType(NavigationPanel), findsNothing);
+
+          addTearDown(tester.view.resetPhysicalSize);
+        },
+      );
+
+      testWidgets(
+        'given a panels query parameter with no addons or knobs, '
+        'then settings panel is not displayed',
+        (tester) async {
+          tester.view.physicalSize = const Size(1200, 800);
+          tester.view.devicePixelRatio = 1.0;
+
+          await tester.pumpWidget(
+            const Widgetbook.material(
+              directories: [],
+              initialRoute: '?panels=navigation',
+            ),
+          );
+
+          await tester.pumpAndSettle();
+
+          expect(find.byType(SettingsPanel), findsNothing);
+
+          addTearDown(tester.view.resetPhysicalSize);
+        },
+      );
+
+      testWidgets(
+        'given a panels query parameter with no addons, '
+        'then addons tab in settings panel is not displayed',
+        (tester) async {
+          tester.view.physicalSize = const Size(1200, 800);
+          tester.view.devicePixelRatio = 1.0;
+
+          await tester.pumpWidget(
+            const Widgetbook.material(
+              directories: [],
+              initialRoute: '?panels=knobs',
+            ),
+          );
+
+          await tester.pumpAndSettle();
+
+          expect(find.text('Addons'), findsNothing);
+
+          addTearDown(tester.view.resetPhysicalSize);
+        },
+      );
+
+      testWidgets(
+        'given a panels query parameter with no knobs, '
+        'then knobs tab in settings panel is not displayed',
+        (tester) async {
+          tester.view.physicalSize = const Size(1200, 800);
+          tester.view.devicePixelRatio = 1.0;
+
+          await tester.pumpWidget(
+            const Widgetbook.material(
+              directories: [],
+              initialRoute: '?panels=addons',
+            ),
+          );
+
+          await tester.pumpAndSettle();
+
+          expect(find.text('Knobs'), findsNothing);
+
+          addTearDown(tester.view.resetPhysicalSize);
+        },
+      );
+    },
+  );
+}

--- a/packages/widgetbook/test/src/settings/settings_panel_test.dart
+++ b/packages/widgetbook/test/src/settings/settings_panel_test.dart
@@ -11,6 +11,33 @@ void main() {
       const title = 'Panel Title';
 
       testWidgets(
+        'given settings data one item, '
+        'then the title is not displayed',
+        (tester) async {
+          await tester.pumpWidgetWithMaterialApp(
+            SettingsPanel(
+              settings: [
+                SettingsPanelData(
+                  name: title,
+                  builder: (_) => [],
+                ),
+              ],
+            ),
+          );
+
+          expect(
+            find.byType(TabBar),
+            findsNothing,
+          );
+
+          expect(
+            find.text(title),
+            findsNothing,
+          );
+        },
+      );
+
+      testWidgets(
         'given settings data has a name, '
         'then the name is displayed',
         (tester) async {
@@ -19,6 +46,10 @@ void main() {
               settings: [
                 SettingsPanelData(
                   name: title,
+                  builder: (_) => [],
+                ),
+                SettingsPanelData(
+                  name: 'foo',
                   builder: (_) => [],
                 ),
               ],


### PR DESCRIPTION
The `panels` query parameter allows to customize the embedded Widgetbook view by hiding or showing certain panels. For example `?panels=addons,knobs` hides the left navigation panel.