### PR TITLE
feat: Expose ScrollBehavior v3

### DIFF
--- a/packages/widgetbook/lib/src/widgetbook.dart
+++ b/packages/widgetbook/lib/src/widgetbook.dart
@@ -25,6 +25,7 @@ class Widgetbook extends StatefulWidget {
     this.appBuilder = widgetsAppBuilder,
     this.addons,
     this.integrations,
+    this.scrollBehavior
   });
 
   /// A [Widgetbook] with [CupertinoApp] as an [appBuilder].
@@ -35,6 +36,7 @@ class Widgetbook extends StatefulWidget {
     this.appBuilder = cupertinoAppBuilder,
     this.addons,
     this.integrations,
+    this.scrollBehavior
   });
 
   /// A [Widgetbook] with [MaterialApp] as an [appBuilder].
@@ -45,6 +47,7 @@ class Widgetbook extends StatefulWidget {
     this.appBuilder = materialAppBuilder,
     this.addons,
     this.integrations,
+    this.scrollBehavior
   });
 
   /// The initial route for that will be used on first startup.
@@ -70,6 +73,10 @@ class Widgetbook extends StatefulWidget {
   /// integrate with Widgetbook Cloud via [WidgetbookCloudIntegration], but
   /// can also be used to integrate with third-party packages.
   final List<WidgetbookIntegration>? integrations;
+
+  /// The scroll behavior to be applied to the Widgetbook application.
+  /// This parameter allows you to customize the scrolling behavior of the app.
+  final ScrollBehavior? scrollBehavior;
 
   @override
   State<Widgetbook> createState() => _WidgetbookState();
@@ -114,6 +121,7 @@ class _WidgetbookState extends State<Widgetbook> {
         darkTheme: Themes.dark,
         routerConfig: router,
         debugShowCheckedModeBanner: false,
+        scrollBehavior: widget.scrollBehavior,
       ),
     );
   }


### PR DESCRIPTION
On web I want to override the app scrollBehavior. This can be done inside MaterialApp.

Widget book create always 2 materialApp :
- Widgetbook()
- Widgetbook().appBuilder

We can override the one in appBuilder but not the root one, that's why i create this PR.

This PR can be rejected if we find a way to well embed modals created using useRootNavigator inside the appBuilder's MaterialApp. I guess if https://github.com/widgetbook/widgetbook/issues/1526 is fixed maybe this PR can be rejected.

### List of issues which are fixed by the PR

As the root WidgetBook didn't expose scrollBehavior, we can't customize it and when displaying for example some bottom sheet using root navigator, then we can't drag & drop them on web.

### Screenshots

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
