### PR TITLE
fix: rebuild workbench subtree on story navigation

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- **FIX**: Rebuild workbench subtree when navigating between stories or scenarios (`ValueKey` path on `_WorkbenchWrapper`), so the nested preview replaces correctly (regression vs v3 use-case keys). ([#1912](https://github.com/widgetbook/widgetbook/pull/1912))
+
 - **FIX**: Preserve story definition order in navigation panel instead of sorting alphabetically. ([#1897](https://github.com/widgetbook/widgetbook/pull/1897))
 - **BREAKING**: Rename `SetupBuilder`'s second parameter from `TWidget widget` to `Widget child`, enabling `InheritedWidget`s injected by `setup` to be resolved in the story `builder`'s `BuildContext`. ([#1896](https://github.com/widgetbook/widgetbook/pull/1896))
 - **FIX**: Make addon-provided `InheritedWidget`s accessible via `BuildContext` in story `builder` and `setup` functions. ([#1894](https://github.com/widgetbook/widgetbook/pull/1894))

--- a/packages/widgetbook/lib/src/core/workbench/workbench.dart
+++ b/packages/widgetbook/lib/src/core/workbench/workbench.dart
@@ -24,6 +24,7 @@ class Workbench extends StatelessWidget {
     final scenario = state.scenario;
     if (scenario != null) {
       return _WorkbenchWrapper(
+        key: ValueKey('scenario:${state.path}'),
         child: scenario.buildWithConfig(
           context,
           state.config,
@@ -34,6 +35,7 @@ class Workbench extends StatelessWidget {
     final story = state.story;
     if (story != null) {
       return _WorkbenchWrapper(
+        key: ValueKey('story:${state.path}'),
         child: story.buildWithConfig(
           context,
           state.config,
@@ -47,6 +49,7 @@ class Workbench extends StatelessWidget {
 
 class _WorkbenchWrapper extends StatelessWidget {
   const _WorkbenchWrapper({
+    super.key,
     required this.child,
   });
 

--- a/packages/widgetbook/test/core/workbench/workbench_test.dart
+++ b/packages/widgetbook/test/core/workbench/workbench_test.dart
@@ -80,6 +80,80 @@ void main() {
           );
         },
       );
+
+      testWidgets(
+        'rebuilds story preview when navigating between leaves via '
+        '`WidgetbookState.updatePath`',
+        (tester) async {
+          final storyButton = MockStory();
+          final storyCounter = MockStory();
+          final buttonArgs = MockStoryArgs();
+          final counterArgs = MockStoryArgs();
+
+          var counterCalls = 0;
+
+          when(() => storyButton.args).thenReturn(buttonArgs);
+          when(() => storyCounter.args).thenReturn(counterArgs);
+          when(() => buttonArgs.safeList).thenReturn([]);
+          when(() => counterArgs.safeList).thenReturn([]);
+
+          when(() => storyButton.name).thenReturn('Default');
+          when(() => storyButton.path).thenReturn('widgets/Button/Default');
+          when(() => storyButton.allScenarios(any())).thenReturn([]);
+          when(
+            () => storyButton.buildWithConfig(any(), any()),
+          ).thenReturn(const Text('StoryButton'));
+
+          when(() => storyCounter.name).thenReturn('Default');
+          when(() => storyCounter.path).thenReturn('widgets/Counter/Default');
+          when(() => storyCounter.allScenarios(any())).thenReturn([]);
+          when(() => storyCounter.buildWithConfig(any(), any())).thenAnswer((
+            _,
+          ) {
+            counterCalls++;
+            return const Text('StoryCounter');
+          });
+
+          final componentButton = Component<Widget, MockStoryArgs>(
+            path: 'widgets',
+            name: 'Button',
+            stories: [storyButton],
+          );
+          final componentCounter = Component<Widget, MockStoryArgs>(
+            path: 'widgets',
+            name: 'Counter',
+            stories: [storyCounter],
+          );
+
+          final state = WidgetbookState(
+            path: 'widgets/Button/Default',
+            config: Config(
+              home: const Placeholder(),
+              components: [componentButton, componentCounter],
+            ),
+          );
+
+          await tester.pumpWidgetWithState(
+            state: state,
+            builder: (_) => const Workbench(),
+          );
+
+          await tester.pumpAndSettle();
+
+          expect(find.text('StoryButton'), findsOneWidget);
+          expect(find.text('StoryCounter'), findsNothing);
+          expect(counterCalls, 0);
+
+          state.updatePath('widgets/Counter/Default');
+
+          await tester.pump();
+          await tester.pumpAndSettle();
+
+          expect(find.text('StoryCounter'), findsOneWidget);
+          expect(find.text('StoryButton'), findsNothing);
+          expect(counterCalls, greaterThan(0));
+        },
+      );
     },
   );
 }


### PR DESCRIPTION
## Problem
Clicking between story leaves updates selection and the Args panel, but the center preview can stay stuck on the previous story until a Docs node forces a different widget tree (nested `MaterialApp.home` reused without a route refresh).

## Cause
Widgetbook v3 keyed the workbench subtree (`ValueKey(state.uri)` / `ValueKey(_configuration)`). That was dropped in the v4 router/workbench rewrite, so Flutter reused the same inner navigator subtree across story paths.

## Fix
- `ValueKey('story:${state.path}')` / `ValueKey('scenario:${state.path}')` on `_WorkbenchWrapper`, mirroring v3 use-case keys without keying the entire `ResponsiveLayout` (side panels keep scroll/focus).

## Test
Widget test: `updatePath` from one story to another shows the second story and invokes `buildWithConfig`.

Repro: [widgetbook-bug-test](https://github.com/dario-digregorio/widgetbook-bug-test)

Related knob-only fix: #1911

Made with [Cursor](https://cursor.com)