### PR TITLE
feat: add snapshot deduplication

### DIFF
--- a/packages/widgetbook_cli/lib/src/api/models/create_build_response.dart
+++ b/packages/widgetbook_cli/lib/src/api/models/create_build_response.dart
@@ -54,10 +54,12 @@ class CreateDraftBuildResponse extends CreateBuildResponse {
     required super.buildId,
     required this.baseHref,
     required this.storage,
+    required this.snapshotStorage,
   });
 
   final String baseHref;
   final StorageInfo storage;
+  final StorageInfo snapshotStorage;
 
   // ignore: sort_constructors_first
   factory CreateDraftBuildResponse.fromJson(Map<String, dynamic> json) {
@@ -65,6 +67,9 @@ class CreateDraftBuildResponse extends CreateBuildResponse {
       buildId: json['buildId'] as String,
       baseHref: json['baseHref'] as String,
       storage: StorageInfo.fromJson(json['storage'] as Map<String, dynamic>),
+      snapshotStorage: StorageInfo.fromJson(
+        json['snapshotStorage'] as Map<String, dynamic>,
+      ),
     );
   }
 }


### PR DESCRIPTION
Snapshots previously have been uploaded in a subfolder of builds; now snapshots are uploaded to a sub-folder of a project so they can be re-used by multiple builds reducing cost. 