### PR TITLE
fix: make addon context accessible in story `builder` and `setup` functions

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **FIX**: Make addon-provided `InheritedWidget`s accessible via `BuildContext` in story `builder` and `setup` functions. ([#1893](https://github.com/widgetbook/widgetbook/pull/1893))
+- **FIX**: Make addon-provided `InheritedWidget`s accessible via `BuildContext` in story `builder` and `setup` functions. ([#1894](https://github.com/widgetbook/widgetbook/pull/1894))
 
 ## 4.0.0-beta.3
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Make addon-provided `InheritedWidget`s accessible via `BuildContext` in story `builder` and `setup` functions. ([#1893](https://github.com/widgetbook/widgetbook/pull/1893))
+
 ## 4.0.0-beta.3
 
 - **FIX**: Virtualize navigation tree to only build visible items, improving performance for large catalogs. ([#1886](https://github.com/widgetbook/widgetbook/pull/1886))

--- a/packages/widgetbook/lib/src/core/framework/story.dart
+++ b/packages/widgetbook/lib/src/core/framework/story.dart
@@ -142,15 +142,17 @@ abstract class Story<TWidget extends Widget, TArgs extends StoryArgs<TWidget>> {
     syncArgs(context);
     initBuilderArgs(context, effectiveArgs);
 
-    final widget = builder(context, effectiveArgs);
-    final story = setup(context, widget, effectiveArgs);
-
     return config.appBuilder(
       context,
       NestedBuilder(
         items: effectiveAddons,
         builder: (context, addon, child) => addon.build(context, child),
-        child: story,
+        child: Builder(
+          builder: (context) {
+            final widget = this.builder(context, effectiveArgs);
+            return setup(context, widget, effectiveArgs);
+          },
+        ),
       ),
     );
   }

--- a/packages/widgetbook/test/core/framework/story_context_test.dart
+++ b/packages/widgetbook/test/core/framework/story_context_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import '../../helper/helper.dart';
+
+class _CustomThemeData {
+  const _CustomThemeData({required this.color});
+
+  final Color color;
+}
+
+class _CustomTheme extends InheritedWidget {
+  const _CustomTheme({
+    required this.data,
+    required super.child,
+  });
+
+  final _CustomThemeData data;
+
+  static _CustomThemeData of(BuildContext context) {
+    final widget = context.dependOnInheritedWidgetOfExactType<_CustomTheme>();
+    return widget!.data;
+  }
+
+  @override
+  bool updateShouldNotify(covariant _CustomTheme oldWidget) {
+    return data != oldWidget.data;
+  }
+}
+
+class _SimpleArgs extends StoryArgs<Text> {
+  const _SimpleArgs();
+
+  @override
+  List<Arg?> get list => const [];
+}
+
+class _TestStory<TWidget extends Widget, TArgs extends StoryArgs<TWidget>>
+    extends Story<TWidget, TArgs> {
+  _TestStory({
+    super.setup,
+    required super.args,
+    required super.builder,
+  });
+}
+
+void main() {
+  group('$Story.buildWithConfig', () {
+    const themeData = _CustomThemeData(color: Colors.red);
+
+    final config = Config(
+      addons: [
+        ThemeAddon<_CustomThemeData>(
+          {'Red': themeData},
+          (context, theme, child) {
+            return _CustomTheme(
+              data: theme,
+              child: child,
+            );
+          },
+        ),
+      ],
+    );
+
+    testWidgets(
+      'given a ThemeAddon with a custom theme, '
+      'when accessing the theme via context in builder, '
+      'then the theme is accessible',
+      (tester) async {
+        final story = _TestStory<Text, _SimpleArgs>(
+          args: const _SimpleArgs(),
+          builder: (context, args) {
+            final theme = _CustomTheme.of(context);
+            return Text('${theme.color}');
+          },
+        );
+
+        await tester.pumpWidgetWithState(
+          state: WidgetbookState(),
+          builder: (context) {
+            return story.buildWithConfig(context, config);
+          },
+        );
+
+        expect(find.text('${Colors.red}'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'given a ThemeAddon with a custom theme, '
+      'when accessing the theme via context in setup, '
+      'then the theme is accessible',
+      (tester) async {
+        final story = _TestStory<Text, _SimpleArgs>(
+          args: const _SimpleArgs(),
+          setup: (context, widget, args) {
+            final theme = _CustomTheme.of(context);
+            return Text('${theme.color}');
+          },
+          builder: (context, args) {
+            return const Text('unused');
+          },
+        );
+
+        await tester.pumpWidgetWithState(
+          state: WidgetbookState(),
+          builder: (context) {
+            return story.buildWithConfig(context, config);
+          },
+        );
+
+        expect(find.text('${Colors.red}'), findsOneWidget);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary                                                                                                               
  - Fix `BuildContext` in story `builder` and `setup` functions not having access to addon-provided `InheritedWidget`s   
  (e.g. custom themes via `ThemeAddon`)                                                                                    
  - The context was from above the addon layer, so `CustomTheme.of(context)` would throw a null check error
  - Wraps `builder`/`setup` in a `Builder` widget so they execute below the addon layer in the widget tree  