### PR TITLE
perf: debounce search

### DIFF
--- a/packages/widgetbook/lib/src/navigation/widgets/navigation_panel.dart
+++ b/packages/widgetbook/lib/src/navigation/widgets/navigation_panel.dart
@@ -78,13 +78,14 @@ class _NavigationPanelState extends State<NavigationPanel> {
           padding: const EdgeInsets.all(16),
           child: SearchField(
             value: query,
+            onCleared: () => WidgetbookState.of(context).updateQuery(''),
             onChanged: (value) {
               _debounce?.cancel();
-              _debounce = Timer(const Duration(milliseconds: 100), () {
-                WidgetbookState.of(context).updateQuery(value);
-              });
+              _debounce = Timer(
+                const Duration(milliseconds: 100),
+                () => WidgetbookState.of(context).updateQuery(value),
+              );
             },
-            onCleared: () => WidgetbookState.of(context).updateQuery(''),
           ),
         ),
         if (filteredRoot.children != null)


### PR DESCRIPTION
Everytime user type or erase a character a rebuild is done which is not really an issue. But when user hold the erase key, the number of rebuild produce a visible lag.

I believe **we need to find a better strategy** to improve performance. Every knobs update trigger heavy operation which cost performances.

### List of issues which are fixed by the PR

No ticket needed i guess for this one.

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
