### PR TITLE
refactor: expand args query group

### DIFF
--- a/examples/full_example/lib/customs/custom_arg.dart
+++ b/examples/full_example/lib/customs/custom_arg.dart
@@ -10,11 +10,11 @@ class RangeArg extends Arg<RangeValues> {
   @override
   List<Field> get fields => [
     DoubleInputField(
-      name: 'min-$name',
+      name: 'min',
       initialValue: value.start,
     ),
     DoubleInputField(
-      name: 'max-$name',
+      name: 'max',
       initialValue: value.end,
     ),
   ];
@@ -22,16 +22,16 @@ class RangeArg extends Arg<RangeValues> {
   @override
   RangeValues valueFromQueryGroup(Map<String, String> group) {
     return RangeValues(
-      valueOf('min-$name', group)!,
-      valueOf('max-$name', group)!,
+      valueOf('min', group)!,
+      valueOf('max', group)!,
     );
   }
 
   @override
   Map<String, String> valueToQueryGroup(RangeValues value) {
     return {
-      'min-$name': paramOf('min-$name', value),
-      'max-$name': paramOf('max-$name', value),
+      'min': paramOf('min', value),
+      'max': paramOf('max', value),
     };
   }
 

--- a/packages/widgetbook/lib/src/args/bool_arg.dart
+++ b/packages/widgetbook/lib/src/args/bool_arg.dart
@@ -10,19 +10,19 @@ class BoolArg extends Arg<bool> {
   @override
   List<Field> get fields => [
     BooleanField(
-      name: name,
+      name: 'value',
       initialValue: value,
     ),
   ];
 
   @override
   bool valueFromQueryGroup(Map<String, String> group) {
-    return valueOf(name, group)!;
+    return valueOf('value', group)!;
   }
 
   @override
   Map<String, String> valueToQueryGroup(bool value) {
-    return {name: paramOf(name, value)};
+    return {'value': paramOf('value', value)};
   }
 
   @override

--- a/packages/widgetbook/lib/src/args/color_arg.dart
+++ b/packages/widgetbook/lib/src/args/color_arg.dart
@@ -12,19 +12,19 @@ class ColorArg extends Arg<Color> {
   @override
   List<Field> get fields => [
     ColorField(
-      name: name,
+      name: 'value',
       initialValue: value,
     ),
   ];
 
   @override
   Color valueFromQueryGroup(Map<String, String> group) {
-    return valueOf(name, group)!;
+    return valueOf('value', group)!;
   }
 
   @override
   Map<String, String> valueToQueryGroup(Color value) {
-    return {name: paramOf(name, value)};
+    return {'value': paramOf('value', value)};
   }
 
   @override

--- a/packages/widgetbook/lib/src/args/double_arg.dart
+++ b/packages/widgetbook/lib/src/args/double_arg.dart
@@ -10,19 +10,19 @@ class DoubleArg extends Arg<double> {
   @override
   List<Field> get fields => [
     DoubleInputField(
-      name: name,
+      name: 'value',
       initialValue: value,
     ),
   ];
 
   @override
   double valueFromQueryGroup(Map<String, String> group) {
-    return valueOf(name, group)!;
+    return valueOf('value', group)!;
   }
 
   @override
   Map<String, String> valueToQueryGroup(double value) {
-    return {name: paramOf(name, value)};
+    return {'value': paramOf('value', value)};
   }
 
   @override

--- a/packages/widgetbook/lib/src/args/duration_arg.dart
+++ b/packages/widgetbook/lib/src/args/duration_arg.dart
@@ -10,19 +10,19 @@ class DurationArg extends Arg<Duration> {
   @override
   List<Field> get fields => [
     DurationField(
-      name: name,
+      name: 'value',
       initialValue: value,
     ),
   ];
 
   @override
   Duration valueFromQueryGroup(Map<String, String> group) {
-    return valueOf(name, group)!;
+    return valueOf('value', group)!;
   }
 
   @override
   Map<String, String> valueToQueryGroup(Duration value) {
-    return {name: paramOf(name, value)};
+    return {'value': paramOf('value', value)};
   }
 
   @override

--- a/packages/widgetbook/lib/src/args/int_arg.dart
+++ b/packages/widgetbook/lib/src/args/int_arg.dart
@@ -10,19 +10,19 @@ class IntArg extends Arg<int> {
   @override
   List<Field> get fields => [
     IntInputField(
-      name: name,
+      name: 'value',
       initialValue: value,
     ),
   ];
 
   @override
   int valueFromQueryGroup(Map<String, String> group) {
-    return valueOf(name, group)!;
+    return valueOf('value', group)!;
   }
 
   @override
   Map<String, String> valueToQueryGroup(int value) {
-    return {name: paramOf(name, value)};
+    return {'value': paramOf('value', value)};
   }
 
   @override

--- a/packages/widgetbook/lib/src/args/single_arg.dart
+++ b/packages/widgetbook/lib/src/args/single_arg.dart
@@ -16,7 +16,7 @@ class SingleArg<T> extends Arg<T> {
   List<Field> get fields {
     return [
       ObjectDropdownField<T>(
-        name: name,
+        name: 'value',
         values: values,
         initialValue: value,
         labelBuilder: labelBuilder ?? ObjectDropdownField.defaultLabelBuilder,
@@ -26,12 +26,12 @@ class SingleArg<T> extends Arg<T> {
 
   @override
   T valueFromQueryGroup(Map<String, String> group) {
-    return valueOf(name, group)!;
+    return valueOf('value', group)!;
   }
 
   @override
   Map<String, String> valueToQueryGroup(T value) {
-    return {name: paramOf(name, value)};
+    return {'value': paramOf('value', value)};
   }
 
   @override

--- a/packages/widgetbook/lib/src/args/string_arg.dart
+++ b/packages/widgetbook/lib/src/args/string_arg.dart
@@ -10,19 +10,19 @@ class StringArg extends Arg<String> {
   @override
   List<Field> get fields => [
     StringField(
-      name: name,
+      name: 'value',
       initialValue: value,
     ),
   ];
 
   @override
   String valueFromQueryGroup(Map<String, String> group) {
-    return valueOf(name, group)!;
+    return valueOf('value', group)!;
   }
 
   @override
   Map<String, String> valueToQueryGroup(String value) {
-    return {name: paramOf(name, value)};
+    return {'value': paramOf('value', value)};
   }
 
   @override

--- a/packages/widgetbook/lib/src/core/arg.dart
+++ b/packages/widgetbook/lib/src/core/arg.dart
@@ -31,6 +31,9 @@ abstract class Arg<T> extends FieldsComposable<T> {
     return $name!;
   }
 
+  @override
+  String get groupName => name;
+
   /// Creates a copy of this using the provided [name] for late initialization.
   /// If [$name] was already set, it should have precedence over [name].
   ///
@@ -43,9 +46,6 @@ abstract class Arg<T> extends FieldsComposable<T> {
 
   static ConstArg<T> fixed<T>(T value) => ConstArg<T>(value);
 
-  @override
-  String get groupName => 'args';
-
   /// Resolves the value of this argument based on the current context.
   /// If there is no [WidgetbookState] in the widget tree, it returns the
   /// default [value].
@@ -53,7 +53,10 @@ abstract class Arg<T> extends FieldsComposable<T> {
     final state = WidgetbookState.maybeOf(context);
     if (state == null) return value;
 
-    final queryGroup = FieldCodec.decodeQueryGroup(state.queryParams['args']);
+    final queryGroup = FieldCodec.decodeQueryGroup(
+      state.queryParams[groupName],
+    );
+
     return valueFromQueryGroup(queryGroup);
   }
 

--- a/packages/widgetbook/lib/src/core/const_arg.dart
+++ b/packages/widgetbook/lib/src/core/const_arg.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/widgets.dart';
+
 import '../fields/fields.dart';
 import 'arg.dart';
 
@@ -15,4 +17,7 @@ class ConstArg<T> extends Arg<T> {
   T valueFromQueryGroup(Map<String, String> group) => value;
 
   Map<String, String> valueToQueryGroup(T value) => {};
+
+  @override
+  T resolve(BuildContext context) => value;
 }

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -227,12 +227,18 @@ class WidgetbookState extends ChangeNotifier {
   /// Resets the args during the update.
   @internal
   void updatePath(String newPath) {
-    path = newPath;
-    queryParams.remove('args'); // Reset args
+    // Reset args
+    final oldStory = story;
+    oldStory?.args.safeList.forEach(
+      (arg) => queryParams.remove(arg.groupName),
+    );
 
-    if (story != null) {
+    path = newPath; // Changes `story` to new one
+
+    final newStory = story;
+    if (newStory != null) {
       integrations?.forEach(
-        (integration) => integration.onStoryChange(story!),
+        (integration) => integration.onStoryChange(newStory),
       );
     }
 

--- a/packages/widgetbook/test/src/state/widgetbook_state_test.dart
+++ b/packages/widgetbook/test/src/state/widgetbook_state_test.dart
@@ -1,6 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:widgetbook/src/routing/routing.dart';
 import 'package:widgetbook/widgetbook.dart';
+
+import '../../helper/mocks.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -88,13 +91,33 @@ void main() {
         'when the path is updated, '
         'then the args are removed from query params',
         () {
+          final args = [const IntArg(1, name: 'number')];
+          final previousStoryArgs = MockStoryArgs();
+          when(() => previousStoryArgs.safeList).thenReturn(args);
+
+          final previousStory = MockStory();
+          when(() => previousStory.name).thenReturn('previous');
+          when(() => previousStory.args).thenReturn(previousStoryArgs);
+
+          final nextStory = MockStory();
+          when(() => nextStory.name).thenReturn('next');
+
           final state = WidgetbookState(
-            queryParams: {'args': '{arg:value}'},
+            path: 'component/previous',
+            queryParams: {for (final arg in args) arg.groupName: '{}'},
+            components: [
+              Component(
+                name: 'component',
+                stories: [previousStory, nextStory],
+              ),
+            ],
           );
 
-          state.updatePath('component/use-case');
+          state.updatePath('component/next');
 
-          expect(state.queryParams['args'], isNull);
+          for (final arg in args) {
+            expect(state.queryParams.containsKey(arg.groupName), isFalse);
+          }
         },
       );
 

--- a/sandbox/lib/[sam]/types_table.stories.dart
+++ b/sandbox/lib/[sam]/types_table.stories.dart
@@ -63,11 +63,11 @@ class PersonArg extends Arg<Person> {
   @override
   List<Field> get fields => [
     StringField(
-      name: '$name.name',
+      name: 'name',
       initialValue: value.name,
     ),
     IntInputField(
-      name: '$name.age',
+      name: 'age',
       initialValue: value.age,
     ),
   ];
@@ -75,16 +75,16 @@ class PersonArg extends Arg<Person> {
   @override
   Person valueFromQueryGroup(Map<String, String> group) {
     return Person(
-      name: valueOf('$name.name', group)!,
-      age: valueOf('$name.age', group)!,
+      name: valueOf('name', group)!,
+      age: valueOf('age', group)!,
     );
   }
 
   @override
   Map<String, String> valueToQueryGroup(Person value) {
     return {
-      '$name.name': paramOf('$name.name', value.name),
-      '$name.age': paramOf('$name.age', value.age),
+      'name': paramOf('name', value.name),
+      'age': paramOf('age', value.age),
     };
   }
 


### PR DESCRIPTION
This makes it cleaner for multi-field args, for example a `PersonArg`:
- Before `args={person.name:foo,person.age:25,other:x}`
- After `person={name:foo,age:25}&other={value:x}` _(note: `other` will be shortened to `other=x` later)_