### PR TITLE
feat(test): add image dimension

### DIFF
--- a/packages/widgetbook_test/lib/src/scenario_metadata.dart
+++ b/packages/widgetbook_test/lib/src/scenario_metadata.dart
@@ -10,10 +10,14 @@ class ScenarioMetadata {
   const ScenarioMetadata({
     required this.scenario,
     required this.imageBytes,
+    required this.imageWidth,
+    required this.imageHeight,
   });
 
   final Scenario scenario;
   final Uint8List imageBytes;
+  final int imageWidth;
+  final int imageHeight;
 
   Component get component => scenario.story.component;
   Story get story => scenario.story;
@@ -53,6 +57,8 @@ class ScenarioMetadata {
       'image': {
         'path': imageFile.path,
         'hash': hash,
+        'width': imageWidth,
+        'height': imageHeight,
       },
     };
   }

--- a/packages/widgetbook_test/lib/src/test.dart
+++ b/packages/widgetbook_test/lib/src/test.dart
@@ -4,8 +4,8 @@ import 'dart:ui';
 import 'package:flutter/material.dart' hide Image;
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:widgetbook/widgetbook.dart';
+
 import 'font_loader.dart';
 import 'scenario_metadata.dart';
 
@@ -75,6 +75,8 @@ void testScenario(
         final metadata = ScenarioMetadata(
           scenario: scenario,
           imageBytes: imageBytes,
+          imageWidth: image.width,
+          imageHeight: image.height,
         );
 
         await metadata.directory.create(recursive: true);


### PR DESCRIPTION
adds image dimension to the `.json` output format

## Output example `Dark - 3.json`

```
{
    "component": {
        "name": "LabelBadge",
        "path": "[sam]"
    },
    "story": {
        "name": "Primary",
        "designLink": null
    },
    "scenario": {
        "name": "Dark - 3",
        "modes": [
            {
                "name": "Dark"
            }
        ],
        "args": [
            {
                "number": "3"
            }
        ]
    },
    "image": {
        "path": "build/.widgetbook/LabelBadge/Primary/Dark - 3.png",
        "hash": "1c7275d06529b6c7ac7fa9994fb5047845b0f95a36d4abfaf2e9db982005ddeb",
        "width": 192,
        "height": 192
    }
}
```