### PR TITLE
refactor: deprecate `DeviceFrameAddon`

### DIFF
--- a/docs/addons/device-frame-addon.mdx
+++ b/docs/addons/device-frame-addon.mdx
@@ -1,7 +1,7 @@
 # Device Frame Addon
 
 <Warning>
-  This addon will get **deprecated** in the near future. Please use the
+  This addon will be **deprecated** in v3.15. Please use the
   [`ViewportAddon`](/addons/viewport-addon) instead.
 </Warning>
 

--- a/examples/full_example/lib/widgetbook.dart
+++ b/examples/full_example/lib/widgetbook.dart
@@ -23,7 +23,7 @@ class WidgetbookApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return Widgetbook.material(
       addons: [
-        DeviceFrameAddon(devices: Devices.ios.all),
+        ViewportAddon(Viewports.all),
         InspectorAddon(),
         GridAddon(100),
         AlignmentAddon(),

--- a/examples/screen_util_example/lib/widgetbook.dart
+++ b/examples/screen_util_example/lib/widgetbook.dart
@@ -17,13 +17,11 @@ class WidgetbookApp extends StatelessWidget {
     return Widgetbook.material(
       addons: [
         TextScaleAddon(),
-        DeviceFrameAddon(
-          devices: [
-            Devices.ios.iPhoneSE,
-            Devices.ios.iPhone12,
-            Devices.ios.iPhone13,
-          ],
-        ),
+        ViewportAddon([
+          IosViewports.iPhoneSE,
+          IosViewports.iPhone12,
+          IosViewports.iPhone13,
+        ]),
         BuilderAddon(
           name: 'ScreenUtil',
           builder: (context, child) {

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **REFACTOR**: Deprecate `DeviceFrameAddon` in favor of `ViewportAddon`. ([#1494](https://github.com/widgetbook/widgetbook/pull/1494))
 - **REFACTOR**: Remove `@experimental` annotation from `ViewportAddon`. ([#1493](https://github.com/widgetbook/widgetbook/pull/1493))
 
 ## 3.14.3

--- a/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
+++ b/packages/widgetbook/lib/src/addons/common/widgetbook_addon.dart
@@ -17,7 +17,7 @@ import '../addons.dart';
 /// * [CupertinoThemeAddon], changes the active [CupertinoThemeData].
 /// * [TextScaleAddon], changes the active text scale.
 /// * [LocalizationAddon], changes the active [Locale].
-/// * [DeviceFrameAddon], an [WidgetbookAddon] to change the active frame that
+/// * [ViewportAddon], an [WidgetbookAddon] to change the active frame that
 ///   allows to view the [WidgetbookUseCase] on different screens.
 @optionalTypeArgs
 abstract class WidgetbookAddon<T> extends FieldsComposable<T> {

--- a/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/device_frame_addon.dart
@@ -9,6 +9,11 @@ import 'none_device.dart';
 
 /// A [WidgetbookAddon] for changing the active device/frame. It's based on
 /// the [`device_frame`](https://pub.dev/packages/device_frame) package.
+@Deprecated(
+  'The [DeviceFrameAddon] is deprecated and will be removed in a future version. '
+  'Please use the [ViewportAddon] instead. '
+  'More info: https://docs.widgetbook.io/addons/viewport-addon',
+)
 class DeviceFrameAddon extends WidgetbookAddon<DeviceFrameSetting> {
   DeviceFrameAddon({
     required List<DeviceInfo> devices,

--- a/packages/widgetbook/test/src/addons/device_frame_addon_test.dart
+++ b/packages/widgetbook/test/src/addons/device_frame_addon_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widgetbook/src/widgetbook_theme.dart';


### PR DESCRIPTION
The `DeviceFrameAddon` is deprecated because we aim to keep our next major version without much dependencies. That's why we introduced a first-class support for the same feature via the [`ViewportAddon`](https://docs.widgetbook.io/addons/viewport-addon).