### PR TITLE
fix: support flutter 3.32

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Support Flutter 3.32.0. ([#1467](https://github.com/widgetbook/widgetbook/pull/1467))
+
 ## 3.14.0
 
 - **FEAT**: Add [`header` parameter](https://docs.widgetbook.io/guides/customization#header-widget) to Widgetbook to allow adding a custom header to the navigation sidebar. ([#1443](https://github.com/widgetbook/widgetbook/pull/1443) - by [@Sourav-Sonkar](https://github.com/Sourav-Sonkar))

--- a/packages/widgetbook/lib/src/themes.dart
+++ b/packages/widgetbook/lib/src/themes.dart
@@ -24,6 +24,7 @@ class Themes {
     onSurface: Color(0xFFE3E2E6),
     onSurfaceVariant: Color(0xFFC3C6CF),
     outline: Color(0xFF8D9199),
+    outlineVariant: Color(0xFF8D9199),
     onInverseSurface: Color(0xFF1A1C1E),
     inverseSurface: Color(0xFFE3E2E6),
     inversePrimary: Color(0xFF0060A7),
@@ -64,6 +65,7 @@ class Themes {
     onSurface: Color(0xFF1A1C1E),
     onSurfaceVariant: Color(0xFF43474E),
     outline: Color(0xFF73777F),
+    outlineVariant: Color(0xFF73777F),
     onInverseSurface: Color(0xFFE3E2E6),
     inverseSurface: Color(0xFF1A1C1E),
     inversePrimary: Color(0xFFA1C9FF),
@@ -117,9 +119,6 @@ class Themes {
     fontFamily: 'Poppins',
     colorScheme: _darkColorScheme,
     hoverColor: const Color(0xFFE3E2E6).withAlpha(20),
-    tabBarTheme: TabBarTheme(
-      dividerColor: _darkColorScheme.outline,
-    ),
     sliderTheme: SliderThemeData(
       overlayShape: SliderComponentShape.noThumb,
       // By default, this is [ColorScheme.surfaceContainerHighest], but we
@@ -144,9 +143,6 @@ class Themes {
     fontFamily: 'Poppins',
     colorScheme: _lightColorScheme,
     hoverColor: const Color(0xFF1A1C1E).withAlpha(20),
-    tabBarTheme: TabBarTheme(
-      dividerColor: _darkColorScheme.outline,
-    ),
     sliderTheme: SliderThemeData(
       overlayShape: SliderComponentShape.noThumb,
       // By default, this is [ColorScheme.surfaceContainerHighest], but we


### PR DESCRIPTION
Flutter 3.32 introduced a breaking change of changing the type of `tabBarTheme` from `TabBarTheme` to `TabBarThemeData`. Since we support older version of Flutter, we cannot just do that change. Instead, the same color was applied via `ColorScheme.outlineVariant`.