### PR TITLE
fix: use raw multi-line string

### DIFF
--- a/packages/widgetbook/lib/src/generator/framework/component_builder.dart
+++ b/packages/widgetbook/lib/src/generator/framework/component_builder.dart
@@ -61,10 +61,11 @@ class ComponentBuilder {
                 'meta',
               ).property('docsBuilder'),
               'docComment': widgetType.element?.documentationComment != null
-                  ? literalString(
-                      widgetType.element!.documentationComment!.replaceAll(
-                        RegExp(r'/// ?'),
-                        '',
+                  ? CodeExpression(
+                      Code(
+                        "r'''"
+                        "${widgetType.element!.documentationComment!.replaceAll(RegExp(r'/// ?'), '')}"
+                        "'''",
                       ),
                     )
                   : literalNull,

--- a/packages/widgetbook/test/generator/doc_comment/doc_comment.stories.g.dart
+++ b/packages/widgetbook/test/generator/doc_comment/doc_comment.stories.g.dart
@@ -16,8 +16,9 @@ final DocCommentWidgetComponent =
       name: meta.name ?? 'DocCommentWidget',
       path: meta.path ?? '',
       docsBuilder: meta.docsBuilder,
-      docComment:
-          'A widget with documentation.\n\nThis has an empty line above.',
+      docComment: r'''A widget with documentation.
+
+This has an empty line above.''',
       stories: [$Default..$generatedName = 'Default'],
     );
 typedef DocCommentWidgetScenario =

--- a/packages/widgetbook/test/generator/doc_comment_code/doc_comment_code.stories.dart
+++ b/packages/widgetbook/test/generator/doc_comment_code/doc_comment_code.stories.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/widgets.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+part 'doc_comment_code.stories.g.dart';
+
+/// Displays a [label].
+///
+/// ```dart
+/// DocCommentCodeWidget(label: '$name ($age)')
+/// ```
+class DocCommentCodeWidget extends StatelessWidget {
+  const DocCommentCodeWidget({
+    super.key,
+    required this.label,
+  });
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) => Text(label);
+}
+
+const meta = Meta<DocCommentCodeWidget>();
+
+final $Default = Object();

--- a/packages/widgetbook/test/generator/doc_comment_code/doc_comment_code.stories.g.dart
+++ b/packages/widgetbook/test/generator/doc_comment_code/doc_comment_code.stories.g.dart
@@ -1,0 +1,68 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'doc_comment_code.stories.dart';
+
+// **************************************************************************
+// StoryGenerator
+// **************************************************************************
+
+typedef _Component = Component<DocCommentCodeWidget, DocCommentCodeWidgetArgs>;
+typedef _Scenario = DocCommentCodeWidgetScenario;
+typedef _Defaults = DocCommentCodeWidgetDefaults;
+typedef _Story = DocCommentCodeWidgetStory;
+typedef _Args = DocCommentCodeWidgetArgs;
+final DocCommentCodeWidgetComponent =
+    Component<DocCommentCodeWidget, DocCommentCodeWidgetArgs>(
+      name: meta.name ?? 'DocCommentCodeWidget',
+      path: meta.path ?? '',
+      docsBuilder: meta.docsBuilder,
+      docComment: r'''Displays a [label].
+
+```dart
+DocCommentCodeWidget(label: '$name ($age)')
+```''',
+      stories: [$Default..$generatedName = 'Default'],
+    );
+typedef DocCommentCodeWidgetScenario =
+    Scenario<DocCommentCodeWidget, DocCommentCodeWidgetArgs>;
+typedef DocCommentCodeWidgetDefaults =
+    Defaults<DocCommentCodeWidget, DocCommentCodeWidgetArgs>;
+
+class DocCommentCodeWidgetStory
+    extends Story<DocCommentCodeWidget, DocCommentCodeWidgetArgs> {
+  DocCommentCodeWidgetStory({
+    super.name,
+    super.setup,
+    super.modes,
+    DocCommentCodeWidgetArgs? args,
+    StoryWidgetBuilder<DocCommentCodeWidget, DocCommentCodeWidgetArgs>? builder,
+    super.scenarios,
+  }) : super(
+         args: args ?? DocCommentCodeWidgetArgs(),
+         builder:
+             builder ??
+             (context, args) =>
+                 DocCommentCodeWidget(key: args.key, label: args.label),
+       );
+}
+
+class DocCommentCodeWidgetArgs extends StoryArgs<DocCommentCodeWidget> {
+  DocCommentCodeWidgetArgs({Arg<Key?>? key, Arg<String>? label})
+    : this.keyArg = $initArg('key', key, null),
+      this.labelArg = $initArg('label', label, StringArg(''))!;
+
+  DocCommentCodeWidgetArgs.fixed({Key? key, String label = ''})
+    : this.keyArg = key == null ? null : Arg.fixed(key),
+      this.labelArg = Arg.fixed(label);
+
+  final Arg<Key?>? keyArg;
+
+  final Arg<String> labelArg;
+
+  Key? get key => keyArg?.value;
+
+  String get label => labelArg.value;
+
+  @override
+  List<Arg?> get list => [keyArg, labelArg];
+}

--- a/packages/widgetbook/test/generator/doc_comment_code/doc_comment_code_test.dart
+++ b/packages/widgetbook/test/generator/doc_comment_code/doc_comment_code_test.dart
@@ -1,0 +1,16 @@
+// Tests that doc comments containing code with $ interpolation are correctly
+// escaped in the generated output.
+
+@TestOn('vm')
+library;
+
+import '../helper.dart';
+
+void main() {
+  test(
+    'generates correct docComment for doc comments with code containing \$ signs',
+    () async {
+      await testStoryGenerator('doc_comment_code');
+    },
+  );
+}


### PR DESCRIPTION
Changes the generator to produce raw multi-line strings which prevents special characters in a string like `$name` to reference a (non-existent) variable in the file. 