### PR TITLE
fix: Keep state on scroll

### DIFF
--- a/packages/widgetbook/lib/src/navigation/icons/component_icon.dart
+++ b/packages/widgetbook/lib/src/navigation/icons/component_icon.dart
@@ -21,14 +21,19 @@ class ComponentIcon extends StatelessWidget {
         height: size,
         child: Transform.rotate(
           angle: 45 * pi / 180,
-          child: GridView.count(
-            crossAxisCount: 2,
-            padding: EdgeInsets.zero,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
             children: List.generate(
-              4,
-              (index) => Icon(
-                Icons.square_rounded,
-                size: size / 2,
+              2,
+              (_) => Row(
+                mainAxisSize: MainAxisSize.min,
+                children: List.generate(
+                  2,
+                  (_) => Icon(
+                    Icons.square_rounded,
+                    size: size / 2,
+                  ),
+                ),
               ),
             ),
           ),

--- a/packages/widgetbook/lib/src/navigation/widgets/navigation_tree_node.dart
+++ b/packages/widgetbook/lib/src/navigation/widgets/navigation_tree_node.dart
@@ -23,7 +23,8 @@ class NavigationTreeNode extends StatefulWidget {
   State<NavigationTreeNode> createState() => _NavigationTreeNodeState();
 }
 
-class _NavigationTreeNodeState extends State<NavigationTreeNode> {
+class _NavigationTreeNodeState extends State<NavigationTreeNode>
+    with AutomaticKeepAliveClientMixin {
   late bool isExpanded;
 
   @override
@@ -35,6 +36,7 @@ class _NavigationTreeNodeState extends State<NavigationTreeNode> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     const animationDuration = Duration(
       milliseconds: 200,
     );
@@ -74,16 +76,17 @@ class _NavigationTreeNodeState extends State<NavigationTreeNode> {
                 curve: Curves.easeInOut,
                 alignment: Alignment.topCenter,
                 heightFactor: isExpanded ? 1 : 0,
-                child: ListView.builder(
-                  physics: const NeverScrollableScrollPhysics(),
-                  itemCount: widget.node.children!.length,
-                  shrinkWrap: true,
-                  itemBuilder: (context, index) => NavigationTreeNode(
-                    node: widget.node.children![index],
-                    selectedNode: widget.selectedNode,
-                    onNodeSelected: widget.onNodeSelected,
-                    enableLeafComponents: widget.enableLeafComponents,
-                  ),
+                child: Column(
+                  children: widget.node.children!
+                      .map(
+                        (item) => NavigationTreeNode(
+                          node: item,
+                          selectedNode: widget.selectedNode,
+                          onNodeSelected: widget.onNodeSelected,
+                          enableLeafComponents: widget.enableLeafComponents,
+                        ),
+                      )
+                      .toList(),
                 ),
               ),
             ),
@@ -91,4 +94,7 @@ class _NavigationTreeNodeState extends State<NavigationTreeNode> {
       ],
     );
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }

--- a/packages/widgetbook/test/src/navigation/widgets/navigation_tree_node_test.dart
+++ b/packages/widgetbook/test/src/navigation/widgets/navigation_tree_node_test.dart
@@ -27,7 +27,7 @@ void main() {
           );
 
           expect(
-            find.byType(ListView),
+            find.byType(AnimatedAlign),
             findsNWidgets(
               // Leaf components don't have a list view rendered for them
               treeRoot.count - treeRoot.leaves.length - leafComponentsCount,
@@ -48,7 +48,7 @@ void main() {
           );
 
           expect(
-            find.byType(ListView),
+            find.byType(AnimatedAlign),
             findsNWidgets(
               treeRoot.count - treeRoot.leaves.length,
             ),


### PR DESCRIPTION
When scrolling through the navigation panels, the expanded widget states are lost due to the use of a `ListView`. Replacing it with a `SingleChildScrollView` is not viable, as it would degrade performance on the home page and the mobile bottom navigation sheet.

A possible solution is to use `AutomaticKeepAliveClientMixin`.

### List of issues which are fixed by the PR
*You must list at least one issue.*

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
