### PR TITLE
feat(test): update ScenarioMetadata

### DIFF
--- a/packages/widgetbook_test/lib/src/scenario_metadata.dart
+++ b/packages/widgetbook_test/lib/src/scenario_metadata.dart
@@ -12,12 +12,14 @@ class ScenarioMetadata {
     required this.imageBytes,
     required this.imageWidth,
     required this.imageHeight,
+    required this.pixelRatio,
   });
 
   final Scenario scenario;
   final Uint8List imageBytes;
   final int imageWidth;
   final int imageHeight;
+  final double pixelRatio;
 
   Component get component => scenario.story.component;
   Story get story => scenario.story;
@@ -59,6 +61,8 @@ class ScenarioMetadata {
         'hash': hash,
         'width': imageWidth,
         'height': imageHeight,
+        'pixelRatio': pixelRatio,
+        'size': imageBytes.length,
       },
     };
   }

--- a/packages/widgetbook_test/lib/src/test.dart
+++ b/packages/widgetbook_test/lib/src/test.dart
@@ -69,7 +69,7 @@ void testScenario(
       await scenario.execute(tester);
 
       final element = tester.element(find.byKey(key));
-      final imageFuture = captureImage(element, 2);
+      final imageFuture = captureImage(element, 1);
 
       // Run on separate isolate as async operations cannot be run inside
       // testWidgets directly.
@@ -84,6 +84,7 @@ void testScenario(
           imageBytes: imageBytes,
           imageWidth: image.width,
           imageHeight: image.height,
+          pixelRatio: tester.view.devicePixelRatio,
         );
 
         await metadata.directory.create(recursive: true);


### PR DESCRIPTION
- adds `pixelRatio` and image `size` properties to `ScenarioMetadata`
- sets captureImage `pixelRatio` to `1` to prevent incorrect image scaling 