### PR TITLE
fix: scale semantics addon properly

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **FIX**: Clamp `NumSliderField` value to avoid exceptions when the boundaries change. ([#1590](https://github.com/widgetbook/widgetbook/pull/1590) - by [@EArminjon](https://github.com/EArminjon))
+- **FIX**: Upscale `SemanticsAddon` to make it fill the entire viewport. ([#1611](https://github.com/widgetbook/widgetbook/pull/1611) - by [@EArminjon](https://github.com/EArminjon))
 
 ## 3.17.0
 

--- a/packages/widgetbook/lib/src/addons/semantics_addon/minimal_semantics_debugger.dart
+++ b/packages/widgetbook/lib/src/addons/semantics_addon/minimal_semantics_debugger.dart
@@ -165,7 +165,6 @@ class _SemanticsDebuggerPainter extends CustomPainter {
     final rootNode = _rootSemanticsNode;
 
     canvas.save();
-    canvas.scale(1.0 / devicePixelRatio, 1.0 / devicePixelRatio);
 
     if (rootNode != null) {
       _paint(canvas, rootNode, _findDepth(rootNode), 0, 0);


### PR DESCRIPTION
As a QA i would check quickly semantics in web. Actually semantics are not displayed using full screen on my MacOs as the devicePixelRatio is 2. As 1 / 2 equal 0.5, is scale by 0.5...

### List of issues which are fixed by the PR

https://github.com/widgetbook/widgetbook/issues/1612

### Screenshots

<img width="2656" height="2324" alt="image" src="https://github.com/user-attachments/assets/161fe095-7721-4c0d-b909-5316658a8a30" />


### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
