### PR TITLE
refactor(generator): migrate to new elements api

### DIFF
--- a/examples/feature_preview/pubspec.lock
+++ b/examples/feature_preview/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
+      sha256: "7d95cbbb1526ab5ae977df9b4cc660963b9b27f6d1075c0b34653868911385e4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "3.0.0"
   build_config:
     dependency: transitive
     description:
@@ -77,26 +77,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
+      sha256: "38c9c339333a09b090a638849a4c56e70a404c6bdd3b511493addfbc113b60c2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "3.0.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
+      sha256: b971d4a1c789eba7be3e6fe6ce5e5b50fd3719e3cb485b3fad6d04358304351d
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.15"
+    version: "2.6.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
+      sha256: c04e612ca801cd0928ccdb891c263a2b1391cb27940a5ea5afcf9ba894de5d62
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "9.2.0"
   built_collection:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: ea90e81dc4a25a043d9bee692d20ed6d1c4a1662a28c03a96417446c093ed6b4
+      sha256: "0b1b12a0a549605e5f04476031cd0bc91ead1d7c8e830773a18ee54179b3cb62"
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.5"
+    version: "8.11.0"
   characters:
     dependency: transitive
     description:
@@ -248,14 +248,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -288,14 +280,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -457,10 +441,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      sha256: fc787b1f89ceac9580c3616f899c9a447413cbdac1df071302127764c023a134
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   source_span:
     dependency: transitive
     description:

--- a/examples/feature_preview/pubspec.yaml
+++ b/examples/feature_preview/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   widgetbook_annotation: ^3.6.0
 
 dev_dependencies: 
-  build_runner: ^2.4.15
+  build_runner: ^2.6.0
   widgetbook_generator: ^3.14.0
 
 flutter:

--- a/examples/full_example/pubspec.lock
+++ b/examples/full_example/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
+      sha256: "7d95cbbb1526ab5ae977df9b4cc660963b9b27f6d1075c0b34653868911385e4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "3.0.0"
   build_config:
     dependency: transitive
     description:
@@ -77,26 +77,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
+      sha256: "38c9c339333a09b090a638849a4c56e70a404c6bdd3b511493addfbc113b60c2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "3.0.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
+      sha256: b971d4a1c789eba7be3e6fe6ce5e5b50fd3719e3cb485b3fad6d04358304351d
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.15"
+    version: "2.6.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
+      sha256: c04e612ca801cd0928ccdb891c263a2b1391cb27940a5ea5afcf9ba894de5d62
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "9.2.0"
   built_collection:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: ea90e81dc4a25a043d9bee692d20ed6d1c4a1662a28c03a96417446c093ed6b4
+      sha256: "0b1b12a0a549605e5f04476031cd0bc91ead1d7c8e830773a18ee54179b3cb62"
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.5"
+    version: "8.11.0"
   characters:
     dependency: transitive
     description:
@@ -248,14 +248,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -288,14 +280,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -457,10 +441,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      sha256: fc787b1f89ceac9580c3616f899c9a447413cbdac1df071302127764c023a134
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   source_span:
     dependency: transitive
     description:

--- a/examples/full_example/pubspec.yaml
+++ b/examples/full_example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   widgetbook_annotation: ^3.6.0
 
 dev_dependencies:
-  build_runner: ^2.4.4
+  build_runner: ^2.6.0
   widgetbook_generator: ^3.14.0
 
 flutter:

--- a/examples/monorepo_example/widgetbook/pubspec.lock
+++ b/examples/monorepo_example/widgetbook/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
+      sha256: "7d95cbbb1526ab5ae977df9b4cc660963b9b27f6d1075c0b34653868911385e4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "3.0.0"
   build_config:
     dependency: transitive
     description:
@@ -77,26 +77,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
+      sha256: "38c9c339333a09b090a638849a4c56e70a404c6bdd3b511493addfbc113b60c2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "3.0.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
+      sha256: b971d4a1c789eba7be3e6fe6ce5e5b50fd3719e3cb485b3fad6d04358304351d
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.15"
+    version: "2.6.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
+      sha256: c04e612ca801cd0928ccdb891c263a2b1391cb27940a5ea5afcf9ba894de5d62
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "9.2.0"
   built_collection:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: ea90e81dc4a25a043d9bee692d20ed6d1c4a1662a28c03a96417446c093ed6b4
+      sha256: "0b1b12a0a549605e5f04476031cd0bc91ead1d7c8e830773a18ee54179b3cb62"
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.5"
+    version: "8.11.0"
   characters:
     dependency: transitive
     description:
@@ -248,14 +248,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -288,14 +280,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -464,10 +448,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      sha256: fc787b1f89ceac9580c3616f899c9a447413cbdac1df071302127764c023a134
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   source_span:
     dependency: transitive
     description:

--- a/examples/monorepo_example/widgetbook/pubspec.yaml
+++ b/examples/monorepo_example/widgetbook/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   widgetbook_annotation: ^3.6.0
 
 dev_dependencies:
-  build_runner:
+  build_runner: ^2.6.0
   widgetbook_generator: ^3.14.0
 
 flutter:

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **BREAKING**: Set minimum SDK version to 3.7.0. ([#1541](https://github.com/widgetbook/widgetbook/pull/1541))
+- **BREAKING**: Support [new element model API](https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md). Use `analyzer` >=7.4.0, `build` >=3.0.0 and `source_gen` >=3.0.0. ([#1544](https://github.com/widgetbook/widgetbook/pull/1544))
 
 ## 3.14.0
 

--- a/packages/widgetbook_generator/lib/src/generators/app_generator.dart
+++ b/packages/widgetbook_generator/lib/src/generators/app_generator.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:collection/collection.dart';
@@ -22,13 +22,13 @@ import '../tree/tree.dart';
 class AppGenerator extends GeneratorForAnnotation<App> {
   @override
   Future<String> generateForAnnotatedElement(
-    Element element,
+    Element2 element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
     // The directory containing the `widgetbook.dart` file
     // without the leading `/`
-    final inputPath = element.librarySource!.fullName;
+    final inputPath = element.library2!.firstFragment.source.fullName;
     final inputDir = path.dirname(inputPath).substring(1);
 
     final emitter = DartEmitter(

--- a/packages/widgetbook_generator/lib/src/generators/use_case_generator.dart
+++ b/packages/widgetbook_generator/lib/src/generators/use_case_generator.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as path;
@@ -20,7 +20,7 @@ class UseCaseGenerator extends GeneratorForAnnotation<UseCase> {
 
   @override
   Future<String> generateForAnnotatedElement(
-    Element element,
+    Element2 element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
@@ -40,20 +40,13 @@ class UseCaseGenerator extends GeneratorForAnnotation<UseCase> {
         .readOrNull('cloudKnobsConfigs')
         ?.parse(_parseKnobsConfigs);
 
-    final componentName = type
-        .getDisplayString(
-          // The `withNullability` parameter is deprecated after analyzer 6.0.0,
-          // since we support analyzer 5.x (to support Dart <3.0.0), then
-          // the deprecation is ignored.
-          // ignore: deprecated_member_use
-          withNullability: false,
-        )
-        // Generic widgets shouldn't have a "<dynamic>" suffix
-        // if no type parameter is specified.
-        .replaceAll('<dynamic>', '');
+    final componentName = type.getDisplayString()
+    // Generic widgets shouldn't have a "<dynamic>" suffix
+    // if no type parameter is specified.
+    .replaceAll('<dynamic>', '');
 
     final useCaseUri = resolveElementUri(element);
-    final componentUri = resolveElementUri(type.element!);
+    final componentUri = resolveElementUri(type.element3!);
 
     final targetNavUri =
         navPathMode == NavPathMode.component ? componentUri : useCaseUri;
@@ -61,7 +54,7 @@ class UseCaseGenerator extends GeneratorForAnnotation<UseCase> {
     final navPath = path ?? getNavPath(targetNavUri);
 
     final metadata = UseCaseMetadata(
-      functionName: element.name!,
+      functionName: element.firstFragment.name2!,
       designLink: designLink,
       name: name,
       importUri: useCaseUri,
@@ -94,8 +87,10 @@ class UseCaseGenerator extends GeneratorForAnnotation<UseCase> {
 
   /// Resolves the URI of an [element] by retrieving the URI from
   /// the [element]'s source.
-  String resolveElementUri(Element element) {
-    final source = element.librarySource ?? element.source!;
+  String resolveElementUri(Element2 element) {
+    final source =
+        element.firstFragment.libraryFragment?.source ??
+        element.library2!.firstFragment.source;
     return source.uri.toString();
   }
 

--- a/packages/widgetbook_generator/lib/src/next/arg_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/arg_builder.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:code_builder/code_builder.dart';
 
 import 'extensions.dart';
@@ -6,14 +6,14 @@ import 'extensions.dart';
 class ArgBuilder {
   ArgBuilder(this.param);
 
-  final ParameterElement param;
+  final FormalParameterElement param;
 
   Field buildField() {
     return Field(
       (b) =>
           b
             ..modifier = FieldModifier.final$
-            ..name = param.name
+            ..name = param.displayName
             ..type = TypeReference(
               (b) =>
                   b
@@ -29,7 +29,7 @@ class ArgBuilder {
       (b) =>
           b
             ..named = true
-            ..name = param.name
+            ..name = param.displayName
             ..type = TypeReference(
               (b) =>
                   b
@@ -66,7 +66,7 @@ class ArgBuilder {
       (b) =>
           b
             ..named = true
-            ..name = param.name
+            ..name = param.displayName
             ..type = TypeReference(
               (b) =>
                   b

--- a/packages/widgetbook_generator/lib/src/next/args_class_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/args_class_builder.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:code_builder/code_builder.dart';
 
@@ -11,8 +11,11 @@ class ArgsClassBuilder {
   final DartType widgetType;
   final DartType argsType;
 
-  Iterable<ParameterElement> get params {
-    return (argsType.element as ClassElement).constructors.first.parameters;
+  Iterable<FormalParameterElement> get params {
+    return (argsType.element3 as ClassElement2)
+        .constructors2
+        .first
+        .formalParameters;
   }
 
   Class build() {
@@ -46,15 +49,17 @@ class ArgsClassBuilder {
                         params.map(
                           (param) =>
                               refer('this')
-                                  .property(param.name)
+                                  .property(param.displayName)
                                   .assign(
-                                    refer(param.name)
+                                    refer(param.displayName)
                                         .maybeProperty(
                                           'init',
                                           nullSafe: param.type.isNullable,
                                         )
                                         .call([], {
-                                          'name': literalString(param.name),
+                                          'name': literalString(
+                                            param.displayName,
+                                          ),
                                         }),
                                   )
                                   .code,
@@ -74,21 +79,21 @@ class ArgsClassBuilder {
                         params.map(
                           (param) =>
                               refer('this')
-                                  .property(param.name)
+                                  .property(param.displayName)
                                   .assign(
                                     param.type.isNullable
-                                        ? refer(param.name)
+                                        ? refer(param.displayName)
                                             .equalTo(literalNull)
                                             .conditional(
                                               literalNull,
                                               InvokeExpression.newOf(
                                                 refer('Arg.fixed'),
-                                                [refer(param.name)],
+                                                [refer(param.displayName)],
                                               ),
                                             )
                                         : InvokeExpression.newOf(
                                           refer('Arg.fixed'),
-                                          [refer(param.name)],
+                                          [refer(param.displayName)],
                                         ),
                                   )
                                   .code,
@@ -120,7 +125,7 @@ class ArgsClassBuilder {
                       ..body =
                           literalList(
                             params.map(
-                              (param) => refer(param.name),
+                              (param) => refer(param.displayName),
                             ),
                           ).code,
               ),

--- a/packages/widgetbook_generator/lib/src/next/component_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/component_builder.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:code_builder/code_builder.dart';
 
@@ -13,7 +13,7 @@ class ComponentBuilder {
 
   final DartType widgetType;
   final DartType argsType;
-  final List<TopLevelVariableElement> stories;
+  final List<TopLevelVariableElement2> stories;
 
   Code build() {
     return declareFinal('${widgetType.nonNullableName}Component')
@@ -33,10 +33,10 @@ class ComponentBuilder {
             {
               'meta': refer('meta'),
               if (stories.length == 1)
-                'story': refer(stories.first.name)
+                'story': refer(stories.first.displayName)
               else
                 'stories': literalList(
-                  stories.map((story) => refer(story.name)).toList(),
+                  stories.map((story) => refer(story.displayName)).toList(),
                 ),
             },
           ),

--- a/packages/widgetbook_generator/lib/src/next/components_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/components_builder.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:glob/glob.dart';
@@ -35,8 +35,10 @@ class ComponentsBuilder implements Builder {
             .map((element) => LibraryReader(element))
             .map(
               (library) => library.allElements
-                  .whereType<TopLevelVariableElement>()
-                  .firstWhere((element) => element.name.endsWith('Component')),
+                  .whereType<TopLevelVariableElement2>()
+                  .firstWhere(
+                    (element) => element.displayName.endsWith('Component'),
+                  ),
             )
             .toList();
 
@@ -45,8 +47,11 @@ class ComponentsBuilder implements Builder {
       components
           .map(
             (e) => refer(
-              e.name,
-              e.librarySource?.uri.toString().replaceAll('.book.dart', '.dart'),
+              e.displayName,
+              e.firstFragment.libraryFragment.source.uri.toString().replaceAll(
+                '.book.dart',
+                '.dart',
+              ),
             ),
           )
           .toList(),

--- a/packages/widgetbook_generator/lib/src/next/extensions.dart
+++ b/packages/widgetbook_generator/lib/src/next/extensions.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:code_builder/code_builder.dart';
@@ -12,7 +12,7 @@ extension ExpressionX on Expression {
   }
 }
 
-extension ParameterElementX on ParameterElement {
+extension FormalParameterElementX on FormalParameterElement {
   bool get requiresArg {
     return !type.isPrimitive && !type.isNullable && !hasDefaultValue;
   }
@@ -63,13 +63,7 @@ extension DartTypeX on DartType {
     //    - Without nullability : Future<bool>
     //    - Expected            : Future<bool?>
 
-    final displayString = getDisplayString(
-      // The `withNullability` parameter is deprecated after analyzer 6.0.0,
-      // since we support analyzer 5.x (to support Dart <3.0.0), then
-      // the deprecation is ignored.
-      // ignore: deprecated_member_use, avoid_redundant_argument_values
-      withNullability: true,
-    );
+    final displayString = getDisplayString();
 
     return nullabilitySuffix != NullabilitySuffix.none
         ? displayString.substring(0, displayString.length - 1)
@@ -85,7 +79,7 @@ extension DartTypeX on DartType {
   }
 
   bool get isEnum {
-    return element is EnumElement;
+    return element3 is EnumElement2;
   }
 
   TypeMeta get meta {
@@ -93,7 +87,7 @@ extension DartTypeX on DartType {
         ? TypeMeta(
           'EnumArg<$nonNullableName>',
           refer(nonNullableName).property(
-            (element as EnumElement).fields.first.name,
+            (element3 as EnumElement2).fields2.first.name3!,
           ),
         )
         : typesMeta[nonNullableName]!;

--- a/packages/widgetbook_generator/lib/src/next/story_class_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/story_class_builder.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:collection/collection.dart';
@@ -14,8 +14,11 @@ class StoryClassBuilder {
   final DartType widgetType;
   final DartType argsType;
 
-  Iterable<ParameterElement> get params {
-    return (argsType.element as ClassElement).constructors.first.parameters;
+  Iterable<FormalParameterElement> get params {
+    return (argsType.element3 as ClassElement2)
+        .constructors2
+        .first
+        .formalParameters;
   }
 
   Class build() {
@@ -109,7 +112,7 @@ class StoryClassBuilder {
                                 ..body =
                                     instantiate(
                                       (param) => refer('args') //
-                                          .property(param.name)
+                                          .property(param.displayName)
                                           .maybeProperty(
                                             'resolve',
                                             nullSafe: param.type.isNullable,
@@ -137,7 +140,7 @@ class StoryClassBuilder {
   }
 
   InvokeExpression instantiate(
-    Expression Function(ParameterElement) assigner,
+    Expression Function(FormalParameterElement) assigner,
   ) {
     return InvokeExpression.newOf(
       refer(widgetType.nonNullableName),
@@ -147,10 +150,10 @@ class StoryClassBuilder {
           .toList(),
       params //
           .where((param) => param.isNamed)
-          .lastBy((param) => param.name)
+          .lastBy((param) => param.displayName)
           .map(
             (_, param) => MapEntry(
-              param.name,
+              param.displayName,
               assigner(param),
             ),
           ),

--- a/packages/widgetbook_generator/lib/src/next/story_generator.dart
+++ b/packages/widgetbook_generator/lib/src/next/story_generator.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
 import 'package:code_builder/code_builder.dart';
@@ -17,13 +17,13 @@ class StoryGenerator extends Generator {
   ) async {
     final storiesVariables =
         library.allElements
-            .whereType<TopLevelVariableElement>()
-            .where((element) => element.name.startsWith('\$'))
+            .whereType<TopLevelVariableElement2>()
+            .where((element) => element.displayName.startsWith('\$'))
             .toList();
 
     final metaVariable = library.allElements
-        .whereType<TopLevelVariableElement>()
-        .firstWhere((element) => element.name == 'meta');
+        .whereType<TopLevelVariableElement2>()
+        .firstWhere((element) => element.displayName == 'meta');
 
     final metaType = metaVariable.type as InterfaceType;
     final widgetType = metaType.typeArguments.first;

--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -15,17 +15,17 @@ environment:
   sdk: ">=3.7.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=6.0.0 <8.0.0"
-  build: ^2.1.0
+  analyzer: ^7.4.0
+  build: ^3.0.0
   code_builder: ^4.5.0
   collection: ^1.15.0
   crypto: ^3.0.0
   glob: ^2.0.2
   meta: ^1.7.0
   path: ^1.8.0
-  source_gen: ">=1.1.0 <3.0.0"
+  source_gen: ^3.0.0
   widgetbook_annotation: ^3.6.0 # TODO: bump to next minor
 
 dev_dependencies:
-  dart_style: ^2.3.0
+  dart_style: ^3.0.0
   test: ^1.21.0

--- a/packages/widgetbook_generator/test/helpers/code.dart
+++ b/packages/widgetbook_generator/test/helpers/code.dart
@@ -4,7 +4,9 @@ import 'package:test/test.dart';
 
 /// Formats output with dart formatter.
 void useDartFormatter() {
-  final _formatter = DartFormatter();
+  final _formatter = DartFormatter(
+    languageVersion: DartFormatter.latestShortStyleLanguageVersion,
+  );
 
   EqualsDart.format = (source) {
     try {

--- a/sandbox/pubspec.lock
+++ b/sandbox/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
+      sha256: "7d95cbbb1526ab5ae977df9b4cc660963b9b27f6d1075c0b34653868911385e4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "3.0.0"
   build_config:
     dependency: transitive
     description:
@@ -85,26 +85,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
+      sha256: "38c9c339333a09b090a638849a4c56e70a404c6bdd3b511493addfbc113b60c2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "3.0.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
+      sha256: b971d4a1c789eba7be3e6fe6ce5e5b50fd3719e3cb485b3fad6d04358304351d
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.15"
+    version: "2.6.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
+      sha256: c04e612ca801cd0928ccdb891c263a2b1391cb27940a5ea5afcf9ba894de5d62
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "9.2.0"
   built_collection:
     dependency: transitive
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: ea90e81dc4a25a043d9bee692d20ed6d1c4a1662a28c03a96417446c093ed6b4
+      sha256: "0b1b12a0a549605e5f04476031cd0bc91ead1d7c8e830773a18ee54179b3cb62"
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.5"
+    version: "8.11.0"
   characters:
     dependency: transitive
     description:
@@ -264,14 +264,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -304,14 +296,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -473,10 +457,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      sha256: fc787b1f89ceac9580c3616f899c9a447413cbdac1df071302127764c023a134
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   source_span:
     dependency: transitive
     description:

--- a/sandbox/pubspec.yaml
+++ b/sandbox/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 
 dev_dependencies:
   alchemist: ^0.11.0
-  build_runner: ^2.3.2
+  build_runner: ^2.6.0
   flutter_test:
     sdk: flutter
   widgetbook_generator: ^3.14.0


### PR DESCRIPTION
The [new Elements API](https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md) will become the new default in `analyzer` v8. 