### PR TITLE
feat(annotation): add `NullKnobConfig`

### DIFF
--- a/docs/cloud/reviews/multi-snapshot.mdx
+++ b/docs/cloud/reviews/multi-snapshot.mdx
@@ -48,7 +48,7 @@ If you are using [Widgetbook Cloud Review](/cloud/reviews), you can now create m
 ## Multi Snapshot for Knobs
 
 1. Go to the file where your use-case is defined.
-1. Add the configurations matrix to the `cloudKnobsConfigs` parameter of the `@UseCase` annotation. In this example we want to test "Disabled Long Text" and "Enabled Short Text" variants of the use-case:
+1. Add the configurations matrix to the `cloudKnobsConfigs` parameter of the `@UseCase` annotation. In this example we want to test two common variants of the use-case:
 
 ```dart
 
@@ -56,13 +56,15 @@ If you are using [Widgetbook Cloud Review](/cloud/reviews), you can now create m
   name: 'Default',
   type: Button,
   cloudAddonsConfigs: {
-    'Disabled Long Text': [
+    'Disabled Long Text Without Badge': [
       BooleanKnobConfig('enabled', false),
       StringKnobConfig('text', 'This is a very very long text for a button that might cause overflow'),
+      NullKnobConfig('badge'),
     ],
-    'Enabled Short Text': [
+    'Enabled Short Text With Badge': [
       BooleanKnobConfig('enabled', true),
       StringKnobConfig('text', 'Button'),
+      IntKnobConfig('badge', 1),
     ],
   },
 )
@@ -70,6 +72,7 @@ Widget buildButtonUseCase(BuildContext context) {
   return Button(
     text: context.knobs.string(label: 'text'),
     enabled: context.knobs.boolean(label: 'enabled'),
+    badge: context.knobs.intOrNull(label: 'badge'),
   );
 }
 ```

--- a/docs/knobs/bool.mdx
+++ b/docs/knobs/bool.mdx
@@ -87,8 +87,8 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart';
   type: Checkbox,
   name: 'Duo state',
   cloudKnobsConfigs: { // [!code highlight]
-    'on': [BooleanKnobConfig('value', true)], // [!code highlight]
-    'off': [BooleanKnobConfig('value', false)], // [!code highlight]
+    'Checked': [BooleanKnobConfig('value', true)], // [!code highlight]
+    'Unchecked': [BooleanKnobConfig('value', false)], // [!code highlight]
   }, // [!code highlight]
 )
 Widget buildCheckboxUseCase(BuildContext context) {
@@ -101,5 +101,24 @@ Widget buildCheckboxUseCase(BuildContext context) {
 
 ### Nullable Bool Knob
 
-Multi-snapshot support is currently not available for the nullable bool knob.
-We're working on adding this feature until the mid of May 2025.
+```dart title="Example: NullKnobConfig"
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart';
+
+@UseCase(
+  type: Checkbox,
+  name: 'Tristate',
+  cloudKnobsConfigs: { // [!code highlight]
+    'Mixed': [NullKnobConfig('value')], // [!code highlight]
+    'Checked': [BooleanKnobConfig('value', true)], // [!code highlight]
+    'Unchecked': [BooleanKnobConfig('value', false)], // [!code highlight]
+  }, // [!code highlight]
+)
+Widget buildCheckboxUseCase(BuildContext context) {
+  return Checkbox(
+    value: context.knobs.booleanOrNull(label: 'value'),
+    onChanged: (value) {},
+  );
+}
+```

--- a/docs/knobs/color.mdx
+++ b/docs/knobs/color.mdx
@@ -68,7 +68,7 @@ Widget buildUseCase(BuildContext context) {
 
 Multi-snapshot support allows you to generate multiple screenshots of a single use case with varying values using [KnobsConfigs](/cloud/reviews/multi-snapshot#multi-snapshot-for-knobs) and [AddonsConfigs](/cloud/reviews/multi-snapshot#multi-snapshot-for-addons).
 
-### Regular String Knob
+### Regular Color Knob
 
 ```dart title="Example: ColorKnobConfig"
 import 'package:flutter/material.dart';
@@ -89,7 +89,24 @@ Widget buildUseCase(BuildContext context) {
 }
 ```
 
-### Nullable String Knob
+### Nullable Color Knob
 
-Multi-snapshot support is currently not available for the nullable String knob.
-We're working on adding this feature until the mid of May 2025.
+```dart title="Example: NullKnobConfig"
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart';
+
+@UseCase(
+  type: MyWidget,
+  name: 'Default',
+  cloudKnobsConfigs: { // [!code highlight]
+    'No color': [NullKnobConfig('color')], // [!code highlight]
+    'Red': [ColorKnobConfig('color', 'FFF44336')], // [!code highlight]
+  }, // [!code highlight]
+)
+Widget buildUseCase(BuildContext context) {
+  return MyWidget(
+    color: context.knobs.colorOrNull(label: 'color'),
+  );
+}
+```

--- a/docs/knobs/datetime.mdx
+++ b/docs/knobs/datetime.mdx
@@ -82,12 +82,35 @@ Multi-snapshot support allows you to generate multiple screenshots of a single u
 
 ### Regular DateTime Knob
 
-```dart title="Example: StringKnobConfig"
+```dart title="Example: DateTimeKnobConfig"
 @UseCase(
   type: MyWidget,
   name: 'Default',
   cloudKnobsConfigs: { // [!code highlight]
     'dateTime': [DateTimeKnobConfig('dateTime', '2020-01-31 16:10')], // [!code highlight]
+  }, // [!code highlight]
+)
+Widget buildUseCase(BuildContext context) {
+  return MyWidget(
+    dateTime: context.knobs.dateTime(
+      label: 'dateTime',
+      initialValue: DateTime.now(),
+      start: DateTime.now().subtract(const Duration(days: 30)),
+      end: DateTime.now().add(const Duration(days: 30)),
+    ),
+  );
+}
+```
+
+### Nullable DateTime Knob
+
+```dart title="Example: NullKnobConfig"
+@UseCase(
+  type: MyWidget,
+  name: 'Default',
+  cloudKnobsConfigs: { // [!code highlight]
+    'Without date': [NullKnobConfig('dateTime')], // [!code highlight]
+    'With date': [DateTimeKnobConfig('dateTime', '2020-01-31 16:10')], // [!code highlight]
   }, // [!code highlight]
 )
 Widget buildUseCase(BuildContext context) {
@@ -100,8 +123,3 @@ Widget buildUseCase(BuildContext context) {
   );
 }
 ```
-
-### Nullable DateTime Knob
-
-Multi-snapshot support is currently not available for the nullable DateTime knob.
-We're working on adding this feature until the mid of May 2025.

--- a/docs/knobs/double/overview.mdx
+++ b/docs/knobs/double/overview.mdx
@@ -58,5 +58,22 @@ Widget buildUseCase(BuildContext context) {
 
 ### Nullable double knob
 
-Multi-snapshot support is currently not available for the nullable double knob.
-We're working on adding this feature until the mid of May 2025.
+```dart title="Example: NullKnobConfig"
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart';
+
+@UseCase(
+  type: MyWidget,
+  name: 'Default',
+  cloudKnobsConfigs: { // [!code highlight]
+    'Without value': [NullKnobConfig('value')], // [!code highlight]
+    'With value': [DoubleKnobConfig('value', 1)], // [!code highlight]
+  }, // [!code highlight]
+)
+Widget buildUseCase(BuildContext context) {
+  return MyWidget(
+    value: context.knobs.doubleOrNull.input(label: 'value'),
+  );
+}
+```

--- a/docs/knobs/duration.mdx
+++ b/docs/knobs/duration.mdx
@@ -81,5 +81,18 @@ Widget buildUseCase(BuildContext context) {
 
 ### Nullable Duration Knob
 
-Multi-snapshot support is currently not available for the nullable Duration knob.
-We're working on adding this feature until the mid of May 2025.
+```dart title="Example: NullKnobConfig"
+@UseCase(
+  type: MyWidget,
+  name: 'Default',
+  cloudKnobsConfigs: { // [!code highlight]
+    'Without duration': [NullKnobConfig('duration')], // [!code highlight]
+    'With duration': [DurationKnobConfig('duration', 2000)], // [!code highlight]
+  }, // [!code highlight]
+)
+Widget buildUseCase(BuildContext context) {
+  return MyWidget(
+    duration: context.knobs.durationOrNull(label: 'duration')
+  );
+}
+```

--- a/docs/knobs/integer/overview.mdx
+++ b/docs/knobs/integer/overview.mdx
@@ -58,5 +58,22 @@ Widget buildUseCase(BuildContext context) {
 
 ### Nullable integer knob
 
-Multi-snapshot support is currently not available for the nullable integer knob.
-We're working on adding this feature until the mid of May 2025.
+```dart title="Example: NullKnobConfig"
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart';
+
+@UseCase(
+  type: MyWidget,
+  name: 'Default',
+  cloudKnobsConfigs: { // [!code highlight]
+    'Without count': [NullKnobConfig('value')], // [!code highlight]
+    'With count': [IntKnobConfig('value', 1)], // [!code highlight]
+  }, // [!code highlight]
+)
+Widget buildUseCase(BuildContext context) {
+  return MyWidget(
+    count: context.knobs.doubleOrNull.input(label: 'count'),
+  );
+}
+```

--- a/docs/knobs/list.mdx
+++ b/docs/knobs/list.mdx
@@ -107,6 +107,34 @@ Multi-snapshot support allows you to generate multiple screenshots of a single u
 )
 Widget buildUseCase(BuildContext context) {
   return MyWidget(
+    status: context.knobs.list(
+      label: 'status',
+      options: [
+        OnlineStatusType.online,
+        OnlineStatusType.offline,
+        OnlineStatusType.busy,
+      ],
+      labelBuilder: (value) => value.name,
+    ),
+  );
+}
+
+enum OnlineStatusType { online, offline, busy }
+```
+
+### Nullable String Knob
+
+```dart title="Example: NullKnobConfig"
+@UseCase(
+  type: MyWidget,
+  name: 'Default',
+  cloudKnobsConfigs: { // [!code highlight]
+    'no status': [NullKnobConfig('status')], // [!code highlight]
+    'online': [ListKnobConfig('status', 'online')], // [!code highlight]
+  }, // [!code highlight]
+)
+Widget buildUseCase(BuildContext context) {
+  return MyWidget(
     status: context.knobs.listOrNull(
       label: 'status',
       options: [
@@ -121,8 +149,3 @@ Widget buildUseCase(BuildContext context) {
 
 enum OnlineStatusType { online, offline, busy }
 ```
-
-### Nullable String Knob
-
-Multi-snapshot support is currently not available for the nullable list knob.
-We're working on adding this feature until the mid of May 2025.

--- a/docs/knobs/string.mdx
+++ b/docs/knobs/string.mdx
@@ -91,5 +91,20 @@ Widget buildUseCase(BuildContext context) {
 
 ### Nullable String Knob
 
-Multi-snapshot support is currently not available for the nullable String knob.
-We're working on adding this feature until the mid of May 2025.
+```dart title="Example: NullKnobConfig"
+import 'package:widgetbook/widgetbook.dart';
+
+@UseCase(
+  type: MyWidget,
+  name: 'Default',
+  cloudKnobsConfigs: { /// [!code highlight]
+    'no name': [NullKnobConfig('name')], // [!code highlight]
+    'with name': [StringKnobConfig('name', 'John Doe')], // [!code highlight]
+  }, // [!code highlight]
+)
+Widget buildUseCase(BuildContext context) {
+  return MyWidget(
+    name: context.knobs.stringOrNull(label: 'name'),
+  );
+}
+```

--- a/packages/widgetbook_annotation/CHANGELOG.md
+++ b/packages/widgetbook_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FEAT**: Add `NullKnobConfig` to support null values in `KnobConfig`s. ([#1451](https://github.com/widgetbook/widgetbook/pull/1451))
+
 ## 3.4.0
 
 - **FEAT**: Add `SemanticsAddonConfig` for supporting the new **experimental** [`SemanticsAddon`](https://docs.widgetbook.io/addons/semantics-addon). ([#1402](https://github.com/widgetbook/widgetbook/pull/1402))

--- a/packages/widgetbook_annotation/lib/src/knob_config.dart
+++ b/packages/widgetbook_annotation/lib/src/knob_config.dart
@@ -14,6 +14,8 @@ class KnobConfig<T> {
   /// ```
   const KnobConfig(this.label, this.value);
 
+  static const nullabilitySymbol = '??';
+
   /// The knob's label.
   final String label;
 
@@ -25,6 +27,20 @@ class KnobConfig<T> {
   MapEntry<String, T> toMapEntry() {
     return MapEntry(label, value);
   }
+}
+
+class NullKnobConfig extends KnobConfig<String> {
+  /// Creates a new [KnobConfig] for the nullable knobs
+  /// with a null value.
+  ///
+  /// ```dart
+  /// const NullKnobConfig('label');
+  /// ```
+  const NullKnobConfig(String label)
+      : super(
+          label,
+          KnobConfig.nullabilitySymbol,
+        );
 }
 
 class IntKnobConfig extends KnobConfig<int> {

--- a/sandbox/lib/settings/nullable_setting.dart
+++ b/sandbox/lib/settings/nullable_setting.dart
@@ -3,7 +3,16 @@ import 'package:widgetbook/src/settings/settings.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 
-@UseCase(name: 'Default', type: NullableSetting)
+@UseCase(
+  name: 'Default',
+  type: NullableSetting,
+  cloudKnobsConfigs: {
+    'Without Description': [NullKnobConfig('Description')],
+    'With Description': [
+      StringKnobConfig('Description', 'This is a description'),
+    ],
+  },
+)
 Widget nullableSettingUseCase(BuildContext context) {
   return NullableSetting(
     name: context.knobs.string(label: 'Name', initialValue: 'Knob'),


### PR DESCRIPTION
If a knob can be `null` (i.e. using the `orNull` variant), then now it can have a `KnobConfig` using the new `NullKnobConfig`:

```dart
@UseCase(
  name: 'Default',
  type: MyWidget,
  cloudKnobsConfigs: {
    'Without text': [NullKnobConfig('text')],
    'With text': [StringKnobConfig('text', 'lorem ipusm')],
  },
)
Widget buildUseCase(BuildContext context) {
  return MyWidget(
    text: context.knobs.stringOrNull(label: 'text'),
  );
}
```