### PR TITLE
fix(preview): restructure nav paths

### DIFF
--- a/examples/feature_preview/lib/knob-preview.dart
+++ b/examples/feature_preview/lib/knob-preview.dart
@@ -9,7 +9,9 @@ import 'widgets/notification_badge.dart';
 import 'widgets/online_status.dart';
 import 'widgets/user_avatar.dart';
 
-typedef KnobPreview = Widget;
+abstract class KnobPreview extends StatelessWidget {
+  const KnobPreview({super.key});
+}
 
 @UseCase(type: KnobPreview, name: 'Int Input Knob')
 Widget buildIntInputKnob(BuildContext context) {


### PR DESCRIPTION
The typedef caused the structure to differ from what is expected in the docs. 

### Previous structure
`widgets/Widget/*` 

### Expected structure
`KnobPreview/*`