### PR TITLE
fix: clamp num slider field value

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Clamp `NumSliderField` value to avoid exceptions when the boundaries change. ([#1590](https://github.com/widgetbook/widgetbook/pull/1590) - by [@EArminjon](https://github.com/EArminjon))
+
 ## 3.17.0
 
 - **FEAT**: Expose Widgetbook's own [scroll behavior](https://docs.widgetbook.io/configure/scroll-behavior) to allow customizing it. ([#1524](https://github.com/widgetbook/widgetbook/pull/1524) - by [@EArminjon](https://github.com/EArminjon))

--- a/packages/widgetbook/lib/src/fields/num_slider_field.dart
+++ b/packages/widgetbook/lib/src/fields/num_slider_field.dart
@@ -38,7 +38,10 @@ class NumSliderField<T extends num> extends Field<T> {
         Expanded(
           flex: 8,
           child: Slider(
-            value: (value ?? initialValue)?.toDouble() ?? 0,
+            value: ((value ?? initialValue)?.toDouble() ?? 0).clamp(
+              min.toDouble(),
+              max.toDouble(),
+            ),
             min: min.toDouble(),
             max: max.toDouble(),
             label: codec.toParam(value ?? initialValue ?? defaultValue),

--- a/packages/widgetbook/test/src/fields/num_slider_field_test.dart
+++ b/packages/widgetbook/test/src/fields/num_slider_field_test.dart
@@ -129,6 +129,32 @@ void main() {
           expect(widget.value, equals(7));
         },
       );
+
+      testWidgets(
+        'given a state that exceed field higher limits, '
+        'then [toWidget] builds and use the maximum available value',
+        (tester) async {
+          final widget = await tester.pumpField<int, Slider>(
+            field,
+            15,
+          );
+
+          expect(widget.value, equals(10.0));
+        },
+      );
+
+      testWidgets(
+        'given a state that exceed field lower limits, '
+        'then [toWidget] builds and use the minmum available value',
+        (tester) async {
+          final widget = await tester.pumpField<int, Slider>(
+            field,
+            -15,
+          );
+
+          expect(widget.value, equals(0.0));
+        },
+      );
     },
   );
 }


### PR DESCRIPTION
To avoid NumSliderField to throw when the value exceed higher or lower limit, we can use clamp() to restrict the value.

### List of issues which are fixed by the PR

- https://github.com/widgetbook/widgetbook/issues/1589

### Screenshots

https://github.com/user-attachments/assets/ef3b83e5-1209-4cd7-9233-23e4301cca82

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
