### PR TITLE
feat: allow excluding use-cases from cloud

### DIFF
--- a/docs/cloud/snapshots/overview.mdx
+++ b/docs/cloud/snapshots/overview.mdx
@@ -43,3 +43,16 @@ Knobs configs = 2 (Button) + 1 (Card) + 1 (Avatar) = 4
 Addons configs = 2 (Dark German and Light English)
 Snapshots = 4 * 2 = 8
 ```
+
+## Exclude Use-cases
+
+If you have some use-cases that you don't want Widgetbook Cloud to process the snapshots for, you can exclude them as follows:
+
+```dart
+@UseCase(
+  name: 'Default',
+  type: UnstableWidget,
+  cloudExclude: true // [!code highlight]
+)
+Widget buildUseCase(BuildContext context) { ... }
+```

--- a/packages/widgetbook_annotation/CHANGELOG.md
+++ b/packages/widgetbook_annotation/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **FEAT**: Add `@UseCase.cloudExclude` option to exclude use-cases from Widgetbook Cloud. ([#1535](https://github.com/widgetbook/widgetbook/pull/1535))
 - **CHORE**: Update license. ([#1529](https://github.com/widgetbook/widgetbook/pull/1529))
 
 ## 3.5.0

--- a/packages/widgetbook_annotation/lib/src/use_case.dart
+++ b/packages/widgetbook_annotation/lib/src/use_case.dart
@@ -16,6 +16,7 @@ class UseCase {
     this.designLink,
     this.path,
     this.cloudKnobsConfigs,
+    this.cloudExclude = false,
   });
 
   /// The name of the UseCase.
@@ -39,4 +40,8 @@ class UseCase {
 
   /// {@macro cloud_knobs_configs}
   final KnobsConfigs? cloudKnobsConfigs;
+
+  /// Whether to exclude this use-case from being processed by Widgetbook Cloud.
+  /// All use-cases are included by default.
+  final bool cloudExclude;
 }

--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **FEAT**: Support `@UseCase.cloudExclude` option. ([#1535](https://github.com/widgetbook/widgetbook/pull/1535))
 - **CHORE**: Update license. ([#1529](https://github.com/widgetbook/widgetbook/pull/1529))
 
 ## 3.8.2

--- a/packages/widgetbook_cli/lib/src/cache/cache_reader.dart
+++ b/packages/widgetbook_cli/lib/src/cache/cache_reader.dart
@@ -44,6 +44,7 @@ class CacheReader {
         .map((list) => list.cast<Map<String, dynamic>>())
         .expand((list) => list) // Flatten JSON List
         .map((item) => UseCaseMetadata.fromJson(item))
+        .whereNot((useCase) => useCase.cloudExclude) // Remove excluded
         .toList();
 
     final addonsConfigs = await cacheFiles

--- a/packages/widgetbook_cli/lib/src/cache/use_case_metadata.dart
+++ b/packages/widgetbook_cli/lib/src/cache/use_case_metadata.dart
@@ -10,6 +10,7 @@ class UseCaseMetadata {
     required this.importStatement,
     required this.componentImportStatement,
     required this.navPath,
+    required this.cloudExclude,
     this.designLink,
     this.knobsConfigs,
   });
@@ -34,6 +35,9 @@ class UseCaseMetadata {
   // This might be null if users are using widgetbook_generator <= 3.2.0
   final String? navPath;
 
+  // Whether to exclude this use-case from the cloud.
+  final bool cloudExclude;
+
   // A link to a component or variant
   final String? designLink;
 
@@ -49,6 +53,8 @@ class UseCaseMetadata {
         importStatement: map['importStatement'] as String,
         componentImportStatement: map['componentImportStatement'] as String,
         navPath: map['navPath'] as String?,
+        // This might be null if users are using widgetbook_generator <= 3.13.0
+        cloudExclude: map['cloudExclude'] as bool? ?? false,
         designLink: map['designLink'] as String?,
         knobsConfigs: map['knobsConfigs'] != null
             ? Map<String, Map<String, dynamic>>.from(map['knobsConfigs'] as Map)

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **FEAT**: Support `@UseCase.cloudExclude` option. Requires `widgetbook_annotation` >=3.5.0. ([#1535](https://github.com/widgetbook/widgetbook/pull/1535))
 - **REFACTOR**: Change generated imports prefixes to use a deterministic format based on the path. ([#1495](https://github.com/widgetbook/widgetbook/pull/1495) - by [@mrgnhnt96](https://github.com/mrgnhnt96))
 - **CHORE**: Update license. ([#1529](https://github.com/widgetbook/widgetbook/pull/1529))
 

--- a/packages/widgetbook_generator/lib/src/generators/use_case_generator.dart
+++ b/packages/widgetbook_generator/lib/src/generators/use_case_generator.dart
@@ -35,6 +35,7 @@ class UseCaseGenerator extends GeneratorForAnnotation<UseCase> {
     final type = annotation.read('type').typeValue;
     final designLink = annotation.readOrNull('designLink')?.stringValue;
     final path = annotation.readOrNull('path')?.stringValue;
+    final cloudExclude = annotation.read('cloudExclude').boolValue;
     final knobsConfigs = annotation //
         .readOrNull('cloudKnobsConfigs')
         ?.parse(_parseKnobsConfigs);
@@ -66,6 +67,7 @@ class UseCaseGenerator extends GeneratorForAnnotation<UseCase> {
       name: name,
       importUri: useCaseUri,
       navPath: navPath,
+      cloudExclude: cloudExclude,
       knobsConfigs: knobsConfigs?.toJson(),
       component: ElementMetadata(
         name: componentName,

--- a/packages/widgetbook_generator/lib/src/models/use_case_metadata.dart
+++ b/packages/widgetbook_generator/lib/src/models/use_case_metadata.dart
@@ -11,6 +11,7 @@ class UseCaseMetadata extends ElementMetadata {
     required super.importUri,
     required this.component,
     required this.navPath,
+    required this.cloudExclude,
     required this.knobsConfigs,
   });
 
@@ -26,6 +27,9 @@ class UseCaseMetadata extends ElementMetadata {
   /// The path this element is placed under in the rendered widgetbook.
   final String navPath;
 
+  /// Whether the [UseCase] should be excluded from cloud builds.
+  final bool cloudExclude;
+
   final Map<String, dynamic>? knobsConfigs;
 
   // ignore: sort_constructors_first
@@ -36,6 +40,7 @@ class UseCaseMetadata extends ElementMetadata {
       name: json['useCaseName'] as String,
       importUri: json['importStatement'] as String,
       navPath: json['navPath'] as String,
+      cloudExclude: json['cloudExclude'] as bool,
       component: ElementMetadata(
         name: json['componentName'] as String,
         importUri: json['componentImportStatement'] as String,
@@ -59,6 +64,7 @@ class UseCaseMetadata extends ElementMetadata {
       'componentName': component.name,
       'componentImportStatement': component.importUri,
       'navPath': navPath,
+      'cloudExclude': cloudExclude,
       'knobsConfigs': knobsConfigs,
     };
   }

--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   meta: ^1.7.0
   path: ^1.8.0
   source_gen: ">=1.1.0 <3.0.0"
-  widgetbook_annotation: ^3.4.0
+  widgetbook_annotation: ^3.4.0 # TODO: bump to next minor before release
 
 dev_dependencies:
   dart_style: ^2.3.0

--- a/packages/widgetbook_generator/test/helpers/mock_use_case_metadata.dart
+++ b/packages/widgetbook_generator/test/helpers/mock_use_case_metadata.dart
@@ -8,6 +8,7 @@ class MockUseCaseMetadata extends UseCaseMetadata {
     super.name = 'Default',
     super.importUri = 'package:widgetbook/src/widgets/component.usecase.dart',
     super.navPath = 'widgets',
+    super.cloudExclude = false,
     String componentName = 'Component',
     String componentImportUri = 'package:widgetbook/src/widgets/component.dart',
   }) : super(

--- a/sandbox/lib/navigation/navigation_panel.dart
+++ b/sandbox/lib/navigation/navigation_panel.dart
@@ -4,9 +4,7 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 
 import 'root_data.dart';
 
-@UseCase(name: 'Default', type: NavigationPanel)
+@UseCase(name: 'Default', type: NavigationPanel, cloudExclude: true)
 Widget navigationPanelDefaultUseCase(BuildContext context) {
-  return NavigationPanel(
-    root: root,
-  );
+  return NavigationPanel(root: root);
 }


### PR DESCRIPTION
Some Widgetbook Cloud users like to exclude some use-cases from being processed.
This new option allows them to achieve that.

```dart
@UseCase(
  name: 'Default',
  type: UnstableWidget,
  cloudExclude: true
)
Widget buildUseCase(BuildContext context) { ... }
```