### PR TITLE
fix: preserve viewport's title style

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **FIX**: Unify background color between the workbench and `DeviceFrameAddon`. ([#1461](https://github.com/widgetbook/widgetbook/pull/1461) - by [@ValentinVignal](https://github.com/ValentinVignal))
 - **FIX**: Fix memory leaks by disposing `WidgetbookState`'s `KnobsRegistry`. ([#1487](https://github.com/widgetbook/widgetbook/pull/1487) - by [@ValentinVignal](https://github.com/ValentinVignal))
 - **FIX**: Add hints to `TextField`s to improve accessibility. ([#1483](https://github.com/widgetbook/widgetbook/pull/1483) - by [@lsaudon](https://github.com/lsaudon))
+- **FIX**: Preserve Viewport's title style when a custom `ThemeData` is used in the `appBuilder`. ([#1489](https://github.com/widgetbook/widgetbook/pull/1489))
 
 ## 3.14.2
 

--- a/packages/widgetbook/lib/src/addons/viewport_addon/viewport.dart
+++ b/packages/widgetbook/lib/src/addons/viewport_addon/viewport.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 import 'package:nested/nested.dart';
 
+import '../../widgetbook_theme.dart';
 import 'viewport_data.dart';
 
 @experimental
@@ -99,11 +100,16 @@ class _ViewportFrame extends StatelessWidget {
         Transform.translate(
           offset: Offset(-borderWidth, 0),
           child: Container(
-            child: Text(title),
             color: color,
             padding: const EdgeInsets.symmetric(
               vertical: 4,
               horizontal: 12,
+            ),
+            child: Text(
+              title,
+              style: WidgetbookTheme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Colors.black87,
+                  ),
             ),
           ),
         ),


### PR DESCRIPTION
Some users might override the root `Theme` in their `appBuilder` as follows:

```dart
Widgetbook.material(
  appBuilder: (context, child) {
    return MaterialApp(
      theme: MyCustomThemeData()
    ); 
  }
)
```

If `MyCustomThemeData` doesn't have a proper `TextTheme`, then the `Viewport`'s title will get messed up.

![screenshot](https://github.com/user-attachments/assets/3cfa40d5-57a9-428f-a842-227637581268)


This PR uses the `WidgetbookTheme` to ensure that it matches Widgetbook's own theme, and not any other theme down the widget tree.