### PR TITLE
fix: ensure slider label use max size

### DIFF
--- a/packages/widgetbook/lib/src/fields/num_slider_field.dart
+++ b/packages/widgetbook/lib/src/fields/num_slider_field.dart
@@ -44,6 +44,11 @@ class NumSliderField<T extends num> extends Field<T> {
     final minLabel = codec.toParam(min);
     final maxLabel = codec.toParam(max);
 
+    final textStyle = DefaultTextStyle.of(context).style;
+    final minSize = _getTextSize(minLabel, textStyle);
+    final maxSize = _getTextSize(maxLabel, textStyle);
+    final widestSize = minSize.width > maxSize.width ? minSize : maxSize;
+
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       spacing:
@@ -71,11 +76,7 @@ class NumSliderField<T extends num> extends Field<T> {
           ),
         ),
         SizedBox(
-          width: _getTextSize(
-            // Min label can be larger than max in case of negative numbers
-            maxLabel.length > minLabel.length ? maxLabel : minLabel,
-            DefaultTextStyle.of(context).style,
-          ).width,
+          width: widestSize.width,
           child: Text(
             label,
             textAlign: TextAlign.end,


### PR DESCRIPTION
When min is "-99" and max "200", the << - >> character is smaller than the << 2 >> digit leading to the cut of the label as there is not enough space.

### List of issues which are fixed by the PR
*You must list at least one issue.*

### Screenshots

Before : 
<img width="363" height="55" alt="image" src="https://github.com/user-attachments/assets/80aa1399-8a65-4730-a594-74d6d79671ce" />


After :
<img width="371" height="61" alt="image" src="https://github.com/user-attachments/assets/ae3cbda6-040d-4a6f-ae27-583fcb835b86" />


### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing. // I didn't know how to unit test how many letter are displayed from a text.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
