### PR TITLE
fix: Improve performance

### DIFF
--- a/packages/widgetbook/lib/src/fields/field.dart
+++ b/packages/widgetbook/lib/src/fields/field.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../state/state.dart';
+import 'field_builder.dart';
 import 'field_codec.dart';
 import 'field_type.dart';
 
@@ -95,7 +96,11 @@ abstract class Field<T> {
     final groupMap = FieldCodec.decodeQueryGroup(state.queryParams[group]);
     final value = valueFrom(groupMap);
 
-    return toWidget(context, group, value);
+    return FieldBuilder<T>(
+      group: group,
+      value: value,
+      builder: (context) => toWidget(context, group, value),
+    );
   }
 
   /// Converts this field into a [Widget] that can be used in the

--- a/packages/widgetbook/lib/src/fields/field_builder.dart
+++ b/packages/widgetbook/lib/src/fields/field_builder.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+/// A [FieldBuilder] is a widget that prevent useless rebuilds of the field widget when the value of the field changes.
+class FieldBuilder<T> extends StatefulWidget {
+  /// Creates a [FieldBuilder] with the specified configuration.
+  const FieldBuilder({
+    required this.group,
+    required this.value,
+    required this.builder,
+    super.key,
+  });
+
+  /// The name of the query group param.
+  final String group;
+
+  /// The value of the field, used to determine when to rebuild the widget.
+  final T? value;
+
+  /// A builder function that creates the widget to be rendered in the settings side panel.
+  final Widget Function(BuildContext) builder;
+
+  @override
+  State<FieldBuilder<T>> createState() => _FieldBuilderState<T>();
+}
+
+class _FieldBuilderState<T> extends State<FieldBuilder<T>> {
+  late String _lastGroup = widget.group;
+  late T? _lastValue = widget.value;
+  Widget? _cachedWidget;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _cachedWidget = null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_cachedWidget == null ||
+        widget.value != _lastValue ||
+        widget.group != _lastGroup) {
+      _lastValue = widget.value;
+      _lastGroup = widget.group;
+      _cachedWidget = widget.builder(context);
+    }
+    return _cachedWidget!;
+  }
+}

--- a/packages/widgetbook/lib/src/fields/field_builder.dart
+++ b/packages/widgetbook/lib/src/fields/field_builder.dart
@@ -24,25 +24,18 @@ class FieldBuilder<T> extends StatefulWidget {
 }
 
 class _FieldBuilderState<T> extends State<FieldBuilder<T>> {
-  late String _lastGroup = widget.group;
-  late T? _lastValue = widget.value;
   Widget? _cachedWidget;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _cachedWidget = null;
+  void didUpdateWidget(covariant FieldBuilder<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.value != oldWidget.value || widget.group != oldWidget.group) {
+      _cachedWidget = null;
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    if (_cachedWidget == null ||
-        widget.value != _lastValue ||
-        widget.group != _lastGroup) {
-      _lastValue = widget.value;
-      _lastGroup = widget.group;
-      _cachedWidget = widget.builder(context);
-    }
-    return _cachedWidget!;
+    return _cachedWidget ??= widget.builder(context);
   }
 }

--- a/packages/widgetbook/lib/src/settings/settings_panel.dart
+++ b/packages/widgetbook/lib/src/settings/settings_panel.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
+import 'settings_panel_builder.dart';
+
 @internal
 class SettingsPanelData {
   SettingsPanelData({
@@ -54,19 +56,23 @@ class SettingsPanel extends StatelessWidget {
                 (setting) {
                   final children = setting.builder(context);
 
-                  return children.isEmpty
-                      ? Center(
-                          child: Padding(
-                            padding: const EdgeInsets.all(8),
-                            child: Text('No ${setting.name} available'),
-                          ),
-                        )
-                      : SingleChildScrollView(
-                          padding: const EdgeInsets.symmetric(vertical: 16),
-                          child: Column(
-                            children: children,
-                          ),
-                        );
+                  if (children.isEmpty) {
+                    return Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(8),
+                        child: Text('No ${setting.name} available'),
+                      ),
+                    );
+                  } else {
+                    return SettingsPanelBuilder(
+                      builder: (context) => SingleChildScrollView(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        child: Column(
+                          children: children,
+                        ),
+                      ),
+                    );
+                  }
                 },
               ).toList(),
             ),

--- a/packages/widgetbook/lib/src/settings/settings_panel_builder.dart
+++ b/packages/widgetbook/lib/src/settings/settings_panel_builder.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+/// A [StatefulWidget] that builds the content of a settings panel and keeps it alive when it's not visible.
+class SettingsPanelBuilder extends StatefulWidget {
+  /// Creates a [SettingsPanelBuilder] with the specified configuration.
+  const SettingsPanelBuilder({required this.builder, super.key});
+
+  /// A builder function that creates the widget to be rendered in the settings side panel.
+  final Widget Function(BuildContext) builder;
+
+  @override
+  State<SettingsPanelBuilder> createState() => _SettingsPanelBuilderState();
+}
+
+class _SettingsPanelBuilderState extends State<SettingsPanelBuilder>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return widget.builder(context);
+  }
+
+  @override
+  bool get wantKeepAlive => true;
+}

--- a/packages/widgetbook/test/src/fields/field_builder_test.dart
+++ b/packages/widgetbook/test/src/fields/field_builder_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/src/fields/field_builder.dart';
+
+void main() {
+  testWidgets('renders widget returned by builder', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FieldBuilder<int>(
+          group: 'group',
+          value: 1,
+          builder: (_) => const Text('Field'),
+        ),
+      ),
+    );
+
+    expect(find.text('Field'), findsOneWidget);
+  });
+
+  testWidgets('does not rebuild when value and group are unchanged', (
+    tester,
+  ) async {
+    var buildCount = 0;
+
+    Widget buildApp() {
+      return MaterialApp(
+        home: FieldBuilder<int>(
+          group: 'group',
+          value: 1,
+          builder: (_) {
+            buildCount++;
+            return const Text('Field');
+          },
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+    expect(buildCount, 1);
+
+    await tester.pumpWidget(buildApp());
+    expect(buildCount, 1);
+  });
+
+  testWidgets('rebuilds when value changes', (tester) async {
+    var buildCount = 0;
+    var value = 1;
+
+    Widget buildApp() {
+      return MaterialApp(
+        home: FieldBuilder<int>(
+          group: 'group',
+          value: value,
+          builder: (_) {
+            buildCount++;
+            return const Text('Field');
+          },
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+    expect(buildCount, 1);
+
+    value = 2;
+    await tester.pumpWidget(buildApp());
+    expect(buildCount, 2);
+  });
+
+  testWidgets('rebuilds when group changes', (tester) async {
+    var buildCount = 0;
+    var group = 'group';
+
+    Widget buildApp() {
+      return MaterialApp(
+        home: FieldBuilder<int>(
+          group: group,
+          value: 1,
+          builder: (_) {
+            buildCount++;
+            return const Text('Field');
+          },
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+    expect(buildCount, 1);
+
+    group = 'group_2';
+    await tester.pumpWidget(buildApp());
+    expect(buildCount, 2);
+  });
+
+  testWidgets('rebuilds when dependencies change', (tester) async {
+    var buildCount = 0;
+
+    Widget buildApp(ThemeData theme) {
+      return Theme(
+        data: theme,
+        child: FieldBuilder<int>(
+          group: 'group',
+          value: 1,
+          builder: (context) {
+            Theme.of(context);
+            buildCount++;
+            return const SizedBox();
+          },
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp(ThemeData.light()));
+    await tester.pumpAndSettle();
+    expect(buildCount, 1);
+
+    await tester.pumpWidget(buildApp(ThemeData.dark()));
+    await tester.pumpAndSettle();
+    expect(buildCount, 2);
+  });
+}

--- a/packages/widgetbook/test/src/settings/settings_panel_builder_test.dart
+++ b/packages/widgetbook/test/src/settings/settings_panel_builder_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:widgetbook/src/settings/settings_panel_builder.dart';
 
 void main() {
-  testWidgets('Garde le contenu en vie', (tester) async {
+  testWidgets('keeps content alive across page changes', (tester) async {
     final controller = PageController();
     await tester.pumpWidget(
       MaterialApp(
@@ -14,7 +14,7 @@ void main() {
               SettingsPanelBuilder(
                 builder: (context) => const _TestWidget(),
               ),
-              const Text('Autre Page'),
+              const Text('Other Page'),
             ],
           ),
         ),

--- a/packages/widgetbook/test/src/settings/settings_panel_builder_test.dart
+++ b/packages/widgetbook/test/src/settings/settings_panel_builder_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/src/settings/settings_panel_builder.dart';
+
+void main() {
+  testWidgets('Garde le contenu en vie', (tester) async {
+    final controller = PageController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PageView(
+            controller: controller,
+            children: [
+              SettingsPanelBuilder(
+                builder: (context) => const _TestWidget(),
+              ),
+              const Text('Autre Page'),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('0'), findsOneWidget);
+
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+    expect(find.text('1'), findsOneWidget);
+
+    // Go to next page, actual widget is out of screen
+    controller.jumpToPage(1);
+    await tester.pumpAndSettle();
+
+    expect(find.text('1'), findsNothing);
+
+    // Go back
+    controller.jumpToPage(0);
+    await tester.pumpAndSettle();
+
+    expect(find.text('1'), findsOneWidget);
+  });
+}
+
+class _TestWidget extends StatefulWidget {
+  const _TestWidget();
+
+  @override
+  State<_TestWidget> createState() => _TestWidgetState();
+}
+
+class _TestWidgetState extends State<_TestWidget> {
+  int count = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(count.toString()),
+        ElevatedButton(
+          onPressed: () => setState(() => count++),
+          child: const Text('+'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
**Motivation:**

- Every time a knob change, the entire knob panel is rebuild. When you have many knob inside a single use case, this impact performance during your dev journey.
- Every time we swap from 'Knobs' panel to 'Addons' panel, knobs panel is rebuild from scratch which impact again peformance. We can 'keep' alive the panels to avoid this pain.

### List of issues which are fixed by the PR
- https://github.com/widgetbook/widgetbook/issues/1821 seems to (maybe) be fixed with this PR.

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
