### PR TITLE
fix: unify `color` knob fields' heights

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **FIX**: Ensure a fresh state is used when building the use-case. This prevented some rebuilds from happening, causing knobs to not be registered properly. ([#1441](https://github.com/widgetbook/widgetbook/pull/1441))
 - **FIX**: Handle `null` in `durationOrNull` knob. ([#1444](https://github.com/widgetbook/widgetbook/pull/1444))
+- **FIX**: Unify `color` knob fields' heights. ([#1445](https://github.com/widgetbook/widgetbook/pull/1445))
 
 ## 3.13.1
 

--- a/packages/widgetbook/lib/src/themes.dart
+++ b/packages/widgetbook/lib/src/themes.dart
@@ -93,6 +93,11 @@ class Themes {
       // Flutter version being 3.19.0, which does not have the new parameter.
       // ignore: deprecated_member_use
       fillColor: colorScheme.surfaceVariant,
+      // Match TextField and DropdownMenu heights
+      contentPadding: const EdgeInsets.symmetric(
+        vertical: 16.0,
+        horizontal: 12.0,
+      ),
       focusedBorder: OutlineInputBorder(
         borderSide: BorderSide(
           color: colorScheme.primary,


### PR DESCRIPTION
#### Before

![before](https://github.com/user-attachments/assets/1cf5c6bc-bf1a-4cb4-a824-a1fe26f25be7)

#### After

![after](https://github.com/user-attachments/assets/ad3935d5-651f-421a-a63d-5d0cfe625527)
