### PR TITLE
fix: prevent focus loss of TextField-based `Arg`s

### DIFF
--- a/docs/args.mdx
+++ b/docs/args.mdx
@@ -32,6 +32,34 @@ final $Active = _Story(
 );
 ```
 
+## Stateful Widgets and Arg Updates
+
+When an arg changes, Widgetbook rebuilds the story with a new key by default.
+This behavior is especially useful for `StatefulWidget`s because local state is
+reset to match the latest arg values.
+
+- `StatelessWidget`: updates reflect immediately through the new args.
+- `StatefulWidget`: local state is reset on arg change so the widget reflects
+  the updated args.
+
+This means you usually do **not** need a manual `KeyedSubtree` in your story.
+
+### Opt out of the default behavior
+
+If you need to preserve local state across arg updates, override `setup` and
+return the widget unchanged:
+
+```dart title="counter.stories.dart"
+final $Default = _Story(
+  setup: (context, widget, args) => widget,
+  args: _Args(
+    initialValue: IntArg(10),
+  ),
+);
+```
+
+Use this only when keeping local state is intentional.
+
 ## Custom Args Source
 
 The default source for args generation is the widget's constructor. However, you can customize this behavior by using the `MetaWithArgs` as follows

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
-- **FIX**: Resolve URL resetting on story change
+- **FIX**: Prevent focus loss of TextField-based `Arg`s. ([#1836](https://github.com/widgetbook/widgetbook/pull/1836))
+- **FIX**: Resolve URL resetting on story change. ([#1840](https://github.com/widgetbook/widgetbook/pull/1840))
 - **FEAT**: Add `DocBlock` widget for improved documentation support. ([#1820](https://github.com/widgetbook/widgetbook/pull/1820))
 - **FEAT**: Support semantics testing. ([#1809](https://github.com/widgetbook/widgetbook/pull/1809))
 - **BREAKING**: Change generated file extension from `*.book.dart` to `*.g.dart`. ([#1811](https://github.com/widgetbook/widgetbook/pull/1811))

--- a/packages/widgetbook/lib/src/core/fields/controlled_text_field.dart
+++ b/packages/widgetbook/lib/src/core/fields/controlled_text_field.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Internal wrapper for [TextFormField] that uses a controller to preserve
+/// focus and cursor position. Updates the text only when the value changes
+/// externally and the field is not focused.
+class ControlledTextField extends StatefulWidget {
+  const ControlledTextField({
+    super.key,
+    required this.initialValue,
+    required this.onChanged,
+    this.maxLines,
+    this.keyboardType,
+    this.inputFormatters,
+    this.decoration,
+  });
+
+  final String initialValue;
+  final void Function(String text) onChanged;
+  final int? maxLines;
+  final TextInputType? keyboardType;
+  final List<TextInputFormatter>? inputFormatters;
+  final InputDecoration? decoration;
+
+  @override
+  State<ControlledTextField> createState() => _ControlledTextFieldState();
+}
+
+class _ControlledTextFieldState extends State<ControlledTextField> {
+  late TextEditingController _controller;
+  late FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialValue);
+    _focusNode = FocusNode();
+  }
+
+  @override
+  void didUpdateWidget(ControlledTextField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.initialValue != oldWidget.initialValue && !_focusNode.hasFocus) {
+      _controller.text = widget.initialValue;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: _controller,
+      focusNode: _focusNode,
+      maxLines: widget.maxLines,
+      keyboardType: widget.keyboardType,
+      inputFormatters: widget.inputFormatters,
+      decoration: widget.decoration,
+      onChanged: widget.onChanged,
+    );
+  }
+}

--- a/packages/widgetbook/lib/src/core/fields/date_time_field.dart
+++ b/packages/widgetbook/lib/src/core/fields/date_time_field.dart
@@ -23,12 +23,7 @@ final class DateTimeField extends Field<DateTime> {
 
   @override
   Widget toWidget(BuildContext context, String groupName, DateTime value) {
-    return TextFormField(
-      // The "value" used in the key ensures that the TextFormField is rebuilt
-      // when the value is changed via the DateTime picker. Without this
-      // unique key, the TextFormField will only react to value changes
-      // triggered by the user typing in the field.
-      key: ValueKey('$groupName-$name-$value'),
+    return ControlledTextField(
       initialValue: value.toSimpleFormat(),
       keyboardType: TextInputType.datetime,
       decoration: InputDecoration(

--- a/packages/widgetbook/lib/src/core/fields/duration_field.dart
+++ b/packages/widgetbook/lib/src/core/fields/duration_field.dart
@@ -21,7 +21,7 @@ final class DurationField extends Field<Duration> {
 
   @override
   Widget toWidget(BuildContext context, String groupName, Duration value) {
-    return TextFormField(
+    return ControlledTextField(
       initialValue: toParam(value),
       keyboardType: TextInputType.number,
       decoration: const InputDecoration(

--- a/packages/widgetbook/lib/src/core/fields/field.dart
+++ b/packages/widgetbook/lib/src/core/fields/field.dart
@@ -8,6 +8,7 @@ import '../state/state.dart';
 import '../utils.dart';
 import 'color_field/color_picker.dart';
 import 'color_field/color_space.dart';
+import 'controlled_text_field.dart';
 
 part 'boolean_field.dart';
 part 'color_field/color_field.dart';

--- a/packages/widgetbook/lib/src/core/fields/fields_composable.dart
+++ b/packages/widgetbook/lib/src/core/fields/fields_composable.dart
@@ -96,9 +96,6 @@ abstract class FieldsComposable<T> {
     final group = state.queryGroups[groupName];
 
     final child = Column(
-      // This key is needed to force rebuilds when the args are updated
-      // using `Arg.update`.
-      key: group != null ? ValueKey(group) : null,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: fields
           .map(

--- a/packages/widgetbook/lib/src/core/fields/num_input_field.dart
+++ b/packages/widgetbook/lib/src/core/fields/num_input_field.dart
@@ -19,7 +19,7 @@ sealed class NumInputField<T extends num> extends Field<T> {
 
   @override
   Widget toWidget(BuildContext context, String groupName, T value) {
-    return TextFormField(
+    return ControlledTextField(
       initialValue: toParam(value),
       keyboardType: TextInputType.number,
       inputFormatters: formatters,

--- a/packages/widgetbook/lib/src/core/fields/string_field.dart
+++ b/packages/widgetbook/lib/src/core/fields/string_field.dart
@@ -18,7 +18,7 @@ final class StringField extends Field<String> {
 
   @override
   Widget toWidget(BuildContext context, String groupName, String value) {
-    return TextFormField(
+    return ControlledTextField(
       maxLines: maxLines,
       initialValue: value,
       decoration: const InputDecoration(

--- a/packages/widgetbook/lib/src/core/framework/story.dart
+++ b/packages/widgetbook/lib/src/core/framework/story.dart
@@ -78,12 +78,26 @@ abstract class Story<TWidget extends Widget, TArgs extends StoryArgs<TWidget>> {
 
   String get path => p.join(component.fullPath, name);
 
+  /// By default, Widgetbook forces a rebuild when args change as otherwise
+  /// StatefulWidgets might not reflect the latest arg values.
+  /// However, if a story has internal state that should be preserved across
+  /// arg changes, this can be achieved by overriding the [setup] function and
+  /// returning the widget unchanged.
   static Widget defaultSetup(
     BuildContext context,
     Widget widget,
-    dynamic args,
+    StoryArgs args,
   ) {
-    return widget;
+    final key = ValueKey(
+      Object.hashAll(
+        args.safeList.map((arg) => arg.toQueryGroup()),
+      ),
+    );
+
+    return KeyedSubtree(
+      key: key,
+      child: widget,
+    );
   }
 
   @internal

--- a/packages/widgetbook/lib/src/core/workbench/workbench.dart
+++ b/packages/widgetbook/lib/src/core/workbench/workbench.dart
@@ -24,12 +24,9 @@ class Workbench extends StatelessWidget {
     final scenario = state.scenario;
     if (scenario != null) {
       return _WorkbenchWrapper(
-        child: KeyedSubtree(
-          key: ValueKey(state.uri),
-          child: scenario.buildWithConfig(
-            context,
-            state.config,
-          ),
+        child: scenario.buildWithConfig(
+          context,
+          state.config,
         ),
       );
     }
@@ -37,12 +34,9 @@ class Workbench extends StatelessWidget {
     final story = state.story;
     if (story != null) {
       return _WorkbenchWrapper(
-        child: KeyedSubtree(
-          key: ValueKey(state.uri),
-          child: story.buildWithConfig(
-            context,
-            state.config,
-          ),
+        child: story.buildWithConfig(
+          context,
+          state.config,
         ),
       );
     }

--- a/packages/widgetbook/test/core/fields/boolean_field_test.dart
+++ b/packages/widgetbook/test/core/fields/boolean_field_test.dart
@@ -58,6 +58,30 @@ void main() {
           expect(widget.value, equals(true));
         },
       );
+
+      testWidgets(
+        'given an arg with an initial value, '
+        'when [Arg.update] is called with a new value, '
+        'then the switch displays the updated value',
+        (tester) async {
+          final arg = BoolArg(false, name: 'isEnabled');
+
+          await tester.pumpWidgetWithState(
+            state: WidgetbookState(),
+            builder: (context) => arg.buildFields(context),
+          );
+
+          final initialSwitch = tester.widget<Switch>(find.byType(Switch));
+          expect(initialSwitch.value, equals(false));
+
+          final context = tester.element(find.byType(Switch));
+          arg.update(context, true);
+          await tester.pumpAndSettle();
+
+          final updatedSwitch = tester.widget<Switch>(find.byType(Switch));
+          expect(updatedSwitch.value, equals(true));
+        },
+      );
     },
   );
 }

--- a/packages/widgetbook/test/core/fields/color_field_test.dart
+++ b/packages/widgetbook/test/core/fields/color_field_test.dart
@@ -225,6 +225,34 @@ void main() {
           expect(find.byType(ColorPickerDialog), findsOneWidget);
         },
       );
+
+      testWidgets(
+        'given an arg with an initial value, '
+        'when [Arg.update] is called with a new value, '
+        'then the color picker displays the updated value',
+        (tester) async {
+          final arg = ColorArg(blue, name: 'color');
+
+          await tester.pumpWidgetWithState(
+            state: WidgetbookState(),
+            builder: (context) => arg.buildFields(context),
+          );
+
+          var widget = tester.widget<ColorPicker>(
+            find.byType(ColorPicker),
+          );
+          expect(widget.value, equals(blue));
+
+          final context = tester.element(find.byType(ColorPicker));
+          arg.update(context, red);
+          await tester.pumpAndSettle();
+
+          widget = tester.widget<ColorPicker>(
+            find.byType(ColorPicker),
+          );
+          expect(widget.value, equals(red));
+        },
+      );
     },
   );
 }

--- a/packages/widgetbook/test/core/fields/date_time_field_test.dart
+++ b/packages/widgetbook/test/core/fields/date_time_field_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:widgetbook/src/core/fields/fields.dart';
+import 'package:widgetbook/src/core/args/args.dart';
+import 'package:widgetbook/src/core/fields/field.dart';
+import 'package:widgetbook/src/core/state/state.dart';
 import 'package:widgetbook/src/core/utils.dart';
 
 import '../../helper/helper.dart';
@@ -71,6 +73,37 @@ void main() {
         );
 
         expect(widget.decoration?.hintText, equals('Enter a DateTime'));
+      },
+    );
+
+    testWidgets(
+      'given an arg with an initial value, '
+      'when [Arg.update] is called with a new value, '
+      'then the field displays the updated value',
+      (tester) async {
+        final start = now.subtract(const Duration(days: 365));
+        final end = now.add(const Duration(days: 365));
+        final arg = DateTimeArg(
+          now,
+          name: 'dateTime',
+          start: start,
+          end: end,
+        );
+
+        await tester.pumpWidgetWithState(
+          state: WidgetbookState(),
+          builder: (context) => arg.buildFields(context),
+        );
+
+        expect(find.text(now.toSimpleFormat()), findsOneWidget);
+
+        final context = tester.element(find.byType(TextFormField));
+        final newDateTime = now.add(const Duration(days: 30));
+        arg.update(context, newDateTime);
+        await tester.pumpAndSettle();
+
+        expect(find.text(newDateTime.toSimpleFormat()), findsOneWidget);
+        expect(find.text(now.toSimpleFormat()), findsNothing);
       },
     );
   });

--- a/packages/widgetbook/test/core/fields/double_input_field_test.dart
+++ b/packages/widgetbook/test/core/fields/double_input_field_test.dart
@@ -58,6 +58,29 @@ void main() {
           expect(widget.initialValue, equals('7.0'));
         },
       );
+
+      testWidgets(
+        'given an arg with an initial value, '
+        'when [Arg.update] is called with a new value, '
+        'then the field displays the updated value',
+        (tester) async {
+          final arg = DoubleArg(3.14, name: 'value');
+
+          await tester.pumpWidgetWithState(
+            state: WidgetbookState(),
+            builder: (context) => arg.buildFields(context),
+          );
+
+          expect(find.text('3.14'), findsOneWidget);
+
+          final context = tester.element(find.byType(TextFormField));
+          arg.update(context, 2.71);
+          await tester.pumpAndSettle();
+
+          expect(find.text('2.71'), findsOneWidget);
+          expect(find.text('3.14'), findsNothing);
+        },
+      );
     },
   );
 }

--- a/packages/widgetbook/test/core/fields/double_slider_field_test.dart
+++ b/packages/widgetbook/test/core/fields/double_slider_field_test.dart
@@ -95,6 +95,38 @@ void main() {
           );
         },
       );
+
+      testWidgets(
+        'given an arg with an initial value, '
+        'when [Arg.update] is called with a new value, '
+        'then the slider displays the updated value',
+        (tester) async {
+          final arg = DoubleArg(
+            3.0,
+            name: 'opacity',
+            style: const SliderDoubleArgStyle(
+              min: 0.0,
+              max: 10.0,
+              divisions: 10,
+            ),
+          );
+
+          await tester.pumpWidgetWithState(
+            state: WidgetbookState(),
+            builder: (context) => arg.buildFields(context),
+          );
+
+          final initialSlider = tester.widget<Slider>(find.byType(Slider));
+          expect(initialSlider.value, equals(3.0));
+
+          final context = tester.element(find.byType(Slider));
+          arg.update(context, 7.5);
+          await tester.pumpAndSettle();
+
+          final updatedSlider = tester.widget<Slider>(find.byType(Slider));
+          expect(updatedSlider.value, equals(7.5));
+        },
+      );
     },
   );
 }

--- a/packages/widgetbook/test/core/fields/duration_field_test.dart
+++ b/packages/widgetbook/test/core/fields/duration_field_test.dart
@@ -60,5 +60,28 @@ void main() {
         expect(widget.decoration?.hintText, equals('Enter a duration'));
       },
     );
+
+    testWidgets(
+      'given an arg with an initial value, '
+      'when [Arg.update] is called with a new value, '
+      'then the field displays the updated value',
+      (tester) async {
+        final arg = DurationArg(fiveSeconds, name: 'delay');
+
+        await tester.pumpWidgetWithState(
+          state: WidgetbookState(),
+          builder: (context) => arg.buildFields(context),
+        );
+
+        expect(find.text('5000'), findsOneWidget);
+
+        final context = tester.element(find.byType(TextFormField));
+        arg.update(context, tenSeconds);
+        await tester.pumpAndSettle();
+
+        expect(find.text('10000'), findsOneWidget);
+        expect(find.text('5000'), findsNothing);
+      },
+    );
   });
 }

--- a/packages/widgetbook/test/core/fields/int_input_field_test.dart
+++ b/packages/widgetbook/test/core/fields/int_input_field_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widgetbook/widgetbook.dart';
 
+import '../../helper/helper.dart';
+
 void main() {
   group('$IntInputField', () {
     final field = IntInputField(
@@ -50,6 +52,29 @@ void main() {
         );
 
         expect(find.text('7'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'given an arg with an initial value, '
+      'when [Arg.update] is called with a new value, '
+      'then the field displays the updated value',
+      (tester) async {
+        final arg = IntArg(5, name: 'count');
+
+        await tester.pumpWidgetWithState(
+          state: WidgetbookState(),
+          builder: (context) => arg.buildFields(context),
+        );
+
+        expect(find.text('5'), findsOneWidget);
+
+        final context = tester.element(find.byType(TextFormField));
+        arg.update(context, 10);
+        await tester.pumpAndSettle();
+
+        expect(find.text('10'), findsOneWidget);
+        expect(find.text('5'), findsNothing);
       },
     );
   });

--- a/packages/widgetbook/test/core/fields/int_slider_field_test.dart
+++ b/packages/widgetbook/test/core/fields/int_slider_field_test.dart
@@ -60,6 +60,38 @@ void main() {
           expect(widget.value, equals(7));
         },
       );
+
+      testWidgets(
+        'given an arg with an initial value, '
+        'when [Arg.update] is called with a new value, '
+        'then the slider displays the updated value',
+        (tester) async {
+          final arg = IntArg(
+            3,
+            name: 'volume',
+            style: const SliderIntArgStyle(
+              min: 0,
+              max: 10,
+              divisions: 10,
+            ),
+          );
+
+          await tester.pumpWidgetWithState(
+            state: WidgetbookState(),
+            builder: (context) => arg.buildFields(context),
+          );
+
+          final initialSlider = tester.widget<Slider>(find.byType(Slider));
+          expect(initialSlider.value, equals(3));
+
+          final context = tester.element(find.byType(Slider));
+          arg.update(context, 8);
+          await tester.pumpAndSettle();
+
+          final updatedSlider = tester.widget<Slider>(find.byType(Slider));
+          expect(updatedSlider.value, equals(8));
+        },
+      );
     },
   );
 }

--- a/packages/widgetbook/test/core/fields/iterable_segmented_field_test.dart
+++ b/packages/widgetbook/test/core/fields/iterable_segmented_field_test.dart
@@ -82,6 +82,38 @@ void main() {
           expect(widget.selected, equals({2}));
         },
       );
+
+      testWidgets(
+        'given an arg with an initial value, '
+        'when [Arg.update] is called with a new value, '
+        'then the segmented button displays the updated value',
+        (tester) async {
+          final arg = IterableArg<int>(
+            {1},
+            name: 'segments',
+            values: {1, 2, 3},
+          );
+
+          await tester.pumpWidgetWithState(
+            state: WidgetbookState(),
+            builder: (context) => arg.buildFields(context),
+          );
+
+          var widget = tester.widget<SegmentedButton<int>>(
+            find.byType(SegmentedButton<int>),
+          );
+          expect(widget.selected, equals({1}));
+
+          final context = tester.element(find.byType(SegmentedButton<int>));
+          arg.update(context, {2, 3});
+          await tester.pumpAndSettle();
+
+          widget = tester.widget<SegmentedButton<int>>(
+            find.byType(SegmentedButton<int>),
+          );
+          expect(widget.selected, equals({2, 3}));
+        },
+      );
     },
   );
 }

--- a/packages/widgetbook/test/core/fields/object_dropdown_field_test.dart
+++ b/packages/widgetbook/test/core/fields/object_dropdown_field_test.dart
@@ -89,6 +89,38 @@ void main() {
         // drop down text to be edited.
         variant: TargetPlatformVariant.only(TargetPlatform.macOS),
       );
+
+      testWidgets(
+        'given an arg with an initial value, '
+        'when [Arg.update] is called with a new value, '
+        'then the dropdown displays the updated value',
+        (tester) async {
+          final arg = SingleArg<int>(
+            1,
+            name: 'dropdown',
+            values: [1, 2, 3],
+          );
+
+          await tester.pumpWidgetWithState(
+            state: WidgetbookState(),
+            builder: (context) => arg.buildFields(context),
+          );
+
+          var widget = tester.widget<DropdownMenu<int>>(
+            find.byType(DropdownMenu<int>),
+          );
+          expect(widget.initialSelection, equals(1));
+
+          final context = tester.element(find.byType(DropdownMenu<int>));
+          arg.update(context, 3);
+          await tester.pumpAndSettle();
+
+          widget = tester.widget<DropdownMenu<int>>(
+            find.byType(DropdownMenu<int>),
+          );
+          expect(widget.initialSelection, equals(3));
+        },
+      );
     },
   );
 }

--- a/packages/widgetbook/test/core/fields/object_segmented_field_test.dart
+++ b/packages/widgetbook/test/core/fields/object_segmented_field_test.dart
@@ -69,6 +69,39 @@ void main() {
           expect(widget.selected, equals({2}));
         },
       );
+
+      testWidgets(
+        'given an arg with an initial value, '
+        'when [Arg.update] is called with a new value, '
+        'then the segmented button displays the updated value',
+        (tester) async {
+          final arg = SingleArg<int>(
+            1,
+            name: 'segmented',
+            values: [1, 2, 3],
+            style: const SegmentedSingleArgStyle(),
+          );
+
+          await tester.pumpWidgetWithState(
+            state: WidgetbookState(),
+            builder: (context) => arg.buildFields(context),
+          );
+
+          var widget = tester.widget<SegmentedButton<int>>(
+            find.byType(SegmentedButton<int>),
+          );
+          expect(widget.selected, equals({1}));
+
+          final context = tester.element(find.byType(SegmentedButton<int>));
+          arg.update(context, 3);
+          await tester.pumpAndSettle();
+
+          widget = tester.widget<SegmentedButton<int>>(
+            find.byType(SegmentedButton<int>),
+          );
+          expect(widget.selected, equals({3}));
+        },
+      );
     },
   );
 }

--- a/packages/widgetbook/test/core/fields/string_field_test.dart
+++ b/packages/widgetbook/test/core/fields/string_field_test.dart
@@ -85,6 +85,29 @@ void main() {
           expect(widget.decoration?.hintText, equals('Enter a value'));
         },
       );
+
+      testWidgets(
+        'given an arg with an initial value, '
+        'when [Arg.update] is called with a new value, '
+        'then the field displays the updated value',
+        (tester) async {
+          final arg = StringArg('hello', name: 'message');
+
+          await tester.pumpWidgetWithState(
+            state: WidgetbookState(),
+            builder: (context) => arg.buildFields(context),
+          );
+
+          expect(find.text('hello'), findsOneWidget);
+
+          final context = tester.element(find.byType(TextFormField));
+          arg.update(context, 'world');
+          await tester.pumpAndSettle();
+
+          expect(find.text('world'), findsOneWidget);
+          expect(find.text('hello'), findsNothing);
+        },
+      );
     },
   );
 }

--- a/packages/widgetbook/test/core/framework/story_setup_test.dart
+++ b/packages/widgetbook/test/core/framework/story_setup_test.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import '../../helper/helper.dart';
+
+class _CounterArgs<TWidget extends Widget> extends StoryArgs<TWidget> {
+  _CounterArgs({
+    IntArg? initialValueArg,
+  }) : initialValueArg = initialValueArg ?? IntArg(1, name: 'initialValue');
+
+  final IntArg initialValueArg;
+
+  int get initialValue => initialValueArg.value;
+
+  @override
+  List<Arg?> get list => [initialValueArg];
+}
+
+class _TestStory<TWidget extends Widget, TArgs extends StoryArgs<TWidget>>
+    extends Story<TWidget, TArgs> {
+  _TestStory({
+    super.setup,
+    required super.args,
+    required super.builder,
+  });
+}
+
+class _StatelessCounter extends StatelessWidget {
+  const _StatelessCounter({required this.initialValue});
+
+  final int initialValue;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      '$initialValue',
+      textDirection: TextDirection.ltr,
+    );
+  }
+}
+
+class _StatefulCounter extends StatefulWidget {
+  const _StatefulCounter({required this.initialValue});
+
+  final int initialValue;
+
+  @override
+  State<_StatefulCounter> createState() => _StatefulCounterState();
+}
+
+class _StatefulCounterState extends State<_StatefulCounter> {
+  late int value;
+
+  @override
+  void initState() {
+    super.initState();
+    value = widget.initialValue;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('$value'),
+        IconButton(
+          icon: const Icon(Icons.add),
+          onPressed: () {
+            setState(() {
+              value += 1;
+            });
+          },
+        ),
+      ],
+    );
+  }
+}
+
+void main() {
+  group('$Story.setup', () {
+    testWidgets(
+      'given a stateless widget story, '
+      'when an arg updates, '
+      'then the widget updates',
+      (tester) async {
+        final story =
+            _TestStory<_StatelessCounter, _CounterArgs<_StatelessCounter>>(
+              args: _CounterArgs<_StatelessCounter>(),
+              builder: (context, args) {
+                return _StatelessCounter(initialValue: args.initialValue);
+              },
+            );
+
+        await tester.pumpWidgetWithState(
+          state: WidgetbookState(),
+          builder: (context) {
+            return story.buildWithConfig(context, const Config());
+          },
+        );
+
+        expect(find.text('1'), findsOneWidget);
+
+        final context = tester.element(find.byType(_StatelessCounter));
+        story.args.initialValueArg.update(context, 2);
+        await tester.pumpAndSettle();
+
+        expect(find.text('2'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'given a stateful widget story with default setup, '
+      'when an arg updates, '
+      'then local widget state resets to the new arg value',
+      (tester) async {
+        final story =
+            _TestStory<_StatefulCounter, _CounterArgs<_StatefulCounter>>(
+              args: _CounterArgs<_StatefulCounter>(),
+              builder: (context, args) {
+                return _StatefulCounter(initialValue: args.initialValue);
+              },
+            );
+
+        await tester.pumpWidgetWithState(
+          state: WidgetbookState(),
+          builder: (context) {
+            return story.buildWithConfig(context, const Config());
+          },
+        );
+
+        expect(find.text('1'), findsOneWidget);
+
+        await tester.findAndTap(find.byIcon(Icons.add));
+        expect(find.text('2'), findsOneWidget);
+
+        final context = tester.element(find.byType(_StatefulCounter));
+        story.args.initialValueArg.update(context, 5);
+        await tester.pumpAndSettle();
+
+        expect(find.text('5'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'given a stateful widget story with a custom setup passthrough, '
+      'when an arg updates, '
+      'then local widget state is preserved',
+      (tester) async {
+        final story =
+            _TestStory<_StatefulCounter, _CounterArgs<_StatefulCounter>>(
+              setup: (context, widget, args) => widget,
+              args: _CounterArgs<_StatefulCounter>(),
+              builder: (context, args) {
+                return _StatefulCounter(initialValue: args.initialValue);
+              },
+            );
+
+        await tester.pumpWidgetWithState(
+          state: WidgetbookState(),
+          builder: (context) {
+            return story.buildWithConfig(context, const Config());
+          },
+        );
+
+        expect(find.text('1'), findsOneWidget);
+
+        await tester.findAndTap(find.byIcon(Icons.add));
+        expect(find.text('2'), findsOneWidget);
+
+        final context = tester.element(find.byType(_StatefulCounter));
+        story.args.initialValueArg.update(context, 5);
+        await tester.pumpAndSettle();
+
+        expect(find.text('2'), findsOneWidget);
+        expect(find.text('5'), findsNothing);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Improved rebuilding on Arg changes when. 
Added tests for all Args to prevent regression. 