### PR TITLE
refactor: rework nullable knobs

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **FEAT**: Add [`panels` query param](https://docs.widgetbook.io/guides/embedding#customizing-panels) to show/hide panels when embedding Widgetbook. ([#1439](https://github.com/widgetbook/widgetbook/pull/1439))
+- **FEAT**: Rework nullable knobs to allow them to be expressed in the URL. To indicate that a knob is null it can be expressed as `??` (e.g. `/?path=my-use-case&knobs={my_knob:??}`). ([#1450](https://github.com/widgetbook/widgetbook/pull/1450))
 - **FIX**: Ensure a fresh state is used when building the use-case. This prevented some rebuilds from happening, causing knobs to not be registered properly. ([#1441](https://github.com/widgetbook/widgetbook/pull/1441))
 - **FIX**: Handle `null` in `durationOrNull` knob. ([#1444](https://github.com/widgetbook/widgetbook/pull/1444))
 - **FIX**: Unify `color` knob fields' heights. ([#1445](https://github.com/widgetbook/widgetbook/pull/1445))

--- a/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
+++ b/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import '../../fields/fields.dart';
 import '../../knobs/knobs.dart';
 import '../../navigation/navigation.dart';
-import '../../settings/settings.dart';
 import '../addons.dart';
 
 /// [WidgetbookAddon]s are like global [Knob]s, they change the state for all
@@ -23,37 +22,15 @@ import '../addons.dart';
 @optionalTypeArgs
 abstract class WidgetbookAddon<T> extends FieldsComposable<T> {
   WidgetbookAddon({
-    required this.name,
+    required super.name,
     @Deprecated('Use local field instead') this.initialSetting,
   });
-
-  final String name;
 
   @Deprecated('Use local field instead')
   final T? initialSetting;
 
   @override
   String get groupName => slugify(name);
-
-  @override
-  Widget buildFields(BuildContext context) {
-    return Setting(
-      name: name,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: fields
-            .map(
-              (field) => Padding(
-                padding: const EdgeInsets.symmetric(
-                  vertical: 4.0,
-                ),
-                child: field.build(context, groupName),
-              ),
-            )
-            .toList(),
-      ),
-    );
-  }
 
   /// Wraps use cases with a custom widget depending on the addon [setting]
   /// that is obtained from [valueFromQueryGroup].

--- a/packages/widgetbook/lib/src/knobs/knob.dart
+++ b/packages/widgetbook/lib/src/knobs/knob.dart
@@ -2,94 +2,56 @@ import 'package:flutter/widgets.dart';
 
 import '../fields/fields.dart';
 import '../navigation/navigation.dart';
-import '../settings/settings.dart';
-import '../state/state.dart';
 
 /// Allows [WidgetbookUseCase]s to have dynamically adjustable parameters.
 @optionalTypeArgs
 abstract class Knob<T> extends FieldsComposable<T> {
   Knob({
-    required this.label,
-    this.description,
+    required String label,
+    super.description,
     @Deprecated('Use initialValue instead.') T? value,
     T? initialValue,
-    this.isNullable = false,
+    super.isNullable,
     @Deprecated(
       'This parameter is not used anymore. '
       'It defaults to [value == null] instead of [false]',
     )
-    this.isNull = false,
-  }) : this.initialValue = (initialValue ?? value) as T {
-    this.isNull = this.initialValue == null;
-  }
-
-  /// The label that's put above a knob.
-  final String label;
-
-  /// The Description of what the user can put on the knob.
-  final String? description;
+    bool isNull = false,
+  })  : this.initialValue = (initialValue ?? value) as T,
+        super(name: label);
 
   /// The initial value the knob is set to.
   final T initialValue;
 
-  final bool isNullable;
+  // A workaround to avoid breaking changes
+  String get label => name;
 
   @Deprecated(
     'Knobs are stateless. '
     'They know about their value from [valueFromQueryGroup]. '
     'You can use [initialValue] if you want to set a default value. ',
   )
-  T? value;
-
-  bool isNull;
+  // A workaround to avoid breaking changes
+  T? get value => null;
 
   @override
   String get groupName => 'knobs';
 
   @override
-  Widget buildFields(BuildContext context) {
-    return NullableSetting(
-      name: label,
-      description: description,
-      isNull: isNull,
-      isNullable: isNullable,
-      onChangedNullable: (isEnabled) {
-        WidgetbookState.of(context).knobs.updateNullability(
-              label,
-              !isEnabled,
-            );
-      },
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: fields
-            .map(
-              (field) => Padding(
-                padding: const EdgeInsets.symmetric(
-                  vertical: 4.0,
-                ),
-                child: field.build(context, groupName),
-              ),
-            )
-            .toList(),
-      ),
-    );
-  }
-
-  @override
   bool operator ==(Object other) {
     return other is Knob<T> &&
         other.initialValue == initialValue &&
-        other.label == label &&
+        other.name == name &&
         other.description == description;
   }
 
   @override
-  int get hashCode => label.hashCode;
+  int get hashCode => name.hashCode;
 
   @override
   Map<String, dynamic> toJson() {
     return {
-      'name': label,
+      'name': name,
       'group': groupName,
       'nullable': isNullable,
       'fields': fields.map((field) => field.toFullJson()).toList(),

--- a/packages/widgetbook/lib/src/knobs/knobs_registry.dart
+++ b/packages/widgetbook/lib/src/knobs/knobs_registry.dart
@@ -24,16 +24,8 @@ class KnobsRegistry extends ChangeNotifier with MapMixin<String, Knob> {
     Knob<T?> knob,
     Map<String, String> queryGroup,
   ) {
-    final cachedKnob = _registry.putIfAbsent(
-      knob.label,
-      () => knob,
-    );
+    _registry.putIfAbsent(knob.label, () => knob);
 
-    // Return `null` even if the knob has value, but it was marked as null
-    // using [updateNullability].
-    if (cachedKnob.isNullable && cachedKnob.isNull) return null;
-
-    // Get value from query group
     return knob.valueFromQueryGroup(queryGroup);
   }
 
@@ -42,17 +34,6 @@ class KnobsRegistry extends ChangeNotifier with MapMixin<String, Knob> {
     'they rely on query groups.',
   )
   void updateValue<T>(String label, T value) {}
-
-  /// Updates [Knob.isNull] using the [label] to find the [Knob].
-  @internal
-  void updateNullability(String label, bool isNull) {
-    _registry.update(
-      label,
-      (knob) => knob..isNull = isNull,
-    );
-
-    notifyListeners();
-  }
 
   @override
   Knob? operator [](Object? key) => _registry[key as String];

--- a/packages/widgetbook/lib/src/next/args/arg.dart
+++ b/packages/widgetbook/lib/src/next/args/arg.dart
@@ -12,11 +12,13 @@ abstract class Arg<T> extends FieldsComposable<T> {
     T value, {
     String? name,
   })  : $value = value,
-        $name = name;
+        $name = name,
+        super(name: name ?? '');
 
   const Arg.empty()
       : $value = null,
-        $name = null;
+        $name = null,
+        super(name: '');
 
   final T? $value;
   final String? $name;

--- a/packages/widgetbook/lib/src/settings/nullable_setting.dart
+++ b/packages/widgetbook/lib/src/settings/nullable_setting.dart
@@ -8,15 +8,16 @@ class NullableSetting extends Setting {
     required super.name,
     super.description,
     required super.child,
-    required bool isNull,
-    bool isNullable = false,
-    ValueChanged<bool>? onChangedNullable,
+    required bool isNullified,
+    ValueChanged<bool>? onNullified,
   }) : super(
-          trailing: isNullable
-              ? Checkbox(
-                  value: !isNull,
-                  onChanged: (value) => onChangedNullable?.call(value!),
-                )
-              : null,
+          trailing: Checkbox(
+            // The value is inverted here because the checkbox
+            // is unchecked when the value is nullified.
+            // And the onChange callback is called with true when
+            // the value is unchecked (i.e. nullified).
+            value: !isNullified,
+            onChanged: (value) => onNullified?.call(!value!),
+          ),
         );
 }

--- a/packages/widgetbook/test/src/fields/fields_composable_test.dart
+++ b/packages/widgetbook/test/src/fields/fields_composable_test.dart
@@ -5,6 +5,8 @@ import 'package:widgetbook/widgetbook.dart';
 import 'field_test.dart';
 
 class MockFieldsComposable extends FieldsComposable<bool> {
+  MockFieldsComposable() : super(name: '$MockFieldsComposable');
+
   @override
   Widget buildFields(BuildContext context) {
     return Container();

--- a/packages/widgetbook/test/src/knobs/knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/knob_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:widgetbook/src/settings/nullable_setting.dart';
+import 'package:widgetbook/src/settings/settings.dart';
 import 'package:widgetbook/widgetbook.dart';
 
 import '../../helper/helper.dart';
@@ -8,13 +8,18 @@ import '../../helper/helper.dart';
 class MockKnob extends Knob<bool?> {
   MockKnob({
     required super.label,
-    super.value = true,
+    super.initialValue = true,
     super.description,
     super.isNullable = false,
   });
 
   @override
-  List<Field> get fields => [];
+  List<Field> get fields => [
+        BooleanField(
+          name: label,
+          initialValue: initialValue,
+        ),
+      ];
 
   @override
   bool valueFromQueryGroup(Map<String, String> group) {
@@ -27,7 +32,8 @@ void main() {
     '$Knob',
     () {
       testWidgets(
-        'then it should build a [$NullableSetting]',
+        'given a non-nullable knob,'
+        'then it should build a [$Setting]',
         (tester) async {
           final knob = MockKnob(
             label: 'Mock Knob',
@@ -39,7 +45,7 @@ void main() {
           );
 
           expect(
-            find.byType(NullableSetting),
+            find.byType(Setting),
             findsOneWidget,
           );
         },
@@ -67,7 +73,7 @@ void main() {
           final knob = MockKnob(
             label: 'Mock Knob',
             isNullable: true,
-            value: null,
+            initialValue: null,
           );
 
           await tester.pumpKnob(
@@ -92,7 +98,7 @@ void main() {
           final knob = MockKnob(
             label: 'Mock Knob',
             isNullable: true,
-            value: false,
+            initialValue: false,
           );
 
           await tester.pumpKnob(

--- a/packages/widgetbook/test/src/knobs/string_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/string_knob_test.dart
@@ -73,7 +73,6 @@ void main() {
             text,
           );
 
-          await tester.findAndTap(find.byType(Checkbox));
           expect(find.textWidget(text), findsOneWidget);
         },
       );
@@ -101,10 +100,10 @@ void main() {
           );
 
           await tester.findAndTap(find.byType(Checkbox));
-          expect(find.textWidget(text), findsOneWidget);
+          expect(find.textWidget('null'), findsOneWidget);
 
           await tester.findAndTap(find.byType(Checkbox));
-          expect(find.textWidget('null'), findsOneWidget);
+          expect(find.textWidget(text), findsOneWidget);
         },
       );
     },

--- a/packages/widgetbook/test/src/state/widgetbook_state_test.dart
+++ b/packages/widgetbook/test/src/state/widgetbook_state_test.dart
@@ -158,13 +158,25 @@ void main() {
             ),
           );
 
-          state.knobs
-            ..register(knob, state.queryParams)
-            ..updateNullability(knob.label, true);
+          final groupMap = FieldCodec.decodeQueryGroup(
+            state.queryParams['knobs'],
+          );
+
+          state.knobs.register(knob, groupMap);
+
+          state.updateQueryField(
+            group: 'knobs',
+            field: knob.label,
+            value: '${Field.nullabilitySymbol}any_value',
+          );
+
+          final updateGroupMap = FieldCodec.decodeQueryGroup(
+            state.queryParams['knobs'],
+          );
 
           final result = state.knobs.register(
             knob,
-            state.queryParams,
+            updateGroupMap,
           );
 
           expect(result, isNull);

--- a/sandbox/lib/settings/nullable_setting.dart
+++ b/sandbox/lib/settings/nullable_setting.dart
@@ -6,19 +6,9 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 @UseCase(name: 'Default', type: NullableSetting)
 Widget nullableSettingUseCase(BuildContext context) {
   return NullableSetting(
-    name: context.knobs.string(
-      label: 'Name',
-      initialValue: 'Knob',
-    ),
-    description: context.knobs.stringOrNull(
-      label: 'Description',
-    ),
-    isNull: context.knobs.boolean(
-      label: 'Is Null',
-    ),
-    isNullable: context.knobs.boolean(
-      label: 'Is Nullable',
-    ),
+    name: context.knobs.string(label: 'Name', initialValue: 'Knob'),
+    description: context.knobs.stringOrNull(label: 'Description'),
+    isNullified: context.knobs.boolean(label: 'Is Nullified'),
     child: const Placeholder(),
   );
 }


### PR DESCRIPTION
Previously, the null state of the knob was held inside the `Knob` class, and not reflected in the URL. This prevented the `nullable` knobs from being supported in the `KnobConfig` for multi-snapshot feature.

With this PR, nullable knobs can be expressed as follows:
1. `/?path=my-use-case&knobs={my-knob:??}` - just null
2. `/?path=my-use-case&knobs={my-knob:??my-value}` - `my-value` will be used when the knob is activated via the checkbox.