### PR TITLE
fix: preserve type arguments on generic type parameter bounds

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **FIX**: Make addon-provided `InheritedWidget`s accessible via `BuildContext` in story `builder` and `setup` functions. ([#1894](https://github.com/widgetbook/widgetbook/pull/1894))
+- **FIX**: Preserve type arguments on generic type parameter bounds in generated code. ([#1895](https://github.com/widgetbook/widgetbook/pull/1895))
 
 ## 4.0.0-beta.3
 

--- a/packages/widgetbook/lib/src/generator/framework/extensions.dart
+++ b/packages/widgetbook/lib/src/generator/framework/extensions.dart
@@ -49,10 +49,27 @@ extension DartTypeX on DartType {
     ),
   };
 
-  /// Gets class name without generic parameters
+  /// Gets class name without generic parameters.
   /// Can only be used on classes.
   String get nonGenericName {
     return element!.displayName;
+  }
+
+  /// Converts a type parameter bound to a [Reference] that preserves its
+  /// type arguments recursively.
+  ///
+  /// For `BoundWidget<D, T extends BaseItem<D>>`, the bound on `T` is
+  /// `BaseItem<D>`.
+  Reference get _boundRef {
+    final self = this;
+    if (self is ParameterizedType && self.typeArguments.isNotEmpty) {
+      return TypeReference(
+        (b) => b
+          ..symbol = self.element!.displayName
+          ..types.addAll(self.typeArguments.map((t) => t._boundRef)),
+      );
+    }
+    return refer(element!.displayName);
   }
 
   Iterable<Reference> getTypeParams({
@@ -67,7 +84,7 @@ extension DartTypeX on DartType {
         (b) => b
           ..symbol = typeElement.name
           ..bound = withBounds && typeElement.bound != null
-              ? refer(typeElement.bound!.nonGenericName)
+              ? typeElement.bound!._boundRef
               : null,
       ),
     );

--- a/packages/widgetbook/lib/src/generator/framework/extensions.dart
+++ b/packages/widgetbook/lib/src/generator/framework/extensions.dart
@@ -55,21 +55,34 @@ extension DartTypeX on DartType {
     return element!.displayName;
   }
 
-  /// Converts a type parameter bound to a [Reference] that preserves its
-  /// type arguments recursively.
+  /// Converts a type parameter bound to a [Reference], building a
+  /// [TypeReference] that preserves type arguments and nullability.
   ///
-  /// For `BoundWidget<D, T extends BaseItem<D>>`, the bound on `T` is
-  /// `BaseItem<D>`.
+  /// Without this, [nonGenericName] would strip type arguments from the
+  /// bound. For example, `<D, T extends BaseItem<D>>` would lose the
+  /// `<D>` and emit `T extends BaseItem` (a raw type) instead of
+  /// `T extends BaseItem<D>`.
+  ///
+  /// Handles the following cases recursively:
+  /// - Parameterized bounds: `BaseItem<D>` → `TypeReference('BaseItem', [D])`
+  /// - Nullable type args: `Wrapper<D?>` → preserves the `?` on `D`
+  /// - `dynamic`/`void`/function types: these have no [element], so we
+  ///   fall back to [getDisplayString] (e.g. `Map<dynamic, D>`)
   Reference get _boundRef {
+    final typeElement = element;
+    if (typeElement == null) return refer(getDisplayString());
+
     final self = this;
-    if (self is ParameterizedType && self.typeArguments.isNotEmpty) {
-      return TypeReference(
-        (b) => b
-          ..symbol = self.element!.displayName
-          ..types.addAll(self.typeArguments.map((t) => t._boundRef)),
-      );
-    }
-    return refer(element!.displayName);
+    return TypeReference(
+      (b) {
+        b
+          ..symbol = typeElement.displayName
+          ..isNullable = isNullable;
+        if (self is ParameterizedType && self.typeArguments.isNotEmpty) {
+          b.types.addAll(self.typeArguments.map((t) => t._boundRef));
+        }
+      },
+    );
   }
 
   Iterable<Reference> getTypeParams({

--- a/packages/widgetbook/test/generator/generic_bound/generic_bound.stories.dart
+++ b/packages/widgetbook/test/generator/generic_bound/generic_bound.stories.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/widgets.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+part 'generic_bound.stories.g.dart';
+
+class BaseItem<T> {
+  const BaseItem({required this.value});
+  final T value;
+}
+
+class BoundWidget<D, T extends BaseItem<D>> extends StatelessWidget {
+  const BoundWidget({super.key, required this.item});
+
+  final T item;
+
+  @override
+  Widget build(BuildContext context) => Text(item.value.toString());
+}
+
+// ignore: strict_raw_type
+const meta = Meta<BoundWidget>();
+
+final $Default = Object();

--- a/packages/widgetbook/test/generator/generic_bound/generic_bound.stories.g.dart
+++ b/packages/widgetbook/test/generator/generic_bound/generic_bound.stories.g.dart
@@ -1,0 +1,62 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'generic_bound.stories.dart';
+
+// **************************************************************************
+// StoryGenerator
+// **************************************************************************
+
+typedef _Component = Component<BoundWidget, BoundWidgetArgs>;
+typedef _Scenario<D, T extends BaseItem<D>> = BoundWidgetScenario<D, T>;
+typedef _Defaults = BoundWidgetDefaults;
+typedef _Story<D, T extends BaseItem<D>> = BoundWidgetStory<D, T>;
+typedef _Args<D, T extends BaseItem<D>> = BoundWidgetArgs<D, T>;
+final BoundWidgetComponent = Component<BoundWidget, BoundWidgetArgs>(
+  name: meta.name ?? 'BoundWidget',
+  path: meta.path ?? '',
+  docsBuilder: meta.docsBuilder,
+  docComment: null,
+  stories: [$Default..$generatedName = 'Default'],
+);
+typedef BoundWidgetScenario<D, T extends BaseItem<D>> =
+    Scenario<BoundWidget<D, T>, BoundWidgetArgs<D, T>>;
+typedef BoundWidgetDefaults = Defaults<BoundWidget, BoundWidgetArgs>;
+
+class BoundWidgetStory<D, T extends BaseItem<D>>
+    extends Story<BoundWidget<D, T>, BoundWidgetArgs<D, T>> {
+  BoundWidgetStory({
+    super.name,
+    super.setup,
+    super.modes,
+    required super.args,
+    StoryWidgetBuilder<BoundWidget<D, T>, BoundWidgetArgs<D, T>>? builder,
+    super.scenarios,
+  }) : super(
+         builder:
+             builder ??
+             (context, args) =>
+                 BoundWidget<D, T>(key: args.key, item: args.item),
+       );
+}
+
+class BoundWidgetArgs<D, T extends BaseItem<D>>
+    extends StoryArgs<BoundWidget<D, T>> {
+  BoundWidgetArgs({Arg<Key?>? key, required Arg<T> item})
+    : this.keyArg = $initArg('key', key, null),
+      this.itemArg = $initArg('item', item, null)!;
+
+  BoundWidgetArgs.fixed({Key? key, required T item})
+    : this.keyArg = key == null ? null : Arg.fixed(key),
+      this.itemArg = Arg.fixed(item);
+
+  final Arg<Key?>? keyArg;
+
+  final Arg<T> itemArg;
+
+  Key? get key => keyArg?.value;
+
+  T get item => itemArg.value;
+
+  @override
+  List<Arg?> get list => [keyArg, itemArg];
+}

--- a/packages/widgetbook/test/generator/generic_bound/generic_bound_test.dart
+++ b/packages/widgetbook/test/generator/generic_bound/generic_bound_test.dart
@@ -1,0 +1,16 @@
+// Tests that generic type parameter bounds with type arguments
+// (e.g. <D, T extends BaseItem<D>>) are preserved in generated code.
+
+@TestOn('vm')
+library;
+
+import '../helper.dart';
+
+void main() {
+  test(
+    'preserves type arguments on generic bounds',
+    () async {
+      await testStoryGenerator('generic_bound');
+    },
+  );
+}

--- a/packages/widgetbook/test/generator/generic_bound_dynamic/generic_bound_dynamic.stories.dart
+++ b/packages/widgetbook/test/generator/generic_bound_dynamic/generic_bound_dynamic.stories.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/widgets.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+part 'generic_bound_dynamic.stories.g.dart';
+
+class DynamicBoundWidget<D, T extends Map<dynamic, D>> extends StatelessWidget {
+  const DynamicBoundWidget({super.key, required this.mapping});
+
+  final T mapping;
+
+  @override
+  Widget build(BuildContext context) => Text('$mapping');
+}
+
+// ignore: strict_raw_type
+const meta = Meta<DynamicBoundWidget>();
+
+final $Default = Object();

--- a/packages/widgetbook/test/generator/generic_bound_dynamic/generic_bound_dynamic.stories.g.dart
+++ b/packages/widgetbook/test/generator/generic_bound_dynamic/generic_bound_dynamic.stories.g.dart
@@ -1,0 +1,66 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'generic_bound_dynamic.stories.dart';
+
+// **************************************************************************
+// StoryGenerator
+// **************************************************************************
+
+typedef _Component = Component<DynamicBoundWidget, DynamicBoundWidgetArgs>;
+typedef _Scenario<D, T extends Map<dynamic, D>> =
+    DynamicBoundWidgetScenario<D, T>;
+typedef _Defaults = DynamicBoundWidgetDefaults;
+typedef _Story<D, T extends Map<dynamic, D>> = DynamicBoundWidgetStory<D, T>;
+typedef _Args<D, T extends Map<dynamic, D>> = DynamicBoundWidgetArgs<D, T>;
+final DynamicBoundWidgetComponent =
+    Component<DynamicBoundWidget, DynamicBoundWidgetArgs>(
+      name: meta.name ?? 'DynamicBoundWidget',
+      path: meta.path ?? '',
+      docsBuilder: meta.docsBuilder,
+      docComment: null,
+      stories: [$Default..$generatedName = 'Default'],
+    );
+typedef DynamicBoundWidgetScenario<D, T extends Map<dynamic, D>> =
+    Scenario<DynamicBoundWidget<D, T>, DynamicBoundWidgetArgs<D, T>>;
+typedef DynamicBoundWidgetDefaults =
+    Defaults<DynamicBoundWidget, DynamicBoundWidgetArgs>;
+
+class DynamicBoundWidgetStory<D, T extends Map<dynamic, D>>
+    extends Story<DynamicBoundWidget<D, T>, DynamicBoundWidgetArgs<D, T>> {
+  DynamicBoundWidgetStory({
+    super.name,
+    super.setup,
+    super.modes,
+    required super.args,
+    StoryWidgetBuilder<DynamicBoundWidget<D, T>, DynamicBoundWidgetArgs<D, T>>?
+    builder,
+    super.scenarios,
+  }) : super(
+         builder:
+             builder ??
+             (context, args) =>
+                 DynamicBoundWidget<D, T>(key: args.key, mapping: args.mapping),
+       );
+}
+
+class DynamicBoundWidgetArgs<D, T extends Map<dynamic, D>>
+    extends StoryArgs<DynamicBoundWidget<D, T>> {
+  DynamicBoundWidgetArgs({Arg<Key?>? key, required Arg<T> mapping})
+    : this.keyArg = $initArg('key', key, null),
+      this.mappingArg = $initArg('mapping', mapping, null)!;
+
+  DynamicBoundWidgetArgs.fixed({Key? key, required T mapping})
+    : this.keyArg = key == null ? null : Arg.fixed(key),
+      this.mappingArg = Arg.fixed(mapping);
+
+  final Arg<Key?>? keyArg;
+
+  final Arg<T> mappingArg;
+
+  Key? get key => keyArg?.value;
+
+  T get mapping => mappingArg.value;
+
+  @override
+  List<Arg?> get list => [keyArg, mappingArg];
+}

--- a/packages/widgetbook/test/generator/generic_bound_dynamic/generic_bound_dynamic_test.dart
+++ b/packages/widgetbook/test/generator/generic_bound_dynamic/generic_bound_dynamic_test.dart
@@ -1,0 +1,16 @@
+// Tests that dynamic type arguments within generic bounds
+// (e.g. <D, T extends Map<dynamic, D>>) are preserved in generated code.
+
+@TestOn('vm')
+library;
+
+import '../helper.dart';
+
+void main() {
+  test(
+    'preserves dynamic type arguments on generic bounds',
+    () async {
+      await testStoryGenerator('generic_bound_dynamic');
+    },
+  );
+}

--- a/packages/widgetbook/test/generator/generic_bound_nullable/generic_bound_nullable.stories.dart
+++ b/packages/widgetbook/test/generator/generic_bound_nullable/generic_bound_nullable.stories.dart
@@ -3,12 +3,12 @@ import 'package:widgetbook/widgetbook.dart';
 
 part 'generic_bound_nullable.stories.g.dart';
 
-class Wrapper<T> {
-  const Wrapper({required this.value});
+class BaseItem<T> {
+  const BaseItem({required this.value});
   final T value;
 }
 
-class NullableBoundWidget<D, T extends Wrapper<D?>> extends StatelessWidget {
+class NullableBoundWidget<D, T extends BaseItem<D?>> extends StatelessWidget {
   const NullableBoundWidget({super.key, required this.item});
 
   final T item;

--- a/packages/widgetbook/test/generator/generic_bound_nullable/generic_bound_nullable.stories.dart
+++ b/packages/widgetbook/test/generator/generic_bound_nullable/generic_bound_nullable.stories.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/widgets.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+part 'generic_bound_nullable.stories.g.dart';
+
+class Wrapper<T> {
+  const Wrapper({required this.value});
+  final T value;
+}
+
+class NullableBoundWidget<D, T extends Wrapper<D?>> extends StatelessWidget {
+  const NullableBoundWidget({super.key, required this.item});
+
+  final T item;
+
+  @override
+  Widget build(BuildContext context) => Text('${item.value}');
+}
+
+// ignore: strict_raw_type
+const meta = Meta<NullableBoundWidget>();
+
+final $Default = Object();

--- a/packages/widgetbook/test/generator/generic_bound_nullable/generic_bound_nullable.stories.g.dart
+++ b/packages/widgetbook/test/generator/generic_bound_nullable/generic_bound_nullable.stories.g.dart
@@ -1,0 +1,68 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'generic_bound_nullable.stories.dart';
+
+// **************************************************************************
+// StoryGenerator
+// **************************************************************************
+
+typedef _Component = Component<NullableBoundWidget, NullableBoundWidgetArgs>;
+typedef _Scenario<D, T extends Wrapper<D?>> = NullableBoundWidgetScenario<D, T>;
+typedef _Defaults = NullableBoundWidgetDefaults;
+typedef _Story<D, T extends Wrapper<D?>> = NullableBoundWidgetStory<D, T>;
+typedef _Args<D, T extends Wrapper<D?>> = NullableBoundWidgetArgs<D, T>;
+final NullableBoundWidgetComponent =
+    Component<NullableBoundWidget, NullableBoundWidgetArgs>(
+      name: meta.name ?? 'NullableBoundWidget',
+      path: meta.path ?? '',
+      docsBuilder: meta.docsBuilder,
+      docComment: null,
+      stories: [$Default..$generatedName = 'Default'],
+    );
+typedef NullableBoundWidgetScenario<D, T extends Wrapper<D?>> =
+    Scenario<NullableBoundWidget<D, T>, NullableBoundWidgetArgs<D, T>>;
+typedef NullableBoundWidgetDefaults =
+    Defaults<NullableBoundWidget, NullableBoundWidgetArgs>;
+
+class NullableBoundWidgetStory<D, T extends Wrapper<D?>>
+    extends Story<NullableBoundWidget<D, T>, NullableBoundWidgetArgs<D, T>> {
+  NullableBoundWidgetStory({
+    super.name,
+    super.setup,
+    super.modes,
+    required super.args,
+    StoryWidgetBuilder<
+      NullableBoundWidget<D, T>,
+      NullableBoundWidgetArgs<D, T>
+    >?
+    builder,
+    super.scenarios,
+  }) : super(
+         builder:
+             builder ??
+             (context, args) =>
+                 NullableBoundWidget<D, T>(key: args.key, item: args.item),
+       );
+}
+
+class NullableBoundWidgetArgs<D, T extends Wrapper<D?>>
+    extends StoryArgs<NullableBoundWidget<D, T>> {
+  NullableBoundWidgetArgs({Arg<Key?>? key, required Arg<T> item})
+    : this.keyArg = $initArg('key', key, null),
+      this.itemArg = $initArg('item', item, null)!;
+
+  NullableBoundWidgetArgs.fixed({Key? key, required T item})
+    : this.keyArg = key == null ? null : Arg.fixed(key),
+      this.itemArg = Arg.fixed(item);
+
+  final Arg<Key?>? keyArg;
+
+  final Arg<T> itemArg;
+
+  Key? get key => keyArg?.value;
+
+  T get item => itemArg.value;
+
+  @override
+  List<Arg?> get list => [keyArg, itemArg];
+}

--- a/packages/widgetbook/test/generator/generic_bound_nullable/generic_bound_nullable.stories.g.dart
+++ b/packages/widgetbook/test/generator/generic_bound_nullable/generic_bound_nullable.stories.g.dart
@@ -7,10 +7,11 @@ part of 'generic_bound_nullable.stories.dart';
 // **************************************************************************
 
 typedef _Component = Component<NullableBoundWidget, NullableBoundWidgetArgs>;
-typedef _Scenario<D, T extends Wrapper<D?>> = NullableBoundWidgetScenario<D, T>;
+typedef _Scenario<D, T extends BaseItem<D?>> =
+    NullableBoundWidgetScenario<D, T>;
 typedef _Defaults = NullableBoundWidgetDefaults;
-typedef _Story<D, T extends Wrapper<D?>> = NullableBoundWidgetStory<D, T>;
-typedef _Args<D, T extends Wrapper<D?>> = NullableBoundWidgetArgs<D, T>;
+typedef _Story<D, T extends BaseItem<D?>> = NullableBoundWidgetStory<D, T>;
+typedef _Args<D, T extends BaseItem<D?>> = NullableBoundWidgetArgs<D, T>;
 final NullableBoundWidgetComponent =
     Component<NullableBoundWidget, NullableBoundWidgetArgs>(
       name: meta.name ?? 'NullableBoundWidget',
@@ -19,12 +20,12 @@ final NullableBoundWidgetComponent =
       docComment: null,
       stories: [$Default..$generatedName = 'Default'],
     );
-typedef NullableBoundWidgetScenario<D, T extends Wrapper<D?>> =
+typedef NullableBoundWidgetScenario<D, T extends BaseItem<D?>> =
     Scenario<NullableBoundWidget<D, T>, NullableBoundWidgetArgs<D, T>>;
 typedef NullableBoundWidgetDefaults =
     Defaults<NullableBoundWidget, NullableBoundWidgetArgs>;
 
-class NullableBoundWidgetStory<D, T extends Wrapper<D?>>
+class NullableBoundWidgetStory<D, T extends BaseItem<D?>>
     extends Story<NullableBoundWidget<D, T>, NullableBoundWidgetArgs<D, T>> {
   NullableBoundWidgetStory({
     super.name,
@@ -45,7 +46,7 @@ class NullableBoundWidgetStory<D, T extends Wrapper<D?>>
        );
 }
 
-class NullableBoundWidgetArgs<D, T extends Wrapper<D?>>
+class NullableBoundWidgetArgs<D, T extends BaseItem<D?>>
     extends StoryArgs<NullableBoundWidget<D, T>> {
   NullableBoundWidgetArgs({Arg<Key?>? key, required Arg<T> item})
     : this.keyArg = $initArg('key', key, null),

--- a/packages/widgetbook/test/generator/generic_bound_nullable/generic_bound_nullable_test.dart
+++ b/packages/widgetbook/test/generator/generic_bound_nullable/generic_bound_nullable_test.dart
@@ -1,0 +1,16 @@
+// Tests that nullable type arguments within generic bounds
+// (e.g. <D, T extends Wrapper<D?>>) are preserved in generated code.
+
+@TestOn('vm')
+library;
+
+import '../helper.dart';
+
+void main() {
+  test(
+    'preserves nullable type arguments on generic bounds',
+    () async {
+      await testStoryGenerator('generic_bound_nullable');
+    },
+  );
+}


### PR DESCRIPTION
## Summary                                                                       
Fix code generator emitting raw types for type parameter bounds that themselves have type arguments (e.g. `T extends BaseItem<D>` was emitted as `T extends BaseItem`, dropping the `<D>`)