### PR TITLE
refactor: remove viewport `id`

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **FEAT**: Add [`panels` query param](https://docs.widgetbook.io/guides/embedding#customizing-panels) to show/hide panels when embedding Widgetbook. ([#1439](https://github.com/widgetbook/widgetbook/pull/1439))
 - **FEAT**: Rework nullable knobs to allow them to be expressed in the URL. To indicate that a knob is null it can be expressed as `??` (e.g. `/?path=my-use-case&knobs={my_knob:??}`). ([#1450](https://github.com/widgetbook/widgetbook/pull/1450))
 - **FEAT**: Add `safeAreas` to viewports. ([#1452](https://github.com/widgetbook/widgetbook/pull/1452))
+- **REFACTOR**: Remove `ViewportData.id` in favor of `ViewportData.name`. ([#1454](https://github.com/widgetbook/widgetbook/pull/1454))
 - **FIX**: Ensure a fresh state is used when building the use-case. This prevented some rebuilds from happening, causing knobs to not be registered properly. ([#1441](https://github.com/widgetbook/widgetbook/pull/1441))
 - **FIX**: Handle `null` in `durationOrNull` knob. ([#1444](https://github.com/widgetbook/widgetbook/pull/1444))
 - **FIX**: Unify `color` knob fields' heights. ([#1445](https://github.com/widgetbook/widgetbook/pull/1445))

--- a/packages/widgetbook/lib/src/addons/viewport_addon/viewport.dart
+++ b/packages/widgetbook/lib/src/addons/viewport_addon/viewport.dart
@@ -44,7 +44,7 @@ class Viewport extends StatelessWidget {
                       // we don't want that in the frameless mode
                       padding: const EdgeInsets.all(16),
                       child: _ViewportFrame(
-                        title: data.name ?? data.id,
+                        title: data.name,
                         child: child!,
                       ),
                     );

--- a/packages/widgetbook/lib/src/addons/viewport_addon/viewport_addon.dart
+++ b/packages/widgetbook/lib/src/addons/viewport_addon/viewport_addon.dart
@@ -45,16 +45,16 @@ class ViewportAddon extends WidgetbookAddon<ViewportData> {
   @override
   List<Field> get fields => [
         ListField<ViewportData>(
-          name: 'id',
+          name: 'name',
           initialValue: viewports.first,
           values: viewports,
-          labelBuilder: (viewport) => viewport.id,
+          labelBuilder: (viewport) => viewport.name,
         ),
       ];
 
   @override
   ViewportData valueFromQueryGroup(Map<String, String> group) {
-    return valueOf<ViewportData>('id', group)!;
+    return valueOf<ViewportData>('name', group)!;
   }
 
   @override

--- a/packages/widgetbook/lib/src/addons/viewport_addon/viewport_data.dart
+++ b/packages/widgetbook/lib/src/addons/viewport_addon/viewport_data.dart
@@ -5,8 +5,7 @@ import 'package:meta/meta.dart';
 @experimental
 class ViewportData {
   const ViewportData({
-    required this.id,
-    this.name,
+    required this.name,
     required this.width,
     required this.height,
     required this.pixelRatio,
@@ -14,8 +13,7 @@ class ViewportData {
     this.safeAreas = EdgeInsets.zero,
   });
 
-  final String id;
-  final String? name;
+  final String name;
   final double width;
   final double height;
   final double pixelRatio;

--- a/packages/widgetbook/lib/src/addons/viewport_addon/viewports/android_viewports.dart
+++ b/packages/widgetbook/lib/src/addons/viewport_addon/viewports/android_viewports.dart
@@ -25,7 +25,6 @@ abstract class AndroidViewports {
   ];
 
   static const onePlus8Pro = ViewportData(
-    id: 'one-plus-8-pro',
     name: 'OnePlus 8 Pro',
     width: 360,
     height: 800,
@@ -38,7 +37,6 @@ abstract class AndroidViewports {
   );
 
   static const samsungGalaxyA50 = ViewportData(
-    id: 'samsung-galaxy-a50',
     name: 'Samsung Galaxy A50',
     width: 412,
     height: 892,
@@ -51,7 +49,6 @@ abstract class AndroidViewports {
   );
 
   static const samsungGalaxyNote20 = ViewportData(
-    id: 'samsung-galaxy-note20',
     name: 'Samsung Galaxy Note 20',
     width: 412,
     height: 916,
@@ -64,7 +61,6 @@ abstract class AndroidViewports {
   );
 
   static const samsungGalaxyNote20Ultra = ViewportData(
-    id: 'samsung-galaxy-note20-ultra',
     name: 'Samsung Galaxy Note 20 Ultra',
     width: 412,
     height: 883,
@@ -77,7 +73,6 @@ abstract class AndroidViewports {
   );
 
   static const samsungGalaxyS20 = ViewportData(
-    id: 'samsung-galaxy-s20',
     name: 'Samsung Galaxy S20',
     width: 360,
     height: 800,
@@ -90,7 +85,6 @@ abstract class AndroidViewports {
   );
 
   static const sonyXperia1II = ViewportData(
-    id: 'sony-xperia-1-ii',
     name: 'Sony Xperia 1 II',
     width: 411,
     height: 960,
@@ -102,8 +96,7 @@ abstract class AndroidViewports {
   );
 
   static const smallTablet = ViewportData(
-    id: 'small-android-tablet',
-    name: 'Small Tablet',
+    name: 'Small Android Tablet',
     width: 800,
     height: 1280,
     pixelRatio: 2,
@@ -114,7 +107,6 @@ abstract class AndroidViewports {
   );
 
   static const mediumTablet = ViewportData(
-    id: 'medium-android-tablet',
     name: 'Medium Android Tablet',
     width: 1024,
     height: 1350,
@@ -126,7 +118,6 @@ abstract class AndroidViewports {
   );
 
   static const largeTablet = ViewportData(
-    id: 'large-android-tablet',
     name: 'Large Android Tablet',
     width: 1280,
     height: 1880,

--- a/packages/widgetbook/lib/src/addons/viewport_addon/viewports/ios_viewports.dart
+++ b/packages/widgetbook/lib/src/addons/viewport_addon/viewports/ios_viewports.dart
@@ -28,7 +28,6 @@ abstract class IosViewports {
   ];
 
   static const iPhone12Mini = ViewportData(
-    id: 'iphone-12-mini',
     name: 'iPhone 12 Mini',
     width: 375,
     height: 812,
@@ -41,7 +40,6 @@ abstract class IosViewports {
   );
 
   static const iPhone12 = ViewportData(
-    id: 'iphone-12',
     name: 'iPhone 12',
     width: 390,
     height: 844,
@@ -54,7 +52,6 @@ abstract class IosViewports {
   );
 
   static const iPhone12ProMax = ViewportData(
-    id: 'iphone-12-pro-max',
     name: 'iPhone 12 Pro Max',
     width: 428,
     height: 926,
@@ -67,7 +64,6 @@ abstract class IosViewports {
   );
 
   static const iPhone13Mini = ViewportData(
-    id: 'iphone-13-mini',
     name: 'iPhone 13 Mini',
     width: 375,
     height: 812,
@@ -80,7 +76,6 @@ abstract class IosViewports {
   );
 
   static const iPhone13 = ViewportData(
-    id: 'iphone-13',
     name: 'iPhone 13',
     width: 390,
     height: 844,
@@ -93,7 +88,6 @@ abstract class IosViewports {
   );
 
   static const iPhone13ProMax = ViewportData(
-    id: 'iphone-13-pro-max',
     name: 'iPhone 13 Pro Max',
     width: 428,
     height: 926,
@@ -106,7 +100,6 @@ abstract class IosViewports {
   );
 
   static const iPhoneSE = ViewportData(
-    id: 'iphone-se',
     name: 'iPhone SE',
     width: 375,
     height: 667,
@@ -118,7 +111,6 @@ abstract class IosViewports {
   );
 
   static const iPadAir4 = ViewportData(
-    id: 'ipad-air-4',
     name: 'iPad Air 4',
     width: 820,
     height: 1180,
@@ -130,7 +122,6 @@ abstract class IosViewports {
   );
 
   static const iPad = ViewportData(
-    id: 'ipad',
     name: 'iPad',
     width: 810,
     height: 1080,
@@ -142,7 +133,6 @@ abstract class IosViewports {
   );
 
   static const iPadPro11Inches = ViewportData(
-    id: 'ipad-pro-11inches',
     name: 'iPad Pro (11")',
     width: 834,
     height: 1194,
@@ -154,7 +144,6 @@ abstract class IosViewports {
   );
 
   static const iPad12InchesGen2 = ViewportData(
-    id: 'ipad-pro-12inches-gen2',
     name: 'iPad Pro (12" gen 2)',
     width: 1024,
     height: 1366,
@@ -166,7 +155,6 @@ abstract class IosViewports {
   );
 
   static const iPad12InchesGen4 = ViewportData(
-    id: 'ipad-pro-12inches-gen4',
     name: 'iPad Pro (12" gen 4)',
     width: 1024,
     height: 1366,

--- a/packages/widgetbook/lib/src/addons/viewport_addon/viewports/linux_viewports.dart
+++ b/packages/widgetbook/lib/src/addons/viewport_addon/viewports/linux_viewports.dart
@@ -6,7 +6,6 @@ abstract class LinuxViewports {
   static const all = [desktop];
 
   static const desktop = ViewportData(
-    id: 'linux-desktop',
     name: 'Linux Desktop',
     width: 1920,
     height: 1080,

--- a/packages/widgetbook/lib/src/addons/viewport_addon/viewports/macos_viewports.dart
+++ b/packages/widgetbook/lib/src/addons/viewport_addon/viewports/macos_viewports.dart
@@ -9,7 +9,6 @@ abstract class MacosViewports {
   ];
 
   static const desktop = ViewportData(
-    id: 'macos-desktop',
     name: 'macOS Desktop',
     width: 1920,
     height: 1080,
@@ -18,7 +17,6 @@ abstract class MacosViewports {
   );
 
   static const macbookPro = ViewportData(
-    id: 'macbook-pro',
     name: 'MacBook Pro',
     width: 1800 - 30,
     height: 1000 - 30,

--- a/packages/widgetbook/lib/src/addons/viewport_addon/viewports/viewports.dart
+++ b/packages/widgetbook/lib/src/addons/viewport_addon/viewports/viewports.dart
@@ -14,7 +14,6 @@ import 'windows_viewports.dart';
 class NoneViewport extends ViewportData {
   const NoneViewport()
       : super(
-          id: 'none',
           name: 'None',
           width: 0,
           height: 0,

--- a/packages/widgetbook/lib/src/addons/viewport_addon/viewports/windows_viewports.dart
+++ b/packages/widgetbook/lib/src/addons/viewport_addon/viewports/windows_viewports.dart
@@ -6,7 +6,6 @@ abstract class WindowsViewports {
   static const all = [desktop];
 
   static const desktop = ViewportData(
-    id: 'windows-desktop',
     name: 'Windows Desktop',
     width: 1920,
     height: 1080,

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **BREAKING**: Use `ViewportData.name` instead of `ViewportData.id`. Requires `widgetbook` >=3.14.0. ([#1454](https://github.com/widgetbook/widgetbook/pull/1454))
+
 ## 3.12.0
 
 - **FEAT**: Support Multi Snapshot for knobs. For more information, check our [docs](https://docs.widgetbook.io/cloud/reviews/multi-snapshot#multi-snapshot-for-knobs). ([#1394](https://github.com/widgetbook/widgetbook/pull/1394))

--- a/packages/widgetbook_generator/lib/src/generators/addons_configs_builder.dart
+++ b/packages/widgetbook_generator/lib/src/generators/addons_configs_builder.dart
@@ -66,14 +66,14 @@ class AddonsConfigsBuilder extends BaseBuilder {
 
             if (key == 'viewport') {
               final data = reader.read('value');
-              final id = data.read('id').stringValue;
+              final name = data.read('name').stringValue;
               final ratio = data.read('pixelRatio').doubleValue;
               final width = data.read('width').doubleValue;
               final height = data.read('height').doubleValue;
 
               return AddonConfig(
                 key,
-                'id:$id,\$meta:{w:$width,h:$height,p:$ratio}',
+                'name:$name,\$meta:{w:$width,h:$height,p:$ratio}',
               );
             }
 


### PR DESCRIPTION
Since it's not possible to customize the dropdown menu to show viewports names, while still using IDs under the hood, we are removing the `id` as a whole, and replacing it with the `name`.