### PR TITLE
fix: rebuild `DateTimeField` after using the picker

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **FIX**: Handle `null` in `durationOrNull` knob. ([#1444](https://github.com/widgetbook/widgetbook/pull/1444))
 - **FIX**: Unify `color` knob fields' heights. ([#1445](https://github.com/widgetbook/widgetbook/pull/1445))
 - **FIX**: Prevent falling back to initial/default values when changing `NumInputField`, `DurationField` and `DateTimeField` values. ([#1446](https://github.com/widgetbook/widgetbook/pull/1446))
+- **FIX**: Rebuild `DateTimeField` after using the picker. ([#1447](https://github.com/widgetbook/widgetbook/pull/1447))
 
 ## 3.13.1
 

--- a/packages/widgetbook/lib/src/fields/date_time_field.dart
+++ b/packages/widgetbook/lib/src/fields/date_time_field.dart
@@ -41,6 +41,11 @@ class DateTimeField extends Field<DateTime> {
   @override
   Widget toWidget(BuildContext context, String group, DateTime? value) {
     return TextFormField(
+      // The "value" used in the key ensures that the TextFormField is rebuilt
+      // when the value is changed via the DateTime picker. Without this
+      // unique key, the TextFormField will only react to value changes
+      // triggered by the user typing in the field.
+      key: ValueKey('$group-$name-$value'),
       initialValue: (value ?? initialValue)?.toSimpleFormat(),
       keyboardType: TextInputType.datetime,
       decoration: InputDecoration(


### PR DESCRIPTION
The `TextFormField` value did not reflect the `DateTimeField` value when the picker was used, because Flutter did not rebuild the widget (since is it a stateless one). So by using a `key`, we are forcing Flutter to rebuild the field, when we know it has a different value.