### PR TITLE
feat: add `safeAreas` to viewports

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **FEAT**: Add [`header` parameter](https://docs.widgetbook.io/guides/customization#header-widget) to Widgetbook to allow adding a custom header to the navigation sidebar. ([#1443](https://github.com/widgetbook/widgetbook/pull/1443) - by [@Sourav-Sonkar](https://github.com/Sourav-Sonkar))
 - **FEAT**: Add [`panels` query param](https://docs.widgetbook.io/guides/embedding#customizing-panels) to show/hide panels when embedding Widgetbook. ([#1439](https://github.com/widgetbook/widgetbook/pull/1439))
 - **FEAT**: Rework nullable knobs to allow them to be expressed in the URL. To indicate that a knob is null it can be expressed as `??` (e.g. `/?path=my-use-case&knobs={my_knob:??}`). ([#1450](https://github.com/widgetbook/widgetbook/pull/1450))
+- **FEAT**: Add `safeAreas` to viewports. ([#1452](https://github.com/widgetbook/widgetbook/pull/1452))
 - **FIX**: Ensure a fresh state is used when building the use-case. This prevented some rebuilds from happening, causing knobs to not be registered properly. ([#1441](https://github.com/widgetbook/widgetbook/pull/1441))
 - **FIX**: Handle `null` in `durationOrNull` knob. ([#1444](https://github.com/widgetbook/widgetbook/pull/1444))
 - **FIX**: Unify `color` knob fields' heights. ([#1445](https://github.com/widgetbook/widgetbook/pull/1445))

--- a/packages/widgetbook/lib/src/addons/viewport_addon/viewport.dart
+++ b/packages/widgetbook/lib/src/addons/viewport_addon/viewport.dart
@@ -22,6 +22,8 @@ class Viewport extends StatelessWidget {
     final mediaQuery = MediaQuery.of(context).copyWith(
       size: data.size,
       devicePixelRatio: data.pixelRatio,
+      padding: data.safeAreas,
+      viewPadding: data.safeAreas,
     );
 
     final theme = Theme.of(context).copyWith(

--- a/packages/widgetbook/lib/src/addons/viewport_addon/viewport_data.dart
+++ b/packages/widgetbook/lib/src/addons/viewport_addon/viewport_data.dart
@@ -1,6 +1,5 @@
-import 'dart:ui';
-
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
 import 'package:meta/meta.dart';
 
 @experimental
@@ -12,6 +11,7 @@ class ViewportData {
     required this.height,
     required this.pixelRatio,
     required this.platform,
+    this.safeAreas = EdgeInsets.zero,
   });
 
   final String id;
@@ -20,6 +20,7 @@ class ViewportData {
   final double height;
   final double pixelRatio;
   final TargetPlatform platform;
+  final EdgeInsets safeAreas;
 
   Size get size => Size(width, height);
 }

--- a/packages/widgetbook/lib/src/addons/viewport_addon/viewports/android_viewports.dart
+++ b/packages/widgetbook/lib/src/addons/viewport_addon/viewports/android_viewports.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
 
 import '../viewport_data.dart';
 
@@ -30,6 +31,10 @@ abstract class AndroidViewports {
     height: 800,
     pixelRatio: 4,
     platform: TargetPlatform.android,
+    safeAreas: const EdgeInsets.only(
+      top: 40,
+      bottom: 20,
+    ),
   );
 
   static const samsungGalaxyA50 = ViewportData(
@@ -39,6 +44,10 @@ abstract class AndroidViewports {
     height: 892,
     pixelRatio: 2.625,
     platform: TargetPlatform.android,
+    safeAreas: const EdgeInsets.only(
+      top: 32,
+      bottom: 32,
+    ),
   );
 
   static const samsungGalaxyNote20 = ViewportData(
@@ -48,6 +57,10 @@ abstract class AndroidViewports {
     height: 916,
     pixelRatio: 2.625,
     platform: TargetPlatform.android,
+    safeAreas: const EdgeInsets.only(
+      top: 48,
+      bottom: 32,
+    ),
   );
 
   static const samsungGalaxyNote20Ultra = ViewportData(
@@ -57,6 +70,10 @@ abstract class AndroidViewports {
     height: 883,
     pixelRatio: 3.5,
     platform: TargetPlatform.android,
+    safeAreas: const EdgeInsets.only(
+      top: 36,
+      bottom: 24,
+    ),
   );
 
   static const samsungGalaxyS20 = ViewportData(
@@ -66,6 +83,10 @@ abstract class AndroidViewports {
     height: 800,
     pixelRatio: 4,
     platform: TargetPlatform.android,
+    safeAreas: const EdgeInsets.only(
+      top: 32,
+      bottom: 32,
+    ),
   );
 
   static const sonyXperia1II = ViewportData(
@@ -75,6 +96,9 @@ abstract class AndroidViewports {
     height: 960,
     pixelRatio: 4,
     platform: TargetPlatform.android,
+    safeAreas: const EdgeInsets.only(
+      top: 24,
+    ),
   );
 
   static const smallTablet = ViewportData(
@@ -84,6 +108,9 @@ abstract class AndroidViewports {
     height: 1280,
     pixelRatio: 2,
     platform: TargetPlatform.android,
+    safeAreas: const EdgeInsets.only(
+      top: 24,
+    ),
   );
 
   static const mediumTablet = ViewportData(
@@ -93,6 +120,9 @@ abstract class AndroidViewports {
     height: 1350,
     pixelRatio: 2,
     platform: TargetPlatform.android,
+    safeAreas: const EdgeInsets.only(
+      top: 24,
+    ),
   );
 
   static const largeTablet = ViewportData(
@@ -102,5 +132,8 @@ abstract class AndroidViewports {
     height: 1880,
     pixelRatio: 2,
     platform: TargetPlatform.android,
+    safeAreas: const EdgeInsets.only(
+      top: 24,
+    ),
   );
 }

--- a/packages/widgetbook/lib/src/addons/viewport_addon/viewports/ios_viewports.dart
+++ b/packages/widgetbook/lib/src/addons/viewport_addon/viewports/ios_viewports.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
 
 import '../viewport_data.dart';
 
@@ -33,6 +34,10 @@ abstract class IosViewports {
     height: 812,
     pixelRatio: 3,
     platform: TargetPlatform.iOS,
+    safeAreas: const EdgeInsets.only(
+      top: 44,
+      bottom: 34,
+    ),
   );
 
   static const iPhone12 = ViewportData(
@@ -42,6 +47,10 @@ abstract class IosViewports {
     height: 844,
     pixelRatio: 3,
     platform: TargetPlatform.iOS,
+    safeAreas: const EdgeInsets.only(
+      top: 24,
+      bottom: 20,
+    ),
   );
 
   static const iPhone12ProMax = ViewportData(
@@ -51,6 +60,10 @@ abstract class IosViewports {
     height: 926,
     pixelRatio: 3,
     platform: TargetPlatform.iOS,
+    safeAreas: const EdgeInsets.only(
+      top: 44,
+      bottom: 34,
+    ),
   );
 
   static const iPhone13Mini = ViewportData(
@@ -60,6 +73,10 @@ abstract class IosViewports {
     height: 812,
     pixelRatio: 2,
     platform: TargetPlatform.iOS,
+    safeAreas: const EdgeInsets.only(
+      top: 47,
+      bottom: 34,
+    ),
   );
 
   static const iPhone13 = ViewportData(
@@ -69,6 +86,10 @@ abstract class IosViewports {
     height: 844,
     pixelRatio: 3,
     platform: TargetPlatform.iOS,
+    safeAreas: const EdgeInsets.only(
+      top: 47,
+      bottom: 34,
+    ),
   );
 
   static const iPhone13ProMax = ViewportData(
@@ -78,6 +99,10 @@ abstract class IosViewports {
     height: 926,
     pixelRatio: 3,
     platform: TargetPlatform.iOS,
+    safeAreas: const EdgeInsets.only(
+      top: 47,
+      bottom: 34,
+    ),
   );
 
   static const iPhoneSE = ViewportData(
@@ -87,6 +112,9 @@ abstract class IosViewports {
     height: 667,
     pixelRatio: 2,
     platform: TargetPlatform.iOS,
+    safeAreas: const EdgeInsets.only(
+      top: 20,
+    ),
   );
 
   static const iPadAir4 = ViewportData(
@@ -96,6 +124,9 @@ abstract class IosViewports {
     height: 1180,
     pixelRatio: 3,
     platform: TargetPlatform.iOS,
+    safeAreas: const EdgeInsets.only(
+      top: 20,
+    ),
   );
 
   static const iPad = ViewportData(
@@ -105,6 +136,9 @@ abstract class IosViewports {
     height: 1080,
     pixelRatio: 2,
     platform: TargetPlatform.iOS,
+    safeAreas: const EdgeInsets.only(
+      top: 20,
+    ),
   );
 
   static const iPadPro11Inches = ViewportData(
@@ -114,6 +148,9 @@ abstract class IosViewports {
     height: 1194,
     pixelRatio: 3,
     platform: TargetPlatform.iOS,
+    safeAreas: const EdgeInsets.only(
+      top: 20,
+    ),
   );
 
   static const iPad12InchesGen2 = ViewportData(
@@ -123,6 +160,9 @@ abstract class IosViewports {
     height: 1366,
     pixelRatio: 2,
     platform: TargetPlatform.iOS,
+    safeAreas: const EdgeInsets.only(
+      top: 20,
+    ),
   );
 
   static const iPad12InchesGen4 = ViewportData(
@@ -132,5 +172,9 @@ abstract class IosViewports {
     height: 1366,
     pixelRatio: 2,
     platform: TargetPlatform.iOS,
+    safeAreas: const EdgeInsets.only(
+      top: 24,
+      bottom: 20,
+    ),
   );
 }


### PR DESCRIPTION
Add padding info to `MediaQuery`, to make `SafeArea` widget behave correctly inside the `ViewportAddon`.

| Before | After |
| ------ | ----- |
| ![before](https://github.com/user-attachments/assets/8f1eb5f7-7eab-4797-837b-887bb8cb85f7) | ![after](https://github.com/user-attachments/assets/c6ca347d-d2d4-4593-afe7-238ac3ff3ffb) |
