### PR TITLE
ci: speedup pana

### DIFF
--- a/.github/workflows/_package.yml
+++ b/.github/workflows/_package.yml
@@ -124,11 +124,15 @@ jobs:
           PACKAGE_NAME=$(head -1 pubspec.yaml | cut -c7-)
           melos bootstrap --scope=$PACKAGE_NAME --include-dependencies
 
+      # To speed up the pana checks, we will bypass the screenshots validation
+      # As it requires installing libwebp which can take up to 1.5 minute,
+      # and other seconds are spent in actually reading and checking the images.
+      # Since we are sure that our screenshots are valid, we can skip this step.
+      - name: Remove screenshots entry
+        run: yq eval 'del(.screenshots)' -i pubspec.yaml
+
       - name: Install pana
-        run: |
-          dart pub global activate pana
-          sudo apt-get update
-          sudo apt-get install webp # Needed for screenshots validation
+        run: dart pub global activate pana
 
       - name: Check Package Score
         run: pana . --no-warning --exit-code-threshold 0 --no-dartdoc


### PR DESCRIPTION
Reduces time from 3.5m to 1.5m by bypassing screenshot checks.