### PR TITLE
fix(test): change `args`/`modes` metadata to map

### DIFF
--- a/packages/widgetbook/lib/src/core/mode.dart
+++ b/packages/widgetbook/lib/src/core/mode.dart
@@ -9,6 +9,8 @@ abstract class Mode<T> {
 
   final T value;
 
+  String get groupName => addon.groupName;
+
   /// The associated addon for this mode. Used to build the story, and
   /// to convert to/from query parameters.
   final Addon<T> addon;

--- a/packages/widgetbook_test/lib/src/scenario_metadata.dart
+++ b/packages/widgetbook_test/lib/src/scenario_metadata.dart
@@ -53,8 +53,14 @@ class ScenarioMetadata {
       },
       'scenario': {
         'name': scenario.name,
-        'modes': scenario.modes.map((mode) => mode.toQueryGroup()).toList(),
-        'args': scenario.args.list.map((arg) => arg?.toQueryGroup()).toList(),
+        'modes': {
+          for (final mode in scenario.modes)
+            mode.groupName: mode.toQueryGroup(),
+        },
+        'args': {
+          for (final arg in scenario.args.safeList)
+            arg.groupName: arg.toQueryGroup(),
+        },
       },
       'image': {
         'path': imageFile.path,


### PR DESCRIPTION
### Before

Lists that do not have the `groupName`, and the args list is not "safe".

```
"modes": [
  {
    "name": "Light"
  }
],
"args": [
  null,
  {
    "value": "false"
  },
  {
    "value": "1"
  },
  {
    "value": "0.0"
  },
  {
    "value": "Hello World"
  },
  {
    "value": "fff44336"
  },
  {},
  {
    "value": "none"
  },
  {
    "name": "John Doe",
    "age": "42"
  },
  {},
  null,
  {},
  {},
  null,
  null
]
```

### Afer

```
"modes": {
  "theme": {
    "name": "Light"
  }
},
"args": {
  "boolean": {
    "value": "false"
  },
  "integer": {
    "value": "1"
  },
  "decimal": {
    "value": "0.0"
  },
  "Text": {
    "value": "Hello World"
  },
  "color": {
    "value": "fff44336"
  },
  "status": {
    "value": "none"
  },
  "person": {
    "name": "John Doe",
    "age": "42"
  }
}
```