### PR TITLE
fix: support flutter 3.35

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Support Flutter 3.35.0. ([#1565](https://github.com/widgetbook/widgetbook/pull/1565))
+
 ## 3.16.0
 
 - **BREAKING**: Set minimum SDK version to 3.7.0 & minimum Flutter version to 3.29.0. ([#1541](https://github.com/widgetbook/widgetbook/pull/1541))

--- a/packages/widgetbook/lib/src/addons/device_frame_addon/none_device.dart
+++ b/packages/widgetbook/lib/src/addons/device_frame_addon/none_device.dart
@@ -1,6 +1,7 @@
 import 'package:device_frame_plus/device_frame_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+// ignore: unnecessary_import flutter(<3.35)
 import 'package:meta/meta.dart';
 
 @internal

--- a/packages/widgetbook/lib/src/addons/semantics_addon/minimal_semantics_debugger.dart
+++ b/packages/widgetbook/lib/src/addons/semantics_addon/minimal_semantics_debugger.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
+// ignore: unnecessary_import flutter(<3.35.0)
 import 'package:meta/meta.dart';
 
 extension on SemanticsNode {
@@ -184,12 +185,17 @@ class _SemanticsDebuggerPainter extends CustomPainter {
     final annotations = <String>[];
 
     var wantsTap = false;
+
+    // ignore: deprecated_member_use flutter(<3.35.0)
     if (data.hasFlag(SemanticsFlag.hasCheckedState)) {
       annotations.add(
+        // ignore: deprecated_member_use flutter(<3.35.0)
         data.hasFlag(SemanticsFlag.isChecked) ? 'checked' : 'unchecked',
       );
       wantsTap = true;
     }
+
+    // ignore: deprecated_member_use flutter(<3.35.0)
     if (data.hasFlag(SemanticsFlag.isTextField)) {
       annotations.add('textfield');
       wantsTap = true;

--- a/packages/widgetbook/lib/src/addons/viewport_addon/viewports/viewports.dart
+++ b/packages/widgetbook/lib/src/addons/viewport_addon/viewports/viewports.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+// ignore: unnecessary_import flutter(<3.35.0)
 import 'package:meta/meta.dart';
 
 import '../viewport_data.dart';

--- a/packages/widgetbook/lib/src/knobs/knobs_registry.dart
+++ b/packages/widgetbook/lib/src/knobs/knobs_registry.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
+// ignore: unnecessary_import flutter(<3.35.0)
 import 'package:meta/meta.dart';
 
 import 'knob.dart';


### PR DESCRIPTION
Ignore warnings from Flutter 3.35.0 as they are needed for our minimum supported Flutter version (3.29.0).

The ignored warning can be resolved once Flutter 3.35.0 becomes our minimum version.