### PR TITLE
fix: update enum type generation to use non-nullable name

### DIFF
--- a/packages/widgetbook/lib/src/generator/framework/extensions.dart
+++ b/packages/widgetbook/lib/src/generator/framework/extensions.dart
@@ -125,7 +125,7 @@ extension DartTypeX on DartType {
     if (isEnum) {
       return isNullable
           ? TypeMeta(
-              'NullableEnumArg<${getDisplayString()}>',
+              'NullableEnumArg<$nonNullableName>',
               literalNull,
             )
           : TypeMeta(


### PR DESCRIPTION
For nullable enum properties, the generator creates a `NullableEnumArg<Clip?>`. 
However, this is invalid code since `class NullableEnumArg<T extends Enum>`, therefore T cannot be nullable. 

## Example

When cataloging an ElevatedButton (from Material), the generator creates the following arg initialization

```
this.clipBehaviorArg = $initArg(
  'clipBehavior',
  clipBehavior,
  NullableEnumArg<Clip?>(null, values: Clip.values),
)!,
```

## Result

The PR changes the generator to produce

```
this.clipBehaviorArg = $initArg(
  'clipBehavior',
  clipBehavior,
  NullableEnumArg<Clip>(null, values: Clip.values),
)!,
```