### PR TITLE
fix: rebuild workbench preview when knobs change

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- **FIX**: Rebuild the workbench preview when `WidgetbookState` notifies (e.g. knobs / query groups); sync `Story` args from the addon subtree before `setup` and again before `builder`. Adds a regression test that `Story.buildWithConfig` runs again after `updateQueryField`.
+
 - **FIX**: Preserve story definition order in navigation panel instead of sorting alphabetically. ([#1897](https://github.com/widgetbook/widgetbook/pull/1897))
 - **BREAKING**: Rename `SetupBuilder`'s second parameter from `TWidget widget` to `Widget child`, enabling `InheritedWidget`s injected by `setup` to be resolved in the story `builder`'s `BuildContext`. ([#1896](https://github.com/widgetbook/widgetbook/pull/1896))
 - **FIX**: Make addon-provided `InheritedWidget`s accessible via `BuildContext` in story `builder` and `setup` functions. ([#1894](https://github.com/widgetbook/widgetbook/pull/1894))

--- a/packages/widgetbook/lib/src/core/framework/story.dart
+++ b/packages/widgetbook/lib/src/core/framework/story.dart
@@ -139,8 +139,6 @@ abstract class Story<TWidget extends Widget, TArgs extends StoryArgs<TWidget>> {
     final effectiveArgs = args ?? this.args;
     final effectiveAddons = mergeModesIntoAddons(modes, config.addons ?? []);
 
-    syncArgs(context);
-
     return config.appBuilder(
       context,
       NestedBuilder(
@@ -148,10 +146,13 @@ abstract class Story<TWidget extends Widget, TArgs extends StoryArgs<TWidget>> {
         builder: (context, addon, child) => addon.build(context, child),
         child: Builder(
           builder: (context) {
+            syncArgs(context);
+
             return setup(
               context,
               Builder(
                 builder: (innerContext) {
+                  syncArgs(innerContext);
                   initBuilderArgs(innerContext, effectiveArgs);
                   return this.builder(innerContext, effectiveArgs);
                 },

--- a/packages/widgetbook/lib/src/core/workbench/workbench.dart
+++ b/packages/widgetbook/lib/src/core/workbench/workbench.dart
@@ -17,31 +17,42 @@ class Workbench extends StatelessWidget {
   Widget build(BuildContext context) {
     final state = WidgetbookState.of(context);
 
-    if (state.docs != null) {
-      return const DocsPreview();
-    }
+    // Rebuild the preview when [WidgetbookState] notifies (knobs/query groups,
+    // path, etc.). The Args panel already uses [ListenableBuilder]; without an
+    // explicit listenable here, knob-only updates could refresh the URL and
+    // side panel without rebuilding the center workbench.
+    return ListenableBuilder(
+      listenable: state,
+      builder: (context, _) {
+        final state = WidgetbookState.of(context);
 
-    final scenario = state.scenario;
-    if (scenario != null) {
-      return _WorkbenchWrapper(
-        child: scenario.buildWithConfig(
-          context,
-          state.config,
-        ),
-      );
-    }
+        if (state.docs != null) {
+          return const DocsPreview();
+        }
 
-    final story = state.story;
-    if (story != null) {
-      return _WorkbenchWrapper(
-        child: story.buildWithConfig(
-          context,
-          state.config,
-        ),
-      );
-    }
+        final scenario = state.scenario;
+        if (scenario != null) {
+          return _WorkbenchWrapper(
+            child: scenario.buildWithConfig(
+              context,
+              state.config,
+            ),
+          );
+        }
 
-    return state.config.home;
+        final story = state.story;
+        if (story != null) {
+          return _WorkbenchWrapper(
+            child: story.buildWithConfig(
+              context,
+              state.config,
+            ),
+          );
+        }
+
+        return state.config.home;
+      },
+    );
   }
 }
 

--- a/packages/widgetbook/test/core/workbench/workbench_test.dart
+++ b/packages/widgetbook/test/core/workbench/workbench_test.dart
@@ -80,6 +80,60 @@ void main() {
           );
         },
       );
+
+      testWidgets(
+        'rebuilds selected story when state notifies (e.g. knobs / query groups)',
+        (tester) async {
+          final story = MockStory();
+          var buildWithConfigCount = 0;
+          when(() => story.name).thenReturn('story');
+          when(() => story.path).thenReturn('component/story');
+          when(() => story.allScenarios(any())).thenReturn([]);
+          when(
+            () => story.buildWithConfig(any(), any()),
+          ).thenAnswer((_) {
+            buildWithConfigCount++;
+            return const Text('story');
+          });
+
+          final component = Component<Widget, MockStoryArgs>(
+            name: 'component',
+            stories: [story],
+          );
+
+          final state = WidgetbookState(
+            path: 'component/story',
+            config: Config(
+              home: const Placeholder(),
+              components: [component],
+            ),
+          );
+
+          await tester.pumpWidgetWithState(
+            state: state,
+            builder: (_) => const Workbench(),
+          );
+
+          await tester.pumpAndSettle();
+
+          final countAfterSettle = buildWithConfigCount;
+          expect(countAfterSettle, greaterThan(0));
+
+          state.updateQueryField(
+            groupName: 'knob',
+            fieldName: 'value',
+            fieldValue: 'next',
+          );
+
+          await tester.pump();
+
+          expect(
+            buildWithConfigCount,
+            greaterThan(countAfterSettle),
+            reason: 'Workbench should rebuild when query groups / knobs change',
+          );
+        },
+      );
     },
   );
 }


### PR DESCRIPTION
## Problem
In Widgetbook v4, changing story knobs updated the URL and the Args panel but the preview (center workbench) could stay stale—a common repro is editing a string knob while a story path is selected.

## Cause
The desktop Args panel listens to [`WidgetbookState`](https://github.com/widgetbook/widgetbook/blob/v4/packages/widgetbook/lib/src/core/layout/desktop_layout.dart) via `ListenableBuilder`, but the center `Workbench` did not, so `Story.buildWithConfig` was not always run again when only `queryGroups` changed.

## Fix
- Wrap `Workbench` in `ListenableBuilder(listenable: state)` so the preview rebuilds on any `WidgetbookState` notification (including knob updates).
- Run `syncArgs` after addon `NestedBuilder` has mounted (before `setup`) and again in the inner `Builder` before `builder` / `initBuilderArgs`, keeping arg values aligned with the URL.

## Test
- New widget test: `Story.buildWithConfig` is invoked again after `updateQueryField`.
- Ran: `flutter test test/core/framework/ test/core/workbench/`

Repro app used while developing: [widgetbook-bug-test](https://github.com/dario-digregorio/widgetbook-bug-test) (path override to this branch).

Made with [Cursor](https://cursor.com)