### PR TITLE
fix: ensure fresh state

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Ensure a fresh state is used when building the use-case. This prevented some rebuilds from happening, causing knobs to not be registered properly. ([#1441](https://github.com/widgetbook/widgetbook/pull/1441))
+
 ## 3.13.1
 
 - **FIX**: Add missing fields to `NoneDevice`. These fields were introduced in `device_frame_plus` v1.3.1. ([#1430](https://github.com/widgetbook/widgetbook/pull/1430))

--- a/packages/widgetbook/lib/src/workbench/workbench.dart
+++ b/packages/widgetbook/lib/src/workbench/workbench.dart
@@ -43,21 +43,29 @@ class Workbench extends StatelessWidget {
                   newSetting,
                 );
               },
-              child: Stack(
-                // The Stack is used to loosen the constraints of
-                // the UseCaseBuilder. Without the Stack, UseCaseBuilder
-                // would expand to the whole size of the Workbench.
-                children: [
-                  UseCaseBuilder(
-                    key: ValueKey(state.uri),
-                    builder: (context) {
-                      final state = WidgetbookState.of(context);
-                      final useCase = state.useCase;
+              child: Builder(
+                builder: (context) {
+                  // Get a fresh state that has updated addons,
+                  // as the `state` variable from above might
+                  // be outdated.
+                  final state = WidgetbookState.of(context);
 
-                      return useCase?.build(context) ?? const SizedBox.shrink();
-                    },
-                  ),
-                ],
+                  return Stack(
+                    // The Stack is used to loosen the constraints of
+                    // the UseCaseBuilder. Without the Stack, UseCaseBuilder
+                    // would expand to the whole size of the Workbench.
+                    children: [
+                      UseCaseBuilder(
+                        key: ValueKey(state.uri),
+                        builder: (context) {
+                          final useCase = state.useCase;
+                          return useCase?.build(context) ??
+                              const SizedBox.shrink();
+                        },
+                      ),
+                    ],
+                  );
+                },
               ),
             ),
           ),


### PR DESCRIPTION
Using an old context to retrieve the `WidgetbookState` resulted in outdated states in some cases. When an old state is used, the [key](https://github.com/widgetbook/widgetbook/blob/5f07675bd26d094f09091694c588889e1b972a24/packages/widgetbook/lib/src/workbench/workbench.dart#L52) used in `UseCaseBuilder` remained the same, which prevented the `initState` from being re-called, resulting in knobs not being [`lock()`ed](https://github.com/widgetbook/widgetbook/blob/5f07675bd26d094f09091694c588889e1b972a24/packages/widgetbook/lib/src/workbench/use_case_builder.dart#L26).

