### PR TITLE
fix: resolve nullable arg checkbox requiring two clicks to toggle

### DIFF
--- a/packages/widgetbook/lib/src/core/fields/fields_composable.dart
+++ b/packages/widgetbook/lib/src/core/fields/fields_composable.dart
@@ -130,13 +130,13 @@ abstract class FieldsComposable<T> {
       description: description,
       isNullified: isNullified,
       onNullified: (value) {
-        if (group == null) {
-          state.updateQueryGroup(groupName, QueryGroup.nullified);
-          return;
+        if (value) {
+          final newGroup = group?.nullify() ?? QueryGroup.nullified;
+          state.updateQueryGroup(groupName, newGroup);
+        } else {
+          final newGroup = group?.unnullify() ?? QueryGroup.empty;
+          state.updateQueryGroup(groupName, newGroup);
         }
-
-        final newGroup = value ? group.nullify() : group.unnullify();
-        state.updateQueryGroup(groupName, newGroup);
       },
       child: child,
     );

--- a/packages/widgetbook/test/core/fields/boolean_field_test.dart
+++ b/packages/widgetbook/test/core/fields/boolean_field_test.dart
@@ -82,6 +82,42 @@ void main() {
           expect(updatedSwitch.value, equals(true));
         },
       );
+
+      testWidgets(
+        'given a nullable arg with null initial value, '
+        'when the checkbox is clicked once, '
+        'then the query group is un-nullified',
+        (tester) async {
+          final arg = NullableBoolArg(null, name: 'isEnabled');
+          final state = WidgetbookState();
+
+          await tester.pumpWidgetWithState(
+            state: state,
+            builder: (context) => arg.buildFields(context),
+          );
+
+          // Checkbox should be unchecked initially (value is null = nullified)
+          final initialCheckbox = tester.widget<Checkbox>(
+            find.byType(Checkbox),
+          );
+          expect(initialCheckbox.value, equals(false));
+
+          // Click the checkbox once to un-nullify
+          await tester.tap(find.byType(Checkbox));
+          await tester.pumpAndSettle();
+
+          // The query group should be un-nullified
+          final group = state.queryGroups[arg.groupName];
+          expect(group, isNotNull);
+          expect(group!.isNullified, equals(false));
+
+          // Checkbox should now be checked
+          final updatedCheckbox = tester.widget<Checkbox>(
+            find.byType(Checkbox),
+          );
+          expect(updatedCheckbox.value, equals(true));
+        },
+      );
     },
   );
 }


### PR DESCRIPTION
When a nullable arg had no query group yet (initial state), the onNullified callback always set QueryGroup.nullified regardless of whether the user was enabling or disabling. This caused the first click to be silently ignored.