### PR TITLE
fix: add fallback style for viewport frames

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **FEAT**: Add `style` to `IntArg`, `DoubleArg`, `SingleArg` and `EnumArg` to support different input styles (e.g. sliders, input fields, dropdowns and segmented buttons). ([#1792](https://github.com/widgetbook/widgetbook/pull/1792))
+- **FIX**: Prevent `ViewportAddon`'s frames from failing during tests that have no `ViewportMode`. ([#1800](https://github.com/widgetbook/widgetbook/pull/1800))
 
 ## 4.0.0-alpha.5
 

--- a/packages/widgetbook/lib/src/core/addons/viewport_addon/viewport.dart
+++ b/packages/widgetbook/lib/src/core/addons/viewport_addon/viewport.dart
@@ -110,9 +110,11 @@ class _ViewportFrame extends StatelessWidget {
             ),
             child: Text(
               title,
-              style: WidgetbookTheme.of(context).textTheme.bodyMedium?.copyWith(
-                color: Colors.black87,
-              ),
+              // WidgetbookTheme might not be available in tests
+              style: WidgetbookTheme.maybeOf(context)?.textTheme.bodyMedium
+                  ?.copyWith(
+                    color: Colors.black87,
+                  ),
             ),
           ),
         ),


### PR DESCRIPTION
During tests, the following config generated a `No WidgetbookTheme found in context` error:

```dart
final config = Config(
  components: components,
  addons: [
    ViewportAddon([
      IosViewports.iPhone13,
    ]),
  ],
);
```

This happened because there was no `ViewportMode` configured for the snapshots, so the `Viewport` frame which requires `WidgetbookTheme` was being rendered.