### PR TITLE
docs: fix bash variables

### DIFF
--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -2,7 +2,7 @@
 
 The CLI is available as the [widgetbook_cli](https://pub.dev/packages/widgetbook_cli) package.
 
-```bash
+```
 # 🎯 Activate from https://pub.dev
 dart pub global activate widgetbook_cli {{ versions.cli }}
 

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -21,7 +21,7 @@
 
 1. Add the following dependencies to your `widgetbook` project:
 
-   ```bash
+   ```
    flutter pub add widgetbook:{{ versions.widgetbook }} \
          dev:widgetbook_generator:{{ versions.generator }} \
          dev:widgetbook_test:{{ versions.test }} \


### PR DESCRIPTION
Using variables in bash code blocks didn't work, so we remove the syntax highlight just to make it work properly.