### PR TITLE
refactor(cli): remove command error handling

### DIFF
--- a/packages/widgetbook_cli/lib/src/core/cli_command.dart
+++ b/packages/widgetbook_cli/lib/src/core/cli_command.dart
@@ -33,18 +33,10 @@ abstract class CliCommand<TArgs> extends Command<int> {
 
   @override
   FutureOr<int>? run() async {
-    try {
-      final results = argResults!;
-      final args = await parseResults(context, results);
+    final results = argResults!;
+    final args = await parseResults(context, results);
 
-      return runWith(context, args);
-    } catch (e, stackTrace) {
-      logger.err('Something wrong happened');
-      logger.err(e.toString());
-      logger.err(stackTrace.toString());
-
-      return -1;
-    }
+    return runWith(context, args);
   }
 }
 


### PR DESCRIPTION
The error handling in `CliCommand` is not needed. The `CliRunner` has a top-level [error handler](https://github.com/widgetbook/widgetbook/blob/6e3145c8df2026f69f9f59e082c8fbff0ab9381a/packages/widgetbook_cli/lib/src/core/cli_runner.dart#L61-L69).