### PR TITLE
docs: fix theme addon typo

### DIFF
--- a/docs/addons/theme-addon.mdx
+++ b/docs/addons/theme-addon.mdx
@@ -165,7 +165,6 @@ class WidgetbookApp extends StatelessWidget {
             WidgetbookTheme( // [!code highlight]
               name: 'Dark', // [!code highlight]
               data: AppThemes.dark(), // [!code highlight]
-              ), // [!code highlight]
             ), // [!code highlight]
           ], // [!code highlight]
           themeBuilder: (context, theme, child) { // [!code highlight]


### PR DESCRIPTION
Removed unpaired bracket that made "Custom Theme" example not compilable. 

### List of issues which are fixed by the PR
https://github.com/widgetbook/widgetbook/issues/1715

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.
