### PR TITLE
fix: tighten `device_frame_plus` constraint

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Tighten `device_frame_plus` version constraints; to prevent the [breaking changes](https://github.com/StorybookToolkit/device_frame_plus/issues/5#issuecomment-2907648670) introduced in v1.4.0. ([#1475](https://github.com/widgetbook/widgetbook/pull/1475))
+
 ## 3.14.1
 
 - **FIX**: Support Flutter 3.32.0. ([#1467](https://github.com/widgetbook/widgetbook/pull/1467))

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
 dependencies:
   accessibility_tools: ^2.0.0
   collection: ^1.15.0
-  device_frame_plus: ^1.2.1
+  device_frame_plus: ">=1.2.1 <1.4.0"
   flutter:
     sdk: flutter
   inspector: ">=2.1.0 <4.0.0"


### PR DESCRIPTION
Tightens dependency constraint for `device_frame_plus` to avoid a breaking change introduced in v1.4.0.

### List of issues which are fixed by the PR
Hotfix for #1474 

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making. (no tests needed, as this was a compilation error)
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
