### PR TITLE
fix: dispose `KnobsRegistry` from `WidgetbookState`

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **FIX**: Unify background color between the workbench and `DeviceFrameAddon`. ([#1461](https://github.com/widgetbook/widgetbook/pull/1461) - by [@ValentinVignal](https://github.com/ValentinVignal))
+- **FIX**: Fix memory leaks by disposing `WidgetbookState`'s `KnobsRegistry`. ([#1487](https://github.com/widgetbook/widgetbook/pull/1487) - by [@ValentinVignal](https://github.com/ValentinVignal))
 
 ## 3.14.2
 

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -234,4 +234,10 @@ class WidgetbookState extends ChangeNotifier {
   /// Returns the current active [Story].
   @experimental
   Story? get story => isNext ? useCase as Story : null;
+
+  @override
+  void dispose() {
+    knobs.dispose();
+    super.dispose();
+  }
 }

--- a/packages/widgetbook/test/src/state/widgetbook_state_test.dart
+++ b/packages/widgetbook/test/src/state/widgetbook_state_test.dart
@@ -254,6 +254,31 @@ void main() {
           expect(state.queryParams, <String, String>{});
         },
       );
+
+      test(
+        'given a state, '
+        'when it is disposed, '
+        'its knobs registry is disposed too ',
+        () {
+          final state = WidgetbookState(
+            root: WidgetbookRoot(
+              children: const [],
+            ),
+          );
+          state.dispose();
+
+          expect(
+            () => state.knobs.dispose(),
+            throwsA(
+              isFlutterError.having(
+                (error) => error.message,
+                'message',
+                contains('A KnobsRegistry was used after being disposed'),
+              ),
+            ),
+          );
+        },
+      );
     },
   );
 }


### PR DESCRIPTION
Fixes https://github.com/widgetbook/widgetbook/issues/1486


### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
