### PR TITLE
fix: add hint text to input fields

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **FIX**: Unify background color between the workbench and `DeviceFrameAddon`. ([#1461](https://github.com/widgetbook/widgetbook/pull/1461) - by [@ValentinVignal](https://github.com/ValentinVignal))
 - **FIX**: Fix memory leaks by disposing `WidgetbookState`'s `KnobsRegistry`. ([#1487](https://github.com/widgetbook/widgetbook/pull/1487) - by [@ValentinVignal](https://github.com/ValentinVignal))
+- **FIX**: Add hints to `TextField`s to improve accessibility. ([#1483](https://github.com/widgetbook/widgetbook/pull/1483) - by [@lsaudon](https://github.com/lsaudon))
 
 ## 3.14.2
 

--- a/packages/widgetbook/lib/src/fields/color_field/hex_color_picker.dart
+++ b/packages/widgetbook/lib/src/fields/color_field/hex_color_picker.dart
@@ -24,6 +24,7 @@ class HexColorPicker extends StatelessWidget implements OpaqueColorPicker {
       initialValue: hexValue,
       maxLength: 6,
       decoration: const InputDecoration(
+        hintText: 'Enter a hex color',
         counterText: '',
         prefixText: '#',
       ),

--- a/packages/widgetbook/lib/src/fields/color_field/number_text_field.dart
+++ b/packages/widgetbook/lib/src/fields/color_field/number_text_field.dart
@@ -46,6 +46,7 @@ class NumberTextField extends StatelessWidget {
         onChanged(newValue);
       },
       decoration: InputDecoration(
+        hintText: 'Enter a number',
         counterText: '',
         labelText: labelText,
         suffixText: suffixText,

--- a/packages/widgetbook/lib/src/fields/date_time_field.dart
+++ b/packages/widgetbook/lib/src/fields/date_time_field.dart
@@ -49,6 +49,7 @@ class DateTimeField extends Field<DateTime> {
       initialValue: (value ?? initialValue)?.toSimpleFormat(),
       keyboardType: TextInputType.datetime,
       decoration: InputDecoration(
+        hintText: 'Enter a DateTime',
         suffixIcon: IconButton(
           icon: const Icon(Icons.calendar_today_rounded),
           onPressed: () async {

--- a/packages/widgetbook/lib/src/fields/duration_field.dart
+++ b/packages/widgetbook/lib/src/fields/duration_field.dart
@@ -35,6 +35,7 @@ class DurationField extends Field<Duration> {
       initialValue: codec.toParam(value ?? initialValue ?? defaultDuration),
       keyboardType: TextInputType.number,
       decoration: const InputDecoration(
+        hintText: 'Enter a duration',
         suffix: Text('ms'),
       ),
       onChanged: (value) {

--- a/packages/widgetbook/lib/src/fields/num_input_field.dart
+++ b/packages/widgetbook/lib/src/fields/num_input_field.dart
@@ -29,6 +29,7 @@ class NumInputField<T extends num> extends Field<T> {
     return TextFormField(
       initialValue: codec.toParam(value ?? initialValue ?? defaultValue),
       keyboardType: TextInputType.number,
+      decoration: const InputDecoration(hintText: 'Enter a number'),
       inputFormatters: formatters,
       onChanged: (value) {
         final number = codec.toValue(value);

--- a/packages/widgetbook/lib/src/fields/num_input_field.dart
+++ b/packages/widgetbook/lib/src/fields/num_input_field.dart
@@ -29,8 +29,10 @@ class NumInputField<T extends num> extends Field<T> {
     return TextFormField(
       initialValue: codec.toParam(value ?? initialValue ?? defaultValue),
       keyboardType: TextInputType.number,
-      decoration: const InputDecoration(hintText: 'Enter a number'),
       inputFormatters: formatters,
+      decoration: const InputDecoration(
+        hintText: 'Enter a number',
+      ),
       onChanged: (value) {
         final number = codec.toValue(value);
         if (number == null) return;

--- a/packages/widgetbook/lib/src/fields/string_field.dart
+++ b/packages/widgetbook/lib/src/fields/string_field.dart
@@ -26,6 +26,9 @@ class StringField extends Field<String> {
     return TextFormField(
       maxLines: maxLines,
       initialValue: value ?? initialValue,
+      decoration: const InputDecoration(
+        hintText: 'Enter a value',
+      ),
       onChanged: (value) => updateField(context, group, value),
     );
   }

--- a/packages/widgetbook/test/src/fields/color_field_test.dart
+++ b/packages/widgetbook/test/src/fields/color_field_test.dart
@@ -183,6 +183,30 @@ void main() {
           expect(find.text('50'), findsOneWidget);
         },
       );
+
+      testWidgets(
+        'given a field, '
+        'then [toWidget] builds a [$HexColorPicker] the hintText value',
+        (tester) async {
+          await tester.pumpField<Color, ColorPicker>(
+            field,
+            null,
+          );
+
+          await tester.findAndTap(find.byType(DropdownMenu<ColorSpace>));
+          await tester.findAndTap(find.text('HEX').last);
+          await tester.pumpAndSettle();
+
+          final widget = tester.widget<TextField>(
+            find.descendant(
+              of: find.byType(HexColorPicker),
+              matching: find.byType(TextField),
+            ),
+          );
+
+          expect(widget.decoration?.hintText, equals('Enter a hex color'));
+        },
+      );
     },
   );
 }

--- a/packages/widgetbook/test/src/fields/date_time_field_test.dart
+++ b/packages/widgetbook/test/src/fields/date_time_field_test.dart
@@ -86,5 +86,18 @@ void main() {
         expect(widget.initialValue, equals(field.end.toSimpleFormat()));
       },
     );
+
+    testWidgets(
+      'given a field, '
+      'then [toWidget] builds the hintText value',
+      (tester) async {
+        final widget = await tester.pumpField<DateTime, TextField>(
+          field,
+          null,
+        );
+
+        expect(widget.decoration?.hintText, equals('Enter a DateTime'));
+      },
+    );
   });
 }

--- a/packages/widgetbook/test/src/fields/duration_field_test.dart
+++ b/packages/widgetbook/test/src/fields/duration_field_test.dart
@@ -73,6 +73,19 @@ void main() {
         expect(widget.initialValue, equals(tenSecondsInMilliseconds));
       },
     );
+
+    testWidgets(
+      'given a field, '
+      'then [toWidget] builds the hintText value',
+      (tester) async {
+        final widget = await tester.pumpField<Duration, TextField>(
+          field,
+          null,
+        );
+
+        expect(widget.decoration?.hintText, equals('Enter a duration'));
+      },
+    );
   });
 
   group('Duration Codec', () {

--- a/packages/widgetbook/test/src/fields/num_input_field_test.dart
+++ b/packages/widgetbook/test/src/fields/num_input_field_test.dart
@@ -62,6 +62,19 @@ void main() {
           expect(widget.initialValue, equals('7.0'));
         },
       );
+
+      testWidgets(
+        'given a field, '
+        'then [toWidget] builds the hintText value',
+        (tester) async {
+          final widget = await tester.pumpField<double, TextField>(
+            field,
+            null,
+          );
+
+          expect(widget.decoration?.hintText, equals('Enter a number'));
+        },
+      );
     },
   );
 

--- a/packages/widgetbook/test/src/fields/string_field_test.dart
+++ b/packages/widgetbook/test/src/fields/string_field_test.dart
@@ -72,6 +72,19 @@ void main() {
           expect(widget.initialValue, equals(value));
         },
       );
+
+      testWidgets(
+        'given a field, '
+        'then [toWidget] builds the hintText value',
+        (tester) async {
+          final widget = await tester.pumpField<String, TextField>(
+            field,
+            null,
+          );
+
+          expect(widget.decoration?.hintText, equals('Enter a value'));
+        },
+      );
     },
   );
 }


### PR DESCRIPTION
I'm getting errors from the Widgetbook and not from my components with AccessibilityTools

```sh
Accessibility issue 1: Text field is missing a label.

Consider adding a hint or a label to the text field widget. For example:

  TextField(
    inputDecoration: InputDecoration(hint: 'This is hint'),
  )
```

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
