### PR TITLE
fix: re-enable nullified fields on change

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **FIX**: Support Flutter 3.35.0. ([#1565](https://github.com/widgetbook/widgetbook/pull/1565))
 - **REFACTOR**: Deprecate `WidgetbookLeafComponent` in favor of `WidgetbookComponent` which will now have similar behavior when it has a single use-case. ([#1573](https://github.com/widgetbook/widgetbook/pull/1573))
 - **FIX**: Allow knobs to be re-registered. This makes it possible for a knob to mutate other knobs. ([#1578](https://github.com/widgetbook/widgetbook/pull/1578) - by [@EArminjon](https://github.com/EArminjon))
+- **FIX**: Re-enable nullified knobs on change. ([#1586](https://github.com/widgetbook/widgetbook/pull/1586) - by [@EArminjon](https://github.com/EArminjon))
 
 ## 3.16.0
 

--- a/packages/widgetbook/lib/src/fields/field.dart
+++ b/packages/widgetbook/lib/src/fields/field.dart
@@ -99,7 +99,7 @@ abstract class Field<T> {
     // value was null (i.e. had the nullability symbol).
     final rawNewValue = codec.toParam(value);
     final newValue =
-        isNull(groupMap)
+        value == null && isNull(groupMap)
             ? '${Field.nullabilitySymbol}$rawNewValue'
             : rawNewValue;
 

--- a/packages/widgetbook/lib/src/fields/field.dart
+++ b/packages/widgetbook/lib/src/fields/field.dart
@@ -93,20 +93,12 @@ abstract class Field<T> {
   /// with the URL query parameters.
   void updateField(BuildContext context, String group, T value) {
     final state = WidgetbookState.of(context);
-    final groupMap = FieldCodec.decodeQueryGroup(state.queryParams[group]);
-
-    // Preserve the nullability symbol in the new value if the previous
-    // value was null (i.e. had the nullability symbol).
-    final rawNewValue = codec.toParam(value);
-    final newValue =
-        value == null && isNull(groupMap)
-            ? '${Field.nullabilitySymbol}$rawNewValue'
-            : rawNewValue;
+    final stringifiedValue = codec.toParam(value);
 
     state.updateQueryField(
       group: group,
       field: name,
-      value: newValue,
+      value: stringifiedValue,
     );
   }
 

--- a/packages/widgetbook/test/src/fields/field_test.dart
+++ b/packages/widgetbook/test/src/fields/field_test.dart
@@ -127,6 +127,31 @@ void main() {
         },
       );
 
+      testWidgets('given a nullable field value, '
+          'when updateField is called, '
+          'then it updates the query params with the new non nullable value', (
+        tester,
+      ) async {
+        const group = 'mock_group';
+
+        final state = await tester.pumpWidgetWithQueryParams(
+          queryParams: {
+            group: '{${field.name}:${Field.nullabilitySymbol}false}',
+          },
+          builder: (context) => Container(),
+        );
+
+        final context = tester.element(find.byType(Container));
+
+        field.updateField(context, group, true);
+
+        final result = field.valueFrom(
+          FieldCodec.decodeQueryGroup(state.queryParams[group]),
+        );
+
+        expect(result, equals(true));
+      });
+
       test(
         'when toFullJson is called, '
         'then toJson is called',

--- a/packages/widgetbook/test/src/fields/field_test.dart
+++ b/packages/widgetbook/test/src/fields/field_test.dart
@@ -127,30 +127,31 @@ void main() {
         },
       );
 
-      testWidgets('given a nullable field value, '
-          'when updateField is called, '
-          'then it updates the query params with the new non nullable value', (
-        tester,
-      ) async {
-        const group = 'mock_group';
+      testWidgets(
+        'given a nullable field value, '
+        'when updateField is called, '
+        'then it updates the query params with the new non nullable value',
+        (tester) async {
+          const group = 'mock_group';
 
-        final state = await tester.pumpWidgetWithQueryParams(
-          queryParams: {
-            group: '{${field.name}:${Field.nullabilitySymbol}false}',
-          },
-          builder: (context) => Container(),
-        );
+          final state = await tester.pumpWidgetWithQueryParams(
+            queryParams: {
+              group: '{${field.name}:${Field.nullabilitySymbol}false}',
+            },
+            builder: (context) => Container(),
+          );
 
-        final context = tester.element(find.byType(Container));
+          final context = tester.element(find.byType(Container));
 
-        field.updateField(context, group, true);
+          field.updateField(context, group, true);
 
-        final result = field.valueFrom(
-          FieldCodec.decodeQueryGroup(state.queryParams[group]),
-        );
+          final result = field.valueFrom(
+            FieldCodec.decodeQueryGroup(state.queryParams[group]),
+          );
 
-        expect(result, equals(true));
-      });
+          expect(result, equals(true));
+        },
+      );
 
       test(
         'when toFullJson is called, '


### PR DESCRIPTION
By default, changing the value of a disabled knob enable it. When we manually enable and then disable a knob, changing the value didn't enable the knob.

### List of issues which are fixed by the PR
- https://github.com/widgetbook/widgetbook/issues/1585

### Screenshots

https://github.com/user-attachments/assets/3a63441f-2cdf-44c4-9467-f7392f54de07

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
