### PR TITLE
feat: improve `DurationKnob`

### DIFF
--- a/docs/knobs/duration.mdx
+++ b/docs/knobs/duration.mdx
@@ -1,16 +1,25 @@
 # Duration Knob
 
-The Duration knob renders a text field in the Widgetbook UI where you can dynamically enter a string value to specify a Duration is milliseconds for a widget property. 
+The Duration knob renders a set of text fields in the Widgetbook UI where you can dynamically enter a Duration value for a widget property. By default, it shows hours, minutes, and seconds inputs.
 
 ## Variants
 
-The String knob has two variants:
+The Duration knob has two variants:
 - `context.knobs.duration()`: This variant allows you to enter a Duration value. It does not accept `null` values.
 - `context.knobs.durationOrNull()`: This variant allows you to enter a Duration value or `null`. It is useful when the property can be optional.
 
 ## Properties
 
-Besides the knob's [base properties](/knobs/overview#properties), the Duration knob does not feature any additional properties.
+Besides the knob's [base properties](/knobs/overview#properties), the Duration knob supports the following additional properties to control which time units are displayed:
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `enableDays` | `bool` | `false` | Show the days input field. |
+| `enableHours` | `bool` | `true` | Show the hours input field. |
+| `enableMinutes` | `bool` | `true` | Show the minutes input field. |
+| `enableSeconds` | `bool` | `true` | Show the seconds input field. |
+| `enableMilliseconds` | `bool` | `false` | Show the milliseconds input field. |
+| `enableMicroseconds` | `bool` | `false` | Show the microseconds input field. |
 
 ## `context.knobs.duration()`
 
@@ -35,7 +44,23 @@ Widget buildUseCase(BuildContext context) {
 }
 ```
 
-## `context.knobs.durationOrNull()` 
+To enable more granular time units:
+
+```dart title="Example: Duration Knob with all units"
+@UseCase(type: MyWidget, name: 'Default')
+Widget buildUseCase(BuildContext context) {
+  return MyWidget(
+    duration: context.knobs.duration( // [!code highlight]
+      label: 'duration', // [!code highlight]
+      enableDays: true, // [!code highlight]
+      enableMilliseconds: true, // [!code highlight]
+      enableMicroseconds: true, // [!code highlight]
+    ), // [!code highlight]
+  );
+}
+```
+
+## `context.knobs.durationOrNull()`
 
 ### Example
 
@@ -62,7 +87,7 @@ Widget buildUseCase(BuildContext context) {
 
 Multi-snapshot support allows you to generate multiple screenshots of a single use case with varying values using [KnobsConfigs](/cloud/snapshots/multi-snapshot#multi-snapshot-for-knobs) and [AddonsConfigs](/cloud/snapshots/multi-snapshot#multi-snapshot-for-addons).
 
-### Regular String Knob
+### Regular Duration Knob
 
 ```dart title="Example: DurationKnobConfig"
 @UseCase(

--- a/docs/knobs/duration.mdx
+++ b/docs/knobs/duration.mdx
@@ -1,6 +1,6 @@
 # Duration Knob
 
-The Duration knob renders a set of text fields in the Widgetbook UI where you can dynamically enter a `Duration` value for a widget property. By default, it shows inputs for seconds and milliseconds.
+The Duration knob renders a set of text fields in the Widgetbook UI where you can dynamically enter a `Duration` value for a widget property. By default, it shows inputs for hours, minutes, and seconds.
 
 ## Variants
 
@@ -14,7 +14,7 @@ Besides the knob's [base properties](/knobs/overview#properties), the Duration k
 
 | Property | Type | Default | Description |
 |---|---|---|---|
-| `units` | `Set<DurationUnit>` | `{DurationUnit.seconds, DurationUnit.milliseconds}` | The time units to show as separate inputs. |
+| `units` | `Set<DurationUnit>` | `{DurationUnit.hours, DurationUnit.minutes, DurationUnit.seconds}` | The time units to show as separate inputs. |
 
 `DurationUnit` has `days`, `hours`, `minutes`, `seconds`, `milliseconds`, and `microseconds`. Units render largest to smallest regardless of set order, and the largest absorbs any overflow so no value is hidden (e.g. with only `seconds`, `Duration(seconds: 90)` shows `90`).
 

--- a/docs/knobs/duration.mdx
+++ b/docs/knobs/duration.mdx
@@ -10,16 +10,13 @@ The Duration knob has two variants:
 
 ## Properties
 
-Besides the knob's [base properties](/knobs/overview#properties), the Duration knob supports the following additional properties to control which time units are displayed:
+Besides the knob's [base properties](/knobs/overview#properties), the Duration knob supports one additional property to control which time units are displayed:
 
 | Property | Type | Default | Description |
 |---|---|---|---|
-| `enableDays` | `bool` | `false` | Show the days input field. |
-| `enableHours` | `bool` | `true` | Show the hours input field. |
-| `enableMinutes` | `bool` | `true` | Show the minutes input field. |
-| `enableSeconds` | `bool` | `true` | Show the seconds input field. |
-| `enableMilliseconds` | `bool` | `false` | Show the milliseconds input field. |
-| `enableMicroseconds` | `bool` | `false` | Show the microseconds input field. |
+| `units` | `Set<DurationUnit>` | `{DurationUnit.hours, DurationUnit.minutes, DurationUnit.seconds}` | The time units to show as separate inputs. |
+
+`DurationUnit` exposes `days`, `hours`, `minutes`, `seconds`, `milliseconds`, and `microseconds`. Inputs are always rendered from the largest unit to the smallest, regardless of the order in the set. The largest enabled unit absorbs any overflow, so no part of the value is ever hidden (e.g. with only `seconds` enabled, a value of `Duration(seconds: 90)` shows `90`).
 
 ## `context.knobs.duration()`
 
@@ -44,17 +41,22 @@ Widget buildUseCase(BuildContext context) {
 }
 ```
 
-To enable more granular time units:
+To choose which time units to show, pass a `units` set:
 
-```dart title="Example: Duration Knob with all units"
+```dart title="Example: Duration Knob with custom units"
 @UseCase(type: MyWidget, name: 'Default')
 Widget buildUseCase(BuildContext context) {
   return MyWidget(
     duration: context.knobs.duration( // [!code highlight]
       label: 'duration', // [!code highlight]
-      enableDays: true, // [!code highlight]
-      enableMilliseconds: true, // [!code highlight]
-      enableMicroseconds: true, // [!code highlight]
+      units: const { // [!code highlight]
+        DurationUnit.days, // [!code highlight]
+        DurationUnit.hours, // [!code highlight]
+        DurationUnit.minutes, // [!code highlight]
+        DurationUnit.seconds, // [!code highlight]
+        DurationUnit.milliseconds, // [!code highlight]
+        DurationUnit.microseconds, // [!code highlight]
+      }, // [!code highlight]
     ), // [!code highlight]
   );
 }

--- a/docs/knobs/duration.mdx
+++ b/docs/knobs/duration.mdx
@@ -1,12 +1,12 @@
 # Duration Knob
 
-The Duration knob renders a set of text fields in the Widgetbook UI where you can dynamically enter a Duration value for a widget property. By default, it shows hours, minutes, and seconds inputs.
+The Duration knob renders a set of text fields in the Widgetbook UI where you can dynamically enter a `Duration` value for a widget property. By default, it shows inputs for hours, minutes, and seconds.
 
 ## Variants
 
 The Duration knob has two variants:
-- `context.knobs.duration()`: This variant allows you to enter a Duration value. It does not accept `null` values.
-- `context.knobs.durationOrNull()`: This variant allows you to enter a Duration value or `null`. It is useful when the property can be optional.
+- `context.knobs.duration()`: Lets you enter a `Duration` value. It does not accept `null`.
+- `context.knobs.durationOrNull()`: Lets you enter a `Duration` value or `null`. This is useful when the property is optional.
 
 ## Properties
 
@@ -16,7 +16,7 @@ Besides the knob's [base properties](/knobs/overview#properties), the Duration k
 |---|---|---|---|
 | `units` | `Set<DurationUnit>` | `{DurationUnit.hours, DurationUnit.minutes, DurationUnit.seconds}` | The time units to show as separate inputs. |
 
-`DurationUnit` exposes `days`, `hours`, `minutes`, `seconds`, `milliseconds`, and `microseconds`. Inputs are always rendered from the largest unit to the smallest, regardless of the order in the set. The largest enabled unit absorbs any overflow, so no part of the value is ever hidden (e.g. with only `seconds` enabled, a value of `Duration(seconds: 90)` shows `90`).
+`DurationUnit` provides `days`, `hours`, `minutes`, `seconds`, `milliseconds`, and `microseconds`. Inputs are always rendered from the largest unit to the smallest, regardless of their order in the set. The largest unit in the set absorbs any overflow, so no part of the value is ever hidden — for example, when only `seconds` is shown, a value of `Duration(seconds: 90)` displays `90`.
 
 ## `context.knobs.duration()`
 
@@ -41,7 +41,7 @@ Widget buildUseCase(BuildContext context) {
 }
 ```
 
-To choose which time units to show, pass a `units` set:
+To customize which time units are shown, pass a `units` set:
 
 ```dart title="Example: Duration Knob with custom units"
 @UseCase(type: MyWidget, name: 'Default')

--- a/docs/knobs/duration.mdx
+++ b/docs/knobs/duration.mdx
@@ -1,6 +1,6 @@
 # Duration Knob
 
-The Duration knob renders a set of text fields in the Widgetbook UI where you can dynamically enter a `Duration` value for a widget property. By default, it shows inputs for hours, minutes, and seconds.
+The Duration knob renders a set of text fields in the Widgetbook UI where you can dynamically enter a `Duration` value for a widget property. By default, it shows inputs for seconds and milliseconds.
 
 ## Variants
 
@@ -14,9 +14,9 @@ Besides the knob's [base properties](/knobs/overview#properties), the Duration k
 
 | Property | Type | Default | Description |
 |---|---|---|---|
-| `units` | `Set<DurationUnit>` | `{DurationUnit.hours, DurationUnit.minutes, DurationUnit.seconds}` | The time units to show as separate inputs. |
+| `units` | `Set<DurationUnit>` | `{DurationUnit.seconds, DurationUnit.milliseconds}` | The time units to show as separate inputs. |
 
-`DurationUnit` provides `days`, `hours`, `minutes`, `seconds`, `milliseconds`, and `microseconds`. Inputs are always rendered from the largest unit to the smallest, regardless of their order in the set. The largest unit in the set absorbs any overflow, so no part of the value is ever hidden — for example, when only `seconds` is shown, a value of `Duration(seconds: 90)` displays `90`.
+`DurationUnit` has `days`, `hours`, `minutes`, `seconds`, `milliseconds`, and `microseconds`. Units render largest to smallest regardless of set order, and the largest absorbs any overflow so no value is hidden (e.g. with only `seconds`, `Duration(seconds: 90)` shows `90`).
 
 ## `context.knobs.duration()`
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,9 +1,12 @@
+## Unreleased
+
+- **FEAT**: Add `units` parameter to the duration knob (`knobs.duration`/`knobs.durationOrNull`) to configure which time units are shown, exposing all `Duration` units from days to microseconds. The default is now `{DurationUnit.seconds, DurationUnit.milliseconds}`; to restore the previous hours/minutes/seconds inputs, pass `units: {DurationUnit.hours, DurationUnit.minutes, DurationUnit.seconds}`. ([#1915](https://github.com/widgetbook/widgetbook/pull/1915) - by [@EArminjon](https://github.com/EArminjon))
+
 ## 3.23.0
 
 - **FEAT**: Add `defaultToNull` parameter to nullable knobs to make them start in a `null` _(i.e. unchecked)_ state while having a non-null initial value. ([#1790](https://github.com/widgetbook/widgetbook/pull/1790) - by [@youpelegrace](https://github.com/youpelegrace))
 - **REFACTOR**: Allow `inspector` 4.x. ([#1901](https://github.com/widgetbook/widgetbook/pull/1901))
 - **FEAT**: Add `headerPadding` parameter to customize the padding around the navigation panel header. ([#1882](https://github.com/widgetbook/widgetbook/pull/1882) - by [@EArminjon](https://github.com/EArminjon))
-- **FEAT**: Add `units` parameter to the duration knob (`knobs.duration`/`knobs.durationOrNull`) to configure which time units are shown, exposing all `Duration` units from days to microseconds. The default is now `{DurationUnit.seconds, DurationUnit.milliseconds}`; to restore the previous hours/minutes/seconds inputs, pass `units: {DurationUnit.hours, DurationUnit.minutes, DurationUnit.seconds}`. ([#1915](https://github.com/widgetbook/widgetbook/pull/1915) - by [@EArminjon](https://github.com/EArminjon))
 
 ## 3.22.0
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **FEAT**: Add `defaultToNull` parameter to nullable knobs to make them start in a `null` _(i.e. unchecked)_ state while having a non-null initial value. ([#1790](https://github.com/widgetbook/widgetbook/pull/1790) - by [@youpelegrace](https://github.com/youpelegrace))
 - **REFACTOR**: Allow `inspector` 4.x. ([#1901](https://github.com/widgetbook/widgetbook/pull/1901))
 - **FEAT**: Add `headerPadding` parameter to customize the padding around the navigation panel header. ([#1882](https://github.com/widgetbook/widgetbook/pull/1882) - by [@EArminjon](https://github.com/EArminjon))
+- **FEAT**: Add `units` parameter to the duration knob (`knobs.duration`/`knobs.durationOrNull`) to configure which time units are shown, exposing all `Duration` units from days to microseconds. The default is now `{DurationUnit.seconds, DurationUnit.milliseconds}`; to restore the previous hours/minutes/seconds inputs, pass `units: {DurationUnit.hours, DurationUnit.minutes, DurationUnit.seconds}`. ([#1915](https://github.com/widgetbook/widgetbook/pull/1915) - by [@EArminjon](https://github.com/EArminjon))
 
 ## 3.22.0
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **FEAT**: Add `units` parameter to the duration knob to choose which time units (days to microseconds) are shown; the default is now seconds and milliseconds. ([#1915](https://github.com/widgetbook/widgetbook/pull/1915) - by [@EArminjon](https://github.com/EArminjon))
+- **FEAT**: Add `units` parameter to the duration knob to choose which time units (days to microseconds) are shown. ([#1915](https://github.com/widgetbook/widgetbook/pull/1915) - by [@EArminjon](https://github.com/EArminjon))
 
 ## 3.24.0
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **FEAT**: Add `units` parameter to the duration knob (`knobs.duration`/`knobs.durationOrNull`) to configure which time units are shown, exposing all `Duration` units from days to microseconds. The default is now `{DurationUnit.seconds, DurationUnit.milliseconds}`; to restore the previous hours/minutes/seconds inputs, pass `units: {DurationUnit.hours, DurationUnit.minutes, DurationUnit.seconds}`. ([#1915](https://github.com/widgetbook/widgetbook/pull/1915) - by [@EArminjon](https://github.com/EArminjon))
+- **FEAT**: Add `units` parameter to the duration knob to choose which time units (days to microseconds) are shown; the default is now seconds and milliseconds. ([#1915](https://github.com/widgetbook/widgetbook/pull/1915) - by [@EArminjon](https://github.com/EArminjon))
 
 ## 3.23.0
 

--- a/packages/widgetbook/lib/src/fields/duration_field/duration_field.dart
+++ b/packages/widgetbook/lib/src/fields/duration_field/duration_field.dart
@@ -11,6 +11,12 @@ class DurationField extends Field<Duration> {
   DurationField({
     required super.name,
     super.initialValue = defaultDuration,
+    this.enableDays = false,
+    this.enableHours = true,
+    this.enableMinutes = true,
+    this.enableSeconds = true,
+    this.enableMilliseconds = false,
+    this.enableMicroseconds = false,
     @Deprecated('Fields should not be aware of their context') super.onChanged,
   }) : super(
          defaultValue: defaultDuration,
@@ -27,6 +33,24 @@ class DurationField extends Field<Duration> {
          ),
        );
 
+  /// Whether to enable input for days in the duration.
+  final bool enableDays;
+
+  /// Whether to enable input for hours in the duration.
+  final bool enableHours;
+
+  /// Whether to enable input for minutes in the duration.
+  final bool enableMinutes;
+
+  /// Whether to enable input for seconds in the duration.
+  final bool enableSeconds;
+
+  /// Whether to enable input for milliseconds in the duration.
+  final bool enableMilliseconds;
+
+  /// Whether to enable input for microseconds in the duration.
+  final bool enableMicroseconds;
+
   /// The default duration value used when no initial value is provided.
   static const defaultDuration = Duration.zero;
 
@@ -38,6 +62,12 @@ class DurationField extends Field<Duration> {
   ) {
     return DurationInput(
       value: value ?? initialValue ?? defaultDuration,
+      enableDays: enableDays,
+      enableHours: enableHours,
+      enableMinutes: enableMinutes,
+      enableSeconds: enableSeconds,
+      enableMilliseconds: enableMilliseconds,
+      enableMicroseconds: enableMicroseconds,
       onChanged: (duration) => updateField(context, group, duration),
     );
   }

--- a/packages/widgetbook/lib/src/fields/duration_field/duration_field.dart
+++ b/packages/widgetbook/lib/src/fields/duration_field/duration_field.dart
@@ -4,6 +4,7 @@ import '../field.dart';
 import '../field_codec.dart';
 import '../field_type.dart';
 import 'duration_input.dart';
+import 'duration_unit.dart';
 
 /// A [Field] that represents a [Duration] value.
 class DurationField extends Field<Duration> {
@@ -11,14 +12,10 @@ class DurationField extends Field<Duration> {
   DurationField({
     required super.name,
     super.initialValue = defaultDuration,
-    this.enableDays = false,
-    this.enableHours = true,
-    this.enableMinutes = true,
-    this.enableSeconds = true,
-    this.enableMilliseconds = false,
-    this.enableMicroseconds = false,
+    this.units = DurationUnit.defaults,
     @Deprecated('Fields should not be aware of their context') super.onChanged,
-  }) : super(
+  }) : assert(units.isNotEmpty, 'At least one DurationUnit must be enabled.'),
+       super(
          defaultValue: defaultDuration,
          type: FieldType.duration,
          codec: FieldCodec(
@@ -33,23 +30,9 @@ class DurationField extends Field<Duration> {
          ),
        );
 
-  /// Whether to enable input for days in the duration.
-  final bool enableDays;
-
-  /// Whether to enable input for hours in the duration.
-  final bool enableHours;
-
-  /// Whether to enable input for minutes in the duration.
-  final bool enableMinutes;
-
-  /// Whether to enable input for seconds in the duration.
-  final bool enableSeconds;
-
-  /// Whether to enable input for milliseconds in the duration.
-  final bool enableMilliseconds;
-
-  /// Whether to enable input for microseconds in the duration.
-  final bool enableMicroseconds;
+  /// The time units displayed as separate inputs, rendered from largest to
+  /// smallest. Defaults to [DurationUnit.defaults] (hours, minutes, seconds).
+  final Set<DurationUnit> units;
 
   /// The default duration value used when no initial value is provided.
   static const defaultDuration = Duration.zero;
@@ -62,12 +45,7 @@ class DurationField extends Field<Duration> {
   ) {
     return DurationInput(
       value: value ?? initialValue ?? defaultDuration,
-      enableDays: enableDays,
-      enableHours: enableHours,
-      enableMinutes: enableMinutes,
-      enableSeconds: enableSeconds,
-      enableMilliseconds: enableMilliseconds,
-      enableMicroseconds: enableMicroseconds,
+      units: units,
       onChanged: (duration) => updateField(context, group, duration),
     );
   }

--- a/packages/widgetbook/lib/src/fields/duration_field/duration_field.dart
+++ b/packages/widgetbook/lib/src/fields/duration_field/duration_field.dart
@@ -31,7 +31,7 @@ class DurationField extends Field<Duration> {
        );
 
   /// The time units displayed as separate inputs, rendered from largest to
-  /// smallest. Defaults to [DurationUnit.defaults] (hours, minutes, seconds).
+  /// smallest. Defaults to [DurationUnit.defaults] (seconds, milliseconds).
   final Set<DurationUnit> units;
 
   /// The default duration value used when no initial value is provided.

--- a/packages/widgetbook/lib/src/fields/duration_field/duration_field.dart
+++ b/packages/widgetbook/lib/src/fields/duration_field/duration_field.dart
@@ -31,7 +31,7 @@ class DurationField extends Field<Duration> {
        );
 
   /// The time units displayed as separate inputs, rendered from largest to
-  /// smallest. Defaults to [DurationUnit.defaults] (seconds, milliseconds).
+  /// smallest. Defaults to [DurationUnit.defaults] (hours, minutes, seconds).
   final Set<DurationUnit> units;
 
   /// The default duration value used when no initial value is provided.

--- a/packages/widgetbook/lib/src/fields/duration_field/duration_input.dart
+++ b/packages/widgetbook/lib/src/fields/duration_field/duration_input.dart
@@ -9,10 +9,22 @@ class DurationInput extends StatefulWidget {
   const DurationInput({
     super.key,
     required this.value,
+    required this.enableDays,
+    required this.enableHours,
+    required this.enableMinutes,
+    required this.enableSeconds,
+    required this.enableMilliseconds,
+    required this.enableMicroseconds,
     required this.onChanged,
   });
 
   final Duration value;
+  final bool enableDays;
+  final bool enableHours;
+  final bool enableMinutes;
+  final bool enableSeconds;
+  final bool enableMilliseconds;
+  final bool enableMicroseconds;
   final ValueChanged<Duration> onChanged;
 
   @override
@@ -20,30 +32,49 @@ class DurationInput extends StatefulWidget {
 }
 
 class _DurationInputState extends State<DurationInput> {
+  late int days;
   late int hours;
   late int minutes;
   late int seconds;
+  late int milliseconds;
+  late int microseconds;
 
   @override
   void initState() {
     super.initState();
-    hours = widget.value.inHours;
+    days = widget.value.inDays;
+    hours = widget.value.inHours.remainder(24);
     minutes = widget.value.inMinutes.remainder(60);
     seconds = widget.value.inSeconds.remainder(60);
+    milliseconds = widget.value.inMilliseconds.remainder(1000);
+    microseconds = widget.value.inMicroseconds.remainder(1000);
   }
 
-  void onValuesChanged(int newHours, int newMinutes, int newSeconds) {
+  void onValuesChanged(
+    int newDays,
+    int newHours,
+    int newMinutes,
+    int newSeconds,
+    int newMilliseconds,
+    int newMicroseconds,
+  ) {
     setState(() {
+      days = newDays;
       hours = newHours;
       minutes = newMinutes.clamp(0, 59);
       seconds = newSeconds.clamp(0, 59);
+      milliseconds = newMilliseconds.clamp(0, 999);
+      microseconds = newMicroseconds.clamp(0, 999);
     });
 
     widget.onChanged.call(
       Duration(
+        days: newDays,
         hours: newHours,
         minutes: newMinutes.clamp(0, 59),
         seconds: newSeconds.clamp(0, 59),
+        milliseconds: newMilliseconds.clamp(0, 999),
+        microseconds: newMicroseconds.clamp(0, 999),
       ),
     );
   }
@@ -51,56 +82,150 @@ class _DurationInputState extends State<DurationInput> {
   @override
   Widget build(BuildContext context) {
     return Row(
+      spacing: 8,
       children: [
-        Expanded(
-          child: NumberTextField(
-            value: hours,
-            maxLength: 6,
-            inputFormatters: [
-              FilteringTextInputFormatter.digitsOnly,
-            ],
-            labelText: 'h',
-            onChanged: (value) {
-              onValuesChanged(value, minutes, seconds);
-            },
+        if (widget.enableDays)
+          Expanded(
+            child: NumberTextField(
+              value: days,
+              maxLength: 6,
+              inputFormatters: [
+                FilteringTextInputFormatter.digitsOnly,
+              ],
+              labelText: 'd',
+              onChanged: (value) {
+                onValuesChanged(
+                  value,
+                  hours,
+                  minutes,
+                  seconds,
+                  milliseconds,
+                  microseconds,
+                );
+              },
+            ),
           ),
-        ),
-        const SizedBox(width: 8),
-        Expanded(
-          child: NumberTextField(
-            value: minutes,
-            maxLength: 2,
-            inputFormatters: [
-              FilteringTextInputFormatter.digitsOnly,
-              FilteringTextInputFormatter.allow(
-                RegExp(r'^[0-5]?[0-9]$'),
-                replacementString: '$minutes',
-              ),
-            ],
-            labelText: 'm',
-            onChanged: (value) {
-              onValuesChanged(hours, value, seconds);
-            },
+        if (widget.enableHours)
+          Expanded(
+            child: NumberTextField(
+              value: hours,
+              maxLength: 6,
+              inputFormatters: [
+                FilteringTextInputFormatter.digitsOnly,
+              ],
+              labelText: 'h',
+              onChanged: (value) {
+                onValuesChanged(
+                  days,
+                  value,
+                  minutes,
+                  seconds,
+                  milliseconds,
+                  microseconds,
+                );
+              },
+            ),
           ),
-        ),
-        const SizedBox(width: 8),
-        Expanded(
-          child: NumberTextField(
-            value: seconds,
-            maxLength: 2,
-            inputFormatters: [
-              FilteringTextInputFormatter.digitsOnly,
-              FilteringTextInputFormatter.allow(
-                RegExp(r'^[0-5]?[0-9]$'),
-                replacementString: '$seconds',
-              ),
-            ],
-            labelText: 's',
-            onChanged: (value) {
-              onValuesChanged(hours, minutes, value);
-            },
+        if (widget.enableMinutes)
+          Expanded(
+            child: NumberTextField(
+              value: minutes,
+              maxLength: 2,
+              inputFormatters: [
+                FilteringTextInputFormatter.digitsOnly,
+                FilteringTextInputFormatter.allow(
+                  RegExp(r'^[0-5]?[0-9]$'),
+                  replacementString: '$minutes',
+                ),
+              ],
+              labelText: 'm',
+              onChanged: (value) {
+                onValuesChanged(
+                  days,
+                  hours,
+                  value,
+                  seconds,
+                  milliseconds,
+                  microseconds,
+                );
+              },
+            ),
           ),
-        ),
+        if (widget.enableSeconds)
+          Expanded(
+            child: NumberTextField(
+              value: seconds,
+              maxLength: 2,
+              inputFormatters: [
+                FilteringTextInputFormatter.digitsOnly,
+                FilteringTextInputFormatter.allow(
+                  RegExp(r'^[0-5]?[0-9]$'),
+                  replacementString: '$seconds',
+                ),
+              ],
+              labelText: 's',
+              onChanged: (value) {
+                onValuesChanged(
+                  days,
+                  hours,
+                  minutes,
+                  value,
+                  milliseconds,
+                  microseconds,
+                );
+              },
+            ),
+          ),
+        if (widget.enableMilliseconds)
+          Expanded(
+            child: NumberTextField(
+              value: milliseconds,
+              maxLength: 3,
+              inputFormatters: [
+                FilteringTextInputFormatter.digitsOnly,
+                FilteringTextInputFormatter.allow(
+                  RegExp(r'^[0-9]{0,3}$'),
+                  replacementString: '$milliseconds',
+                ),
+              ],
+              labelText: 'ms',
+              onChanged: (value) {
+                onValuesChanged(
+                  days,
+                  hours,
+                  minutes,
+                  seconds,
+                  value,
+                  microseconds,
+                );
+              },
+            ),
+          ),
+        if (widget.enableMicroseconds)
+          Expanded(
+            child: NumberTextField(
+              value: microseconds,
+              maxLength: 3,
+              inputFormatters: [
+                FilteringTextInputFormatter.digitsOnly,
+                FilteringTextInputFormatter.allow(
+                  RegExp(r'^[0-9]{0,3}$'),
+                  replacementString: '$microseconds',
+                ),
+              ],
+              labelText: 'µs',
+              onChanged: (value) {
+                onValuesChanged(
+                  days,
+                  hours,
+                  minutes,
+                  seconds,
+                  milliseconds,
+                  value,
+                );
+              },
+            ),
+          ),
       ],
     );
   }

--- a/packages/widgetbook/lib/src/fields/duration_field/duration_input.dart
+++ b/packages/widgetbook/lib/src/fields/duration_field/duration_input.dart
@@ -71,8 +71,7 @@ class _DurationInputState extends State<DurationInput> {
   List<TextInputFormatter> _formattersFor(DurationUnit unit) {
     final boundedPattern = switch (unit) {
       DurationUnit.minutes || DurationUnit.seconds => r'^[0-5]?[0-9]$',
-      DurationUnit.milliseconds ||
-      DurationUnit.microseconds => r'^[0-9]{0,3}$',
+      DurationUnit.milliseconds || DurationUnit.microseconds => r'^[0-9]{0,3}$',
       _ => null,
     };
 

--- a/packages/widgetbook/lib/src/fields/duration_field/duration_input.dart
+++ b/packages/widgetbook/lib/src/fields/duration_field/duration_input.dart
@@ -3,28 +3,19 @@ import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 
 import '../common/number_text_field.dart';
+import 'duration_unit.dart';
 
 @internal
 class DurationInput extends StatefulWidget {
   const DurationInput({
     super.key,
     required this.value,
-    required this.enableDays,
-    required this.enableHours,
-    required this.enableMinutes,
-    required this.enableSeconds,
-    required this.enableMilliseconds,
-    required this.enableMicroseconds,
+    required this.units,
     required this.onChanged,
   });
 
   final Duration value;
-  final bool enableDays;
-  final bool enableHours;
-  final bool enableMinutes;
-  final bool enableSeconds;
-  final bool enableMilliseconds;
-  final bool enableMicroseconds;
+  final Set<DurationUnit> units;
   final ValueChanged<Duration> onChanged;
 
   @override
@@ -32,51 +23,70 @@ class DurationInput extends StatefulWidget {
 }
 
 class _DurationInputState extends State<DurationInput> {
-  late int days;
-  late int hours;
-  late int minutes;
-  late int seconds;
-  late int milliseconds;
-  late int microseconds;
+  /// The current value of each enabled unit, keyed by unit.
+  late Map<DurationUnit, int> values;
 
   @override
   void initState() {
     super.initState();
-    days = widget.value.inDays;
-    hours = widget.value.inHours.remainder(24);
-    minutes = widget.value.inMinutes.remainder(60);
-    seconds = widget.value.inSeconds.remainder(60);
-    milliseconds = widget.value.inMilliseconds.remainder(1000);
-    microseconds = widget.value.inMicroseconds.remainder(1000);
+    values = _decompose(widget.value);
   }
 
-  void onValuesChanged(
-    int newDays,
-    int newHours,
-    int newMinutes,
-    int newSeconds,
-    int newMilliseconds,
-    int newMicroseconds,
-  ) {
+  /// The largest enabled unit; it absorbs everything above the next-smaller
+  /// enabled unit and therefore accepts arbitrarily large values.
+  DurationUnit get _largestUnit =>
+      DurationUnit.values.firstWhere(widget.units.contains);
+
+  /// Splits [value] into a count per enabled unit, walking from largest to
+  /// smallest so that the largest enabled unit holds the overflow and nothing
+  /// is silently dropped when high-order units are disabled.
+  Map<DurationUnit, int> _decompose(Duration value) {
+    final result = <DurationUnit, int>{};
+    var remaining = value.inMicroseconds;
+    for (final unit in DurationUnit.values) {
+      if (!widget.units.contains(unit)) continue;
+      final step = unit.step.inMicroseconds;
+      final count = remaining ~/ step;
+      result[unit] = count;
+      remaining -= count * step;
+    }
+    return result;
+  }
+
+  void _onUnitChanged(DurationUnit unit, int newValue) {
     setState(() {
-      days = newDays;
-      hours = newHours;
-      minutes = newMinutes.clamp(0, 59);
-      seconds = newSeconds.clamp(0, 59);
-      milliseconds = newMilliseconds.clamp(0, 999);
-      microseconds = newMicroseconds.clamp(0, 999);
+      values[unit] = newValue;
     });
 
-    widget.onChanged.call(
-      Duration(
-        days: newDays,
-        hours: newHours,
-        minutes: newMinutes.clamp(0, 59),
-        seconds: newSeconds.clamp(0, 59),
-        milliseconds: newMilliseconds.clamp(0, 999),
-        microseconds: newMicroseconds.clamp(0, 999),
+    var total = Duration.zero;
+    values.forEach((unit, value) {
+      total += unit.step * value;
+    });
+    widget.onChanged(total);
+  }
+
+  /// Bounds smaller units to their natural range (e.g. 0-59, 0-999) so they
+  /// don't overflow into a unit that is shown separately. The largest enabled
+  /// unit is left unbounded so it can represent the full duration.
+  List<TextInputFormatter> _formattersFor(DurationUnit unit) {
+    final boundedPattern = switch (unit) {
+      DurationUnit.minutes || DurationUnit.seconds => r'^[0-5]?[0-9]$',
+      DurationUnit.milliseconds ||
+      DurationUnit.microseconds => r'^[0-9]{0,3}$',
+      _ => null,
+    };
+
+    if (unit == _largestUnit || boundedPattern == null) {
+      return [FilteringTextInputFormatter.digitsOnly];
+    }
+
+    return [
+      FilteringTextInputFormatter.digitsOnly,
+      FilteringTextInputFormatter.allow(
+        RegExp(boundedPattern),
+        replacementString: '${values[unit] ?? 0}',
       ),
-    );
+    ];
   }
 
   @override
@@ -84,148 +94,17 @@ class _DurationInputState extends State<DurationInput> {
     return Row(
       spacing: 8,
       children: [
-        if (widget.enableDays)
-          Expanded(
-            child: NumberTextField(
-              value: days,
-              maxLength: 6,
-              inputFormatters: [
-                FilteringTextInputFormatter.digitsOnly,
-              ],
-              labelText: 'd',
-              onChanged: (value) {
-                onValuesChanged(
-                  value,
-                  hours,
-                  minutes,
-                  seconds,
-                  milliseconds,
-                  microseconds,
-                );
-              },
+        for (final unit in DurationUnit.values)
+          if (widget.units.contains(unit))
+            Expanded(
+              child: NumberTextField(
+                value: values[unit] ?? 0,
+                maxLength: unit == _largestUnit ? 6 : unit.maxLength,
+                inputFormatters: _formattersFor(unit),
+                labelText: unit.label,
+                onChanged: (value) => _onUnitChanged(unit, value),
+              ),
             ),
-          ),
-        if (widget.enableHours)
-          Expanded(
-            child: NumberTextField(
-              value: hours,
-              maxLength: 6,
-              inputFormatters: [
-                FilteringTextInputFormatter.digitsOnly,
-              ],
-              labelText: 'h',
-              onChanged: (value) {
-                onValuesChanged(
-                  days,
-                  value,
-                  minutes,
-                  seconds,
-                  milliseconds,
-                  microseconds,
-                );
-              },
-            ),
-          ),
-        if (widget.enableMinutes)
-          Expanded(
-            child: NumberTextField(
-              value: minutes,
-              maxLength: 2,
-              inputFormatters: [
-                FilteringTextInputFormatter.digitsOnly,
-                FilteringTextInputFormatter.allow(
-                  RegExp(r'^[0-5]?[0-9]$'),
-                  replacementString: '$minutes',
-                ),
-              ],
-              labelText: 'm',
-              onChanged: (value) {
-                onValuesChanged(
-                  days,
-                  hours,
-                  value,
-                  seconds,
-                  milliseconds,
-                  microseconds,
-                );
-              },
-            ),
-          ),
-        if (widget.enableSeconds)
-          Expanded(
-            child: NumberTextField(
-              value: seconds,
-              maxLength: 2,
-              inputFormatters: [
-                FilteringTextInputFormatter.digitsOnly,
-                FilteringTextInputFormatter.allow(
-                  RegExp(r'^[0-5]?[0-9]$'),
-                  replacementString: '$seconds',
-                ),
-              ],
-              labelText: 's',
-              onChanged: (value) {
-                onValuesChanged(
-                  days,
-                  hours,
-                  minutes,
-                  value,
-                  milliseconds,
-                  microseconds,
-                );
-              },
-            ),
-          ),
-        if (widget.enableMilliseconds)
-          Expanded(
-            child: NumberTextField(
-              value: milliseconds,
-              maxLength: 3,
-              inputFormatters: [
-                FilteringTextInputFormatter.digitsOnly,
-                FilteringTextInputFormatter.allow(
-                  RegExp(r'^[0-9]{0,3}$'),
-                  replacementString: '$milliseconds',
-                ),
-              ],
-              labelText: 'ms',
-              onChanged: (value) {
-                onValuesChanged(
-                  days,
-                  hours,
-                  minutes,
-                  seconds,
-                  value,
-                  microseconds,
-                );
-              },
-            ),
-          ),
-        if (widget.enableMicroseconds)
-          Expanded(
-            child: NumberTextField(
-              value: microseconds,
-              maxLength: 3,
-              inputFormatters: [
-                FilteringTextInputFormatter.digitsOnly,
-                FilteringTextInputFormatter.allow(
-                  RegExp(r'^[0-9]{0,3}$'),
-                  replacementString: '$microseconds',
-                ),
-              ],
-              labelText: 'µs',
-              onChanged: (value) {
-                onValuesChanged(
-                  days,
-                  hours,
-                  minutes,
-                  seconds,
-                  milliseconds,
-                  value,
-                );
-              },
-            ),
-          ),
       ],
     );
   }

--- a/packages/widgetbook/lib/src/fields/duration_field/duration_unit.dart
+++ b/packages/widgetbook/lib/src/fields/duration_field/duration_unit.dart
@@ -1,0 +1,45 @@
+/// A single time unit that a [Duration] can be broken down into and edited
+/// through, used by the duration knob to decide which inputs to display.
+///
+/// The declaration order (largest to smallest) is also the order in which the
+/// inputs are rendered and the order in which a [Duration] is decomposed: the
+/// largest enabled unit absorbs everything above the next-smaller enabled unit,
+/// so no part of the value is ever hidden.
+enum DurationUnit {
+  /// Days component, labelled `d`.
+  days(step: Duration(days: 1), label: 'd', maxLength: 6),
+
+  /// Hours component, labelled `h`.
+  hours(step: Duration(hours: 1), label: 'h', maxLength: 6),
+
+  /// Minutes component, labelled `m`.
+  minutes(step: Duration(minutes: 1), label: 'm', maxLength: 2),
+
+  /// Seconds component, labelled `s`.
+  seconds(step: Duration(seconds: 1), label: 's', maxLength: 2),
+
+  /// Milliseconds component, labelled `ms`.
+  milliseconds(step: Duration(milliseconds: 1), label: 'ms', maxLength: 3),
+
+  /// Microseconds component, labelled `µs`.
+  microseconds(step: Duration(microseconds: 1), label: 'µs', maxLength: 3);
+
+  const DurationUnit({
+    required this.step,
+    required this.label,
+    required this.maxLength,
+  });
+
+  /// The size of a single increment of this unit (e.g. `Duration(hours: 1)`).
+  final Duration step;
+
+  /// Short label shown above the input field (e.g. `h` for [hours]).
+  final String label;
+
+  /// Maximum number of digits the input field accepts for this unit when it is
+  /// not the largest enabled unit.
+  final int maxLength;
+
+  /// The units shown by default: hours, minutes and seconds.
+  static const Set<DurationUnit> defaults = {hours, minutes, seconds};
+}

--- a/packages/widgetbook/lib/src/fields/duration_field/duration_unit.dart
+++ b/packages/widgetbook/lib/src/fields/duration_field/duration_unit.dart
@@ -40,6 +40,6 @@ enum DurationUnit {
   /// not the largest enabled unit.
   final int maxLength;
 
-  /// The units shown by default: seconds and milliseconds.
-  static const Set<DurationUnit> defaults = {seconds, milliseconds};
+  /// The units shown by default: hours, minutes and seconds.
+  static const Set<DurationUnit> defaults = {hours, minutes, seconds};
 }

--- a/packages/widgetbook/lib/src/fields/duration_field/duration_unit.dart
+++ b/packages/widgetbook/lib/src/fields/duration_field/duration_unit.dart
@@ -40,6 +40,6 @@ enum DurationUnit {
   /// not the largest enabled unit.
   final int maxLength;
 
-  /// The units shown by default: hours, minutes and seconds.
-  static const Set<DurationUnit> defaults = {hours, minutes, seconds};
+  /// The units shown by default: seconds and milliseconds.
+  static const Set<DurationUnit> defaults = {seconds, milliseconds};
 }

--- a/packages/widgetbook/lib/src/fields/fields.dart
+++ b/packages/widgetbook/lib/src/fields/fields.dart
@@ -4,6 +4,7 @@ export 'date_time_field.dart';
 export 'double_input_field.dart';
 export 'double_slider_field.dart';
 export 'duration_field/duration_field.dart';
+export 'duration_field/duration_unit.dart';
 export 'field.dart';
 export 'field_codec.dart';
 export 'field_type.dart';

--- a/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
@@ -221,12 +221,24 @@ class KnobsBuilder {
     required String label,
     Duration initialValue = Duration.zero,
     String? description,
+    bool enableDays = false,
+    bool enableHours = true,
+    bool enableMinutes = true,
+    bool enableSeconds = true,
+    bool enableMilliseconds = false,
+    bool enableMicroseconds = false,
   }) {
     return onKnobAdded(
       DurationKnob(
         label: label,
         initialValue: initialValue,
         description: description,
+        enableDays: enableDays,
+        enableHours: enableHours,
+        enableMinutes: enableMinutes,
+        enableSeconds: enableSeconds,
+        enableMilliseconds: enableMilliseconds,
+        enableMicroseconds: enableMicroseconds,
       ),
     )!;
   }
@@ -238,6 +250,12 @@ class KnobsBuilder {
     Duration? initialValue,
     String? description,
     bool defaultToNull = false,
+    bool enableDays = false,
+    bool enableHours = true,
+    bool enableMinutes = true,
+    bool enableSeconds = true,
+    bool enableMilliseconds = false,
+    bool enableMicroseconds = false,
   }) {
     return onKnobAdded(
       DurationKnob.nullable(
@@ -245,6 +263,12 @@ class KnobsBuilder {
         initialValue: initialValue,
         description: description,
         defaultToNull: defaultToNull,
+        enableDays: enableDays,
+        enableHours: enableHours,
+        enableMinutes: enableMinutes,
+        enableSeconds: enableSeconds,
+        enableMilliseconds: enableMilliseconds,
+        enableMicroseconds: enableMicroseconds,
       ),
     );
   }

--- a/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/knobs_builder.dart
@@ -221,24 +221,14 @@ class KnobsBuilder {
     required String label,
     Duration initialValue = Duration.zero,
     String? description,
-    bool enableDays = false,
-    bool enableHours = true,
-    bool enableMinutes = true,
-    bool enableSeconds = true,
-    bool enableMilliseconds = false,
-    bool enableMicroseconds = false,
+    Set<DurationUnit> units = DurationUnit.defaults,
   }) {
     return onKnobAdded(
       DurationKnob(
         label: label,
         initialValue: initialValue,
         description: description,
-        enableDays: enableDays,
-        enableHours: enableHours,
-        enableMinutes: enableMinutes,
-        enableSeconds: enableSeconds,
-        enableMilliseconds: enableMilliseconds,
-        enableMicroseconds: enableMicroseconds,
+        units: units,
       ),
     )!;
   }
@@ -250,12 +240,7 @@ class KnobsBuilder {
     Duration? initialValue,
     String? description,
     bool defaultToNull = false,
-    bool enableDays = false,
-    bool enableHours = true,
-    bool enableMinutes = true,
-    bool enableSeconds = true,
-    bool enableMilliseconds = false,
-    bool enableMicroseconds = false,
+    Set<DurationUnit> units = DurationUnit.defaults,
   }) {
     return onKnobAdded(
       DurationKnob.nullable(
@@ -263,12 +248,7 @@ class KnobsBuilder {
         initialValue: initialValue,
         description: description,
         defaultToNull: defaultToNull,
-        enableDays: enableDays,
-        enableHours: enableHours,
-        enableMinutes: enableMinutes,
-        enableSeconds: enableSeconds,
-        enableMilliseconds: enableMilliseconds,
-        enableMicroseconds: enableMicroseconds,
+        units: units,
       ),
     );
   }

--- a/packages/widgetbook/lib/src/knobs/duration_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/duration_knob.dart
@@ -8,6 +8,12 @@ class DurationKnob extends Knob<Duration?> {
   DurationKnob({
     required super.label,
     required super.initialValue,
+    this.enableDays = false,
+    this.enableHours = true,
+    this.enableMinutes = true,
+    this.enableSeconds = true,
+    this.enableMilliseconds = false,
+    this.enableMicroseconds = false,
     super.description,
   });
 
@@ -16,7 +22,31 @@ class DurationKnob extends Knob<Duration?> {
     required super.initialValue,
     super.description,
     super.defaultToNull,
+    this.enableDays = false,
+    this.enableHours = true,
+    this.enableMinutes = true,
+    this.enableSeconds = true,
+    this.enableMilliseconds = false,
+    this.enableMicroseconds = false,
   }) : super(isNullable: true);
+
+  /// Whether to enable input for days in the duration.
+  final bool enableDays;
+
+  /// Whether to enable input for hours in the duration.
+  final bool enableHours;
+
+  /// Whether to enable input for minutes in the duration.
+  final bool enableMinutes;
+
+  /// Whether to enable input for seconds in the duration.
+  final bool enableSeconds;
+
+  /// Whether to enable input for milliseconds in the duration.
+  final bool enableMilliseconds;
+
+  /// Whether to enable input for microseconds in the duration.
+  final bool enableMicroseconds;
 
   @override
   List<Field> get fields {
@@ -24,6 +54,12 @@ class DurationKnob extends Knob<Duration?> {
       DurationField(
         name: label,
         initialValue: initialValue,
+        enableDays: enableDays,
+        enableHours: enableHours,
+        enableMinutes: enableMinutes,
+        enableSeconds: enableSeconds,
+        enableMilliseconds: enableMilliseconds,
+        enableMicroseconds: enableMicroseconds,
       ),
     ];
   }

--- a/packages/widgetbook/lib/src/knobs/duration_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/duration_knob.dart
@@ -8,12 +8,7 @@ class DurationKnob extends Knob<Duration?> {
   DurationKnob({
     required super.label,
     required super.initialValue,
-    this.enableDays = false,
-    this.enableHours = true,
-    this.enableMinutes = true,
-    this.enableSeconds = true,
-    this.enableMilliseconds = false,
-    this.enableMicroseconds = false,
+    this.units = DurationUnit.defaults,
     super.description,
   });
 
@@ -22,31 +17,12 @@ class DurationKnob extends Knob<Duration?> {
     required super.initialValue,
     super.description,
     super.defaultToNull,
-    this.enableDays = false,
-    this.enableHours = true,
-    this.enableMinutes = true,
-    this.enableSeconds = true,
-    this.enableMilliseconds = false,
-    this.enableMicroseconds = false,
+    this.units = DurationUnit.defaults,
   }) : super(isNullable: true);
 
-  /// Whether to enable input for days in the duration.
-  final bool enableDays;
-
-  /// Whether to enable input for hours in the duration.
-  final bool enableHours;
-
-  /// Whether to enable input for minutes in the duration.
-  final bool enableMinutes;
-
-  /// Whether to enable input for seconds in the duration.
-  final bool enableSeconds;
-
-  /// Whether to enable input for milliseconds in the duration.
-  final bool enableMilliseconds;
-
-  /// Whether to enable input for microseconds in the duration.
-  final bool enableMicroseconds;
+  /// The time units displayed as separate inputs, rendered from largest to
+  /// smallest. Defaults to [DurationUnit.defaults] (hours, minutes, seconds).
+  final Set<DurationUnit> units;
 
   @override
   List<Field> get fields {
@@ -54,12 +30,7 @@ class DurationKnob extends Knob<Duration?> {
       DurationField(
         name: label,
         initialValue: initialValue,
-        enableDays: enableDays,
-        enableHours: enableHours,
-        enableMinutes: enableMinutes,
-        enableSeconds: enableSeconds,
-        enableMilliseconds: enableMilliseconds,
-        enableMicroseconds: enableMicroseconds,
+        units: units,
       ),
     ];
   }

--- a/packages/widgetbook/lib/src/knobs/duration_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/duration_knob.dart
@@ -21,7 +21,7 @@ class DurationKnob extends Knob<Duration?> {
   }) : super(isNullable: true);
 
   /// The time units displayed as separate inputs, rendered from largest to
-  /// smallest. Defaults to [DurationUnit.defaults] (hours, minutes, seconds).
+  /// smallest. Defaults to [DurationUnit.defaults] (seconds, milliseconds).
   final Set<DurationUnit> units;
 
   @override

--- a/packages/widgetbook/lib/src/knobs/duration_knob.dart
+++ b/packages/widgetbook/lib/src/knobs/duration_knob.dart
@@ -21,7 +21,7 @@ class DurationKnob extends Knob<Duration?> {
   }) : super(isNullable: true);
 
   /// The time units displayed as separate inputs, rendered from largest to
-  /// smallest. Defaults to [DurationUnit.defaults] (seconds, milliseconds).
+  /// smallest. Defaults to [DurationUnit.defaults] (hours, minutes, seconds).
   final Set<DurationUnit> units;
 
   @override

--- a/packages/widgetbook/test/src/fields/duration_field_test.dart
+++ b/packages/widgetbook/test/src/fields/duration_field_test.dart
@@ -123,6 +123,173 @@ void main() {
         expect(textFields, findsNWidgets(3));
       },
     );
+
+    testWidgets(
+      'given a field with enableDays=true, '
+      'then [toWidget] builds four input fields (d/h/m/s)',
+      (tester) async {
+        final fieldWithDays = DurationField(
+          name: 'duration_field',
+          initialValue: const Duration(
+            days: 1,
+            hours: 2,
+            minutes: 3,
+            seconds: 4,
+          ),
+          enableDays: true,
+        );
+
+        await tester.pumpWidget(
+          Builder(
+            builder: (context) {
+              return MaterialApp(
+                home: Scaffold(
+                  body: fieldWithDays.toWidget(
+                    context,
+                    'duration_field',
+                    null,
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+
+        final textFields = find.byType(TextFormField);
+        expect(textFields, findsNWidgets(4));
+
+        final daysField = tester.widget<TextFormField>(textFields.at(0));
+        final hoursField = tester.widget<TextFormField>(textFields.at(1));
+        final minutesField = tester.widget<TextFormField>(textFields.at(2));
+        final secondsField = tester.widget<TextFormField>(textFields.at(3));
+
+        expect(daysField.initialValue, '1');
+        expect(hoursField.initialValue, '2');
+        expect(minutesField.initialValue, '3');
+        expect(secondsField.initialValue, '4');
+      },
+    );
+
+    testWidgets(
+      'given a field with enableMilliseconds=true and enableMicroseconds=true, '
+      'then [toWidget] builds five input fields (h/m/s/ms/µs)',
+      (tester) async {
+        final fieldWithMs = DurationField(
+          name: 'duration_field',
+          initialValue: const Duration(
+            hours: 1,
+            minutes: 2,
+            seconds: 3,
+            milliseconds: 500,
+            microseconds: 250,
+          ),
+          enableMilliseconds: true,
+          enableMicroseconds: true,
+        );
+
+        await tester.pumpWidget(
+          Builder(
+            builder: (context) {
+              return MaterialApp(
+                home: Scaffold(
+                  body: fieldWithMs.toWidget(
+                    context,
+                    'duration_field',
+                    null,
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+
+        final textFields = find.byType(TextFormField);
+        expect(textFields, findsNWidgets(5));
+
+        final hoursField = tester.widget<TextFormField>(textFields.at(0));
+        final minutesField = tester.widget<TextFormField>(textFields.at(1));
+        final secondsField = tester.widget<TextFormField>(textFields.at(2));
+        final msField = tester.widget<TextFormField>(textFields.at(3));
+        final usField = tester.widget<TextFormField>(textFields.at(4));
+
+        expect(hoursField.initialValue, '1');
+        expect(minutesField.initialValue, '2');
+        expect(secondsField.initialValue, '3');
+        expect(msField.initialValue, '500');
+        expect(usField.initialValue, '250');
+      },
+    );
+
+    testWidgets(
+      'given a field with all units enabled, '
+      'then [toWidget] builds six input fields',
+      (tester) async {
+        final allUnitsField = DurationField(
+          name: 'duration_field',
+          initialValue: const Duration(
+            days: 1,
+            hours: 2,
+            minutes: 3,
+            seconds: 4,
+            milliseconds: 500,
+            microseconds: 250,
+          ),
+          enableDays: true,
+          enableMilliseconds: true,
+          enableMicroseconds: true,
+        );
+
+        await tester.pumpWidget(
+          Builder(
+            builder: (context) {
+              return MaterialApp(
+                home: Scaffold(
+                  body: allUnitsField.toWidget(
+                    context,
+                    'duration_field',
+                    null,
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+
+        final textFields = find.byType(TextFormField);
+        expect(textFields, findsNWidgets(6));
+      },
+    );
+
+    testWidgets(
+      'given a field with enableHours=false, '
+      'then [toWidget] builds two input fields (m/s)',
+      (tester) async {
+        final noHoursField = DurationField(
+          name: 'duration_field',
+          initialValue: fiveSeconds,
+          enableHours: false,
+        );
+
+        await tester.pumpWidget(
+          Builder(
+            builder: (context) {
+              return MaterialApp(
+                home: Scaffold(
+                  body: noHoursField.toWidget(
+                    context,
+                    'duration_field',
+                    null,
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+
+        final textFields = find.byType(TextFormField);
+        expect(textFields, findsNWidgets(2));
+      },
+    );
   });
 
   group('Duration Codec', () {

--- a/packages/widgetbook/test/src/fields/duration_field_test.dart
+++ b/packages/widgetbook/test/src/fields/duration_field_test.dart
@@ -54,15 +54,13 @@ void main() {
         );
 
         final textFields = find.byType(TextFormField);
-        expect(textFields, findsNWidgets(3));
+        expect(textFields, findsNWidgets(2));
 
-        final hoursField = tester.widget<TextFormField>(textFields.at(0));
-        final minutesField = tester.widget<TextFormField>(textFields.at(1));
-        final secondsField = tester.widget<TextFormField>(textFields.at(2));
+        final secondsField = tester.widget<TextFormField>(textFields.at(0));
+        final millisecondsField = tester.widget<TextFormField>(textFields.at(1));
 
-        expect(hoursField.initialValue, '0');
-        expect(minutesField.initialValue, '0');
         expect(secondsField.initialValue, '5');
+        expect(millisecondsField.initialValue, '0');
       },
     );
 
@@ -87,21 +85,19 @@ void main() {
         );
 
         final textFields = find.byType(TextFormField);
-        expect(textFields, findsNWidgets(3));
+        expect(textFields, findsNWidgets(2));
 
-        final hoursField = tester.widget<TextFormField>(textFields.at(0));
-        final minutesField = tester.widget<TextFormField>(textFields.at(1));
-        final secondsField = tester.widget<TextFormField>(textFields.at(2));
+        final secondsField = tester.widget<TextFormField>(textFields.at(0));
+        final millisecondsField = tester.widget<TextFormField>(textFields.at(1));
 
-        expect(hoursField.initialValue, '0');
-        expect(minutesField.initialValue, '0');
         expect(secondsField.initialValue, '10');
+        expect(millisecondsField.initialValue, '0');
       },
     );
 
     testWidgets(
       'given a field, '
-      'then [toWidget] builds three input fields',
+      'then [toWidget] builds two input fields',
       (tester) async {
         await tester.pumpWidget(
           Builder(
@@ -120,7 +116,7 @@ void main() {
         );
 
         final textFields = find.byType(TextFormField);
-        expect(textFields, findsNWidgets(3));
+        expect(textFields, findsNWidgets(2));
       },
     );
 
@@ -300,7 +296,7 @@ void main() {
     );
 
     testWidgets(
-      'given the default units and a value larger than a day, '
+      'given the hours/minutes/seconds units and a value larger than a day, '
       'then the hours field shows the full hour count without dropping the '
       'overflow',
       (tester) async {
@@ -309,6 +305,11 @@ void main() {
         final field = DurationField(
           name: 'duration_field',
           initialValue: const Duration(hours: 50, minutes: 3, seconds: 4),
+          units: const {
+            DurationUnit.hours,
+            DurationUnit.minutes,
+            DurationUnit.seconds,
+          },
         );
 
         await tester.pumpWidget(

--- a/packages/widgetbook/test/src/fields/duration_field_test.dart
+++ b/packages/widgetbook/test/src/fields/duration_field_test.dart
@@ -54,13 +54,15 @@ void main() {
         );
 
         final textFields = find.byType(TextFormField);
-        expect(textFields, findsNWidgets(2));
+        expect(textFields, findsNWidgets(3));
 
-        final secondsField = tester.widget<TextFormField>(textFields.at(0));
-        final millisecondsField = tester.widget<TextFormField>(textFields.at(1));
+        final hoursField = tester.widget<TextFormField>(textFields.at(0));
+        final minutesField = tester.widget<TextFormField>(textFields.at(1));
+        final secondsField = tester.widget<TextFormField>(textFields.at(2));
 
+        expect(hoursField.initialValue, '0');
+        expect(minutesField.initialValue, '0');
         expect(secondsField.initialValue, '5');
-        expect(millisecondsField.initialValue, '0');
       },
     );
 
@@ -85,19 +87,21 @@ void main() {
         );
 
         final textFields = find.byType(TextFormField);
-        expect(textFields, findsNWidgets(2));
+        expect(textFields, findsNWidgets(3));
 
-        final secondsField = tester.widget<TextFormField>(textFields.at(0));
-        final millisecondsField = tester.widget<TextFormField>(textFields.at(1));
+        final hoursField = tester.widget<TextFormField>(textFields.at(0));
+        final minutesField = tester.widget<TextFormField>(textFields.at(1));
+        final secondsField = tester.widget<TextFormField>(textFields.at(2));
 
+        expect(hoursField.initialValue, '0');
+        expect(minutesField.initialValue, '0');
         expect(secondsField.initialValue, '10');
-        expect(millisecondsField.initialValue, '0');
       },
     );
 
     testWidgets(
       'given a field, '
-      'then [toWidget] builds two input fields',
+      'then [toWidget] builds three input fields',
       (tester) async {
         await tester.pumpWidget(
           Builder(
@@ -116,7 +120,7 @@ void main() {
         );
 
         final textFields = find.byType(TextFormField);
-        expect(textFields, findsNWidgets(2));
+        expect(textFields, findsNWidgets(3));
       },
     );
 
@@ -296,7 +300,7 @@ void main() {
     );
 
     testWidgets(
-      'given the hours/minutes/seconds units and a value larger than a day, '
+      'given the default units and a value larger than a day, '
       'then the hours field shows the full hour count without dropping the '
       'overflow',
       (tester) async {
@@ -305,11 +309,6 @@ void main() {
         final field = DurationField(
           name: 'duration_field',
           initialValue: const Duration(hours: 50, minutes: 3, seconds: 4),
-          units: const {
-            DurationUnit.hours,
-            DurationUnit.minutes,
-            DurationUnit.seconds,
-          },
         );
 
         await tester.pumpWidget(

--- a/packages/widgetbook/test/src/fields/duration_field_test.dart
+++ b/packages/widgetbook/test/src/fields/duration_field_test.dart
@@ -125,7 +125,7 @@ void main() {
     );
 
     testWidgets(
-      'given a field with enableDays=true, '
+      'given a field with the days unit enabled, '
       'then [toWidget] builds four input fields (d/h/m/s)',
       (tester) async {
         final fieldWithDays = DurationField(
@@ -136,7 +136,12 @@ void main() {
             minutes: 3,
             seconds: 4,
           ),
-          enableDays: true,
+          units: const {
+            DurationUnit.days,
+            DurationUnit.hours,
+            DurationUnit.minutes,
+            DurationUnit.seconds,
+          },
         );
 
         await tester.pumpWidget(
@@ -171,7 +176,7 @@ void main() {
     );
 
     testWidgets(
-      'given a field with enableMilliseconds=true and enableMicroseconds=true, '
+      'given a field with the milliseconds and microseconds units enabled, '
       'then [toWidget] builds five input fields (h/m/s/ms/µs)',
       (tester) async {
         final fieldWithMs = DurationField(
@@ -183,8 +188,13 @@ void main() {
             milliseconds: 500,
             microseconds: 250,
           ),
-          enableMilliseconds: true,
-          enableMicroseconds: true,
+          units: const {
+            DurationUnit.hours,
+            DurationUnit.minutes,
+            DurationUnit.seconds,
+            DurationUnit.milliseconds,
+            DurationUnit.microseconds,
+          },
         );
 
         await tester.pumpWidget(
@@ -234,9 +244,7 @@ void main() {
             milliseconds: 500,
             microseconds: 250,
           ),
-          enableDays: true,
-          enableMilliseconds: true,
-          enableMicroseconds: true,
+          units: DurationUnit.values.toSet(),
         );
 
         await tester.pumpWidget(
@@ -261,13 +269,13 @@ void main() {
     );
 
     testWidgets(
-      'given a field with enableHours=false, '
+      'given a field without the hours unit, '
       'then [toWidget] builds two input fields (m/s)',
       (tester) async {
         final noHoursField = DurationField(
           name: 'duration_field',
           initialValue: fiveSeconds,
-          enableHours: false,
+          units: const {DurationUnit.minutes, DurationUnit.seconds},
         );
 
         await tester.pumpWidget(
@@ -288,6 +296,88 @@ void main() {
 
         final textFields = find.byType(TextFormField);
         expect(textFields, findsNWidgets(2));
+      },
+    );
+
+    testWidgets(
+      'given the default units and a value larger than a day, '
+      'then the hours field shows the full hour count without dropping the '
+      'overflow',
+      (tester) async {
+        // Regression: previously the hours field showed inHours.remainder(24)
+        // and silently hid the remaining days even though days was disabled.
+        final field = DurationField(
+          name: 'duration_field',
+          initialValue: const Duration(hours: 50, minutes: 3, seconds: 4),
+        );
+
+        await tester.pumpWidget(
+          Builder(
+            builder: (context) {
+              return MaterialApp(
+                home: Scaffold(
+                  body: field.toWidget(context, 'duration_field', null),
+                ),
+              );
+            },
+          ),
+        );
+
+        final textFields = find.byType(TextFormField);
+        expect(textFields, findsNWidgets(3));
+
+        final hoursField = tester.widget<TextFormField>(textFields.at(0));
+        final minutesField = tester.widget<TextFormField>(textFields.at(1));
+        final secondsField = tester.widget<TextFormField>(textFields.at(2));
+
+        expect(hoursField.initialValue, '50');
+        expect(minutesField.initialValue, '3');
+        expect(secondsField.initialValue, '4');
+      },
+    );
+
+    testWidgets(
+      'given only the seconds unit and a value larger than a minute, '
+      'then the seconds field shows the full second count',
+      (tester) async {
+        final field = DurationField(
+          name: 'duration_field',
+          initialValue: const Duration(seconds: 90),
+          units: const {DurationUnit.seconds},
+        );
+
+        await tester.pumpWidget(
+          Builder(
+            builder: (context) {
+              return MaterialApp(
+                home: Scaffold(
+                  body: field.toWidget(context, 'duration_field', null),
+                ),
+              );
+            },
+          ),
+        );
+
+        final textFields = find.byType(TextFormField);
+        expect(textFields, findsNWidgets(1));
+        expect(
+          tester.widget<TextFormField>(textFields.first).initialValue,
+          '90',
+        );
+      },
+    );
+
+    testWidgets(
+      'given an empty unit set, '
+      'then constructing the field throws an assertion error',
+      (tester) async {
+        expect(
+          () => DurationField(
+            name: 'duration_field',
+            units: const {},
+          ),
+          throwsAssertionError,
+        );
       },
     );
   });

--- a/packages/widgetbook/test/src/knobs/duration_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/duration_knob_test.dart
@@ -90,6 +90,68 @@ void main() {
           );
         },
       );
+
+      testWidgets(
+        'given enableDays=true, '
+        'then four input fields should be displayed',
+        (tester) async {
+          await tester.pumpKnob(
+            (context) => Text(
+              context.knobs
+                  .duration(
+                    label: 'DurationKnob',
+                    enableDays: true,
+                  )
+                  .inMilliseconds
+                  .toString(),
+            ),
+          );
+
+          expect(find.byType(TextField), findsNWidgets(4));
+        },
+      );
+
+      testWidgets(
+        'given enableMilliseconds=true and enableMicroseconds=true, '
+        'then five input fields should be displayed',
+        (tester) async {
+          await tester.pumpKnob(
+            (context) => Text(
+              context.knobs
+                  .duration(
+                    label: 'DurationKnob',
+                    enableMilliseconds: true,
+                    enableMicroseconds: true,
+                  )
+                  .inMilliseconds
+                  .toString(),
+            ),
+          );
+
+          expect(find.byType(TextField), findsNWidgets(5));
+        },
+      );
+
+      testWidgets(
+        'given enableHours=false and enableMinutes=false, '
+        'then one input field (seconds) should be displayed',
+        (tester) async {
+          await tester.pumpKnob(
+            (context) => Text(
+              context.knobs
+                  .duration(
+                    label: 'DurationKnob',
+                    enableHours: false,
+                    enableMinutes: false,
+                  )
+                  .inMilliseconds
+                  .toString(),
+            ),
+          );
+
+          expect(find.byType(TextField), findsNWidgets(1));
+        },
+      );
     },
   );
 

--- a/packages/widgetbook/test/src/knobs/duration_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/duration_knob_test.dart
@@ -80,9 +80,9 @@ void main() {
           );
 
           final textFields = find.byType(TextField);
-          expect(textFields, findsNWidgets(2));
+          expect(textFields, findsNWidgets(3));
 
-          await tester.enterText(textFields.at(0), '10');
+          await tester.enterText(textFields.at(2), '10');
           await tester.pumpAndSettle();
 
           expect(

--- a/packages/widgetbook/test/src/knobs/duration_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/duration_knob_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widgetbook/src/knobs/knobs.dart';
+import 'package:widgetbook/widgetbook.dart' show DurationUnit;
 
 import '../../helper/helper.dart';
 
@@ -92,7 +93,7 @@ void main() {
       );
 
       testWidgets(
-        'given enableDays=true, '
+        'given the days unit is enabled, '
         'then four input fields should be displayed',
         (tester) async {
           await tester.pumpKnob(
@@ -100,7 +101,12 @@ void main() {
               context.knobs
                   .duration(
                     label: 'DurationKnob',
-                    enableDays: true,
+                    units: const {
+                      DurationUnit.days,
+                      DurationUnit.hours,
+                      DurationUnit.minutes,
+                      DurationUnit.seconds,
+                    },
                   )
                   .inMilliseconds
                   .toString(),
@@ -112,7 +118,7 @@ void main() {
       );
 
       testWidgets(
-        'given enableMilliseconds=true and enableMicroseconds=true, '
+        'given the milliseconds and microseconds units are enabled, '
         'then five input fields should be displayed',
         (tester) async {
           await tester.pumpKnob(
@@ -120,8 +126,13 @@ void main() {
               context.knobs
                   .duration(
                     label: 'DurationKnob',
-                    enableMilliseconds: true,
-                    enableMicroseconds: true,
+                    units: const {
+                      DurationUnit.hours,
+                      DurationUnit.minutes,
+                      DurationUnit.seconds,
+                      DurationUnit.milliseconds,
+                      DurationUnit.microseconds,
+                    },
                   )
                   .inMilliseconds
                   .toString(),
@@ -133,7 +144,7 @@ void main() {
       );
 
       testWidgets(
-        'given enableHours=false and enableMinutes=false, '
+        'given only the seconds unit is enabled, '
         'then one input field (seconds) should be displayed',
         (tester) async {
           await tester.pumpKnob(
@@ -141,8 +152,7 @@ void main() {
               context.knobs
                   .duration(
                     label: 'DurationKnob',
-                    enableHours: false,
-                    enableMinutes: false,
+                    units: const {DurationUnit.seconds},
                   )
                   .inMilliseconds
                   .toString(),
@@ -150,6 +160,40 @@ void main() {
           );
 
           expect(find.byType(TextField), findsNWidgets(1));
+        },
+      );
+
+      testWidgets(
+        'given the days unit is enabled and the days field is edited, '
+        'then the emitted duration includes the days component',
+        (tester) async {
+          await tester.pumpKnob(
+            (context) => Text(
+              context.knobs
+                  .duration(
+                    label: 'DurationKnob',
+                    units: const {
+                      DurationUnit.days,
+                      DurationUnit.hours,
+                      DurationUnit.minutes,
+                      DurationUnit.seconds,
+                    },
+                  )
+                  .inMilliseconds
+                  .toString(),
+            ),
+          );
+
+          final textFields = find.byType(TextField);
+          expect(textFields, findsNWidgets(4));
+
+          await tester.enterText(textFields.first, '2');
+          await tester.pumpAndSettle();
+
+          expect(
+            find.textWidget('${const Duration(days: 2).inMilliseconds}'),
+            findsOneWidget,
+          );
         },
       );
     },

--- a/packages/widgetbook/test/src/knobs/duration_knob_test.dart
+++ b/packages/widgetbook/test/src/knobs/duration_knob_test.dart
@@ -80,9 +80,9 @@ void main() {
           );
 
           final textFields = find.byType(TextField);
-          expect(textFields, findsNWidgets(3));
+          expect(textFields, findsNWidgets(2));
 
-          await tester.enterText(textFields.at(2), '10');
+          await tester.enterText(textFields.at(0), '10');
           await tester.pumpAndSettle();
 
           expect(


### PR DESCRIPTION
Most `Duration` instances in widgets are used for animations, where millisecond precision is typically required. In Widgetbook, users are unlikely to need durations spanning days, hours, or even minutes. Today, UI interactions can only be adjusted at the second level at best. This PR exposes all available duration units, giving developers the flexibility to choose which ones they want to surface in their use cases.

### List of issues which are fixed by the PR
*You must list at least one issue.*

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
