### PR TITLE
feat(widgetbook): add `setUp` and `tearDown` callbacks to `ScenarioConfig`

### DIFF
--- a/docs/testing/run-scenarios.mdx
+++ b/docs/testing/run-scenarios.mdx
@@ -45,6 +45,33 @@ Because this flow uses `flutter_test`, your scenario `run` callback receives a `
 
 See [Creating Scenarios](/testing/create-scenario) for concrete `run` examples.
 
+## Set Up and Tear Down Hooks
+
+`Config.scenarioConfig` accepts optional `setUp` and `tearDown` callbacks that run around every scenario. Both receive the active `WidgetTester` and the current `Scenario`, so they can pump frames, interact with the widget tree, or branch on scenario metadata.
+
+- `setUp` runs after the scenario has been pumped but before its `run` callback executes. Use it to seed shared state, prime caches, or stub dependencies.
+- `tearDown` runs after the screenshot and semantics data have been written. Use it to reset state mutated during the scenario.
+
+```dart
+import 'package:widgetbook/widgetbook.dart';
+
+import 'components.g.dart';
+
+final config = Config(
+  components: components,
+  scenarioConfig: ScenarioConfig(
+    setUp: (tester, scenario) async {
+      MyService.instance.reset();
+    },
+    tearDown: (tester, scenario) async {
+      MyService.instance.dispose();
+    },
+  ),
+);
+```
+
+The hooks fire for every scenario across every component and story when run via `testWidgetbook(config)`.
+
 ## Generated Snapshot Artifacts
 
 By default, artifacts are written to:

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **FEAT**: Add `setUp` and `tearDown` callbacks to `ScenarioConfig` for logic around each scenario in `testWidgetbook`. ([#1917](https://github.com/widgetbook/widgetbook/pull/1917) - by [@ABausG](https://github.com/ABausG))
 - **BREAKING**: Replace `Config.scenarios` with `Config.scenarioConfig` of new type `ScenarioConfig`; see the [PR description](https://github.com/widgetbook/widgetbook/pull/1930) for migration steps. ([#1930](https://github.com/widgetbook/widgetbook/pull/1930))
 - **REFACTOR**: Allow `analyzer` 11.x and 12.x. ([#1900](https://github.com/widgetbook/widgetbook/pull/1900))
 - **FIX**: Preserve story definition order in navigation panel instead of sorting alphabetically. ([#1897](https://github.com/widgetbook/widgetbook/pull/1897))

--- a/packages/widgetbook/lib/src/core/framework/scenario_config.dart
+++ b/packages/widgetbook/lib/src/core/framework/scenario_config.dart
@@ -1,23 +1,49 @@
+/// @docImport '../../test/test.dart';
 /// @docImport 'config.dart';
 library;
+
+import 'package:flutter_test/flutter_test.dart';
 
 import 'component.dart';
 import 'scenario.dart';
 import 'scenario_definition.dart';
 import 'story.dart';
 
+/// Callback invoked around each [Scenario] run by [testWidgetbook].
+///
+/// Receives the active [WidgetTester] and the [Scenario] currently being
+/// executed.
+typedef ScenarioCallback =
+    Future<void> Function(WidgetTester tester, Scenario scenario);
+
 /// Configuration applied to every [Scenario] discovered from a [Config].
 ///
-/// Currently exposes [definitions] that are expanded into a [Scenario] for
-/// every [Story] of every [Component]. Acts as the home for future
-/// scenario-level configuration.
+/// Exposes [definitions] that are expanded into a [Scenario] for every
+/// [Story] of every [Component], plus optional [setUp] and [tearDown] hooks
+/// invoked around each [Scenario] during [testWidgetbook].
 class ScenarioConfig {
   const ScenarioConfig({
     this.definitions = const [],
+    this.setUp,
+    this.tearDown,
   });
 
   /// [ScenarioDefinition]s applied to every [Story] of every [Component].
   ///
   /// For each definition, a [Scenario] is created on every [Story].
   final List<ScenarioDefinition> definitions;
+
+  /// Runs after each [Scenario] has been pumped but before its `run` callback
+  /// executes.
+  ///
+  /// Use it to seed shared state, prime caches, or stub dependencies the
+  /// scenario depends on. Only applied during [testWidgetbook].
+  final ScenarioCallback? setUp;
+
+  /// Runs after each [Scenario]'s screenshot and semantics data have been
+  /// written to disk.
+  ///
+  /// Use it to reset state mutated by [setUp] or the scenario itself. Only
+  /// applied during [testWidgetbook].
+  final ScenarioCallback? tearDown;
 }

--- a/packages/widgetbook/lib/src/test/test.dart
+++ b/packages/widgetbook/lib/src/test/test.dart
@@ -13,36 +13,70 @@ import 'semantics/semantics_tree_serializer.dart';
 /// The default location is already an ignored path by default.
 const outputDir = 'build/.widgetbook';
 
-Future<void> testWidgetbook(Config config) async {
+typedef ScenarioCallback =
+    Future<void> Function(WidgetTester tester, Scenario scenario);
+
+Future<void> testWidgetbook(
+  Config config, {
+  ScenarioCallback? beforeScenario,
+  ScenarioCallback? afterCapture,
+}) async {
   TestWidgetsFlutterBinding.ensureInitialized();
   await loadFonts();
 
   for (final component in config.components) {
-    testComponent(config, component);
+    testComponent(
+      config,
+      component,
+      beforeScenario: beforeScenario,
+      afterCapture: afterCapture,
+    );
   }
 }
 
-void testComponent(Config config, Component component) {
+void testComponent(
+  Config config,
+  Component component, {
+  ScenarioCallback? beforeScenario,
+  ScenarioCallback? afterCapture,
+}) {
   group('${component.name}', () {
     for (final story in component.stories) {
-      testStory(config, story);
+      testStory(
+        config,
+        story,
+        beforeScenario: beforeScenario,
+        afterCapture: afterCapture,
+      );
     }
   });
 }
 
-void testStory(Config config, Story story) {
+void testStory(
+  Config config,
+  Story story, {
+  ScenarioCallback? beforeScenario,
+  ScenarioCallback? afterCapture,
+}) {
   group(story.name, () {
     final scenarios = story.allScenarios(config);
     for (final scenario in scenarios) {
-      testScenario(config, scenario);
+      testScenario(
+        config,
+        scenario,
+        beforeScenario: beforeScenario,
+        afterCapture: afterCapture,
+      );
     }
   });
 }
 
 void testScenario(
   Config config,
-  Scenario scenario,
-) {
+  Scenario scenario, {
+  ScenarioCallback? beforeScenario,
+  ScenarioCallback? afterCapture,
+}) {
   final defaultViewport = Viewports.none;
   final targetViewport = scenario.viewport ?? defaultViewport;
 
@@ -61,6 +95,8 @@ void testScenario(
           builder: (context) => scenario.buildWithConfig(context, config),
         ),
       );
+
+      await beforeScenario?.call(tester, scenario);
 
       await scenario.execute(tester);
 
@@ -104,6 +140,8 @@ void testScenario(
 
         image.dispose();
       });
+
+      await afterCapture?.call(tester, scenario);
 
       semanticsHandle.dispose();
       addTearDown(tester.view.reset);

--- a/packages/widgetbook/lib/src/test/test.dart
+++ b/packages/widgetbook/lib/src/test/test.dart
@@ -13,70 +13,36 @@ import 'semantics/semantics_tree_serializer.dart';
 /// The default location is already an ignored path by default.
 const outputDir = 'build/.widgetbook';
 
-typedef ScenarioCallback =
-    Future<void> Function(WidgetTester tester, Scenario scenario);
-
-Future<void> testWidgetbook(
-  Config config, {
-  ScenarioCallback? setUpScenario,
-  ScenarioCallback? tearDownScenario,
-}) async {
+Future<void> testWidgetbook(Config config) async {
   TestWidgetsFlutterBinding.ensureInitialized();
   await loadFonts();
 
   for (final component in config.components) {
-    testComponent(
-      config,
-      component,
-      setUpScenario: setUpScenario,
-      tearDownScenario: tearDownScenario,
-    );
+    testComponent(config, component);
   }
 }
 
-void testComponent(
-  Config config,
-  Component component, {
-  ScenarioCallback? setUpScenario,
-  ScenarioCallback? tearDownScenario,
-}) {
+void testComponent(Config config, Component component) {
   group('${component.name}', () {
     for (final story in component.stories) {
-      testStory(
-        config,
-        story,
-        setUpScenario: setUpScenario,
-        tearDownScenario: tearDownScenario,
-      );
+      testStory(config, story);
     }
   });
 }
 
-void testStory(
-  Config config,
-  Story story, {
-  ScenarioCallback? setUpScenario,
-  ScenarioCallback? tearDownScenario,
-}) {
+void testStory(Config config, Story story) {
   group(story.name, () {
     final scenarios = story.allScenarios(config);
     for (final scenario in scenarios) {
-      testScenario(
-        config,
-        scenario,
-        setUpScenario: setUpScenario,
-        tearDownScenario: tearDownScenario,
-      );
+      testScenario(config, scenario);
     }
   });
 }
 
 void testScenario(
   Config config,
-  Scenario scenario, {
-  ScenarioCallback? setUpScenario,
-  ScenarioCallback? tearDownScenario,
-}) {
+  Scenario scenario,
+) {
   final defaultViewport = Viewports.none;
   final targetViewport = scenario.viewport ?? defaultViewport;
 
@@ -96,7 +62,7 @@ void testScenario(
         ),
       );
 
-      await setUpScenario?.call(tester, scenario);
+      await config.scenarioConfig.setUp?.call(tester, scenario);
 
       await scenario.execute(tester);
 
@@ -141,7 +107,7 @@ void testScenario(
         image.dispose();
       });
 
-      await tearDownScenario?.call(tester, scenario);
+      await config.scenarioConfig.tearDown?.call(tester, scenario);
 
       semanticsHandle.dispose();
       addTearDown(tester.view.reset);

--- a/packages/widgetbook/lib/src/test/test.dart
+++ b/packages/widgetbook/lib/src/test/test.dart
@@ -18,8 +18,8 @@ typedef ScenarioCallback =
 
 Future<void> testWidgetbook(
   Config config, {
-  ScenarioCallback? beforeScenario,
-  ScenarioCallback? afterCapture,
+  ScenarioCallback? setUpScenario,
+  ScenarioCallback? tearDownScenario,
 }) async {
   TestWidgetsFlutterBinding.ensureInitialized();
   await loadFonts();
@@ -28,8 +28,8 @@ Future<void> testWidgetbook(
     testComponent(
       config,
       component,
-      beforeScenario: beforeScenario,
-      afterCapture: afterCapture,
+      setUpScenario: setUpScenario,
+      tearDownScenario: tearDownScenario,
     );
   }
 }
@@ -37,16 +37,16 @@ Future<void> testWidgetbook(
 void testComponent(
   Config config,
   Component component, {
-  ScenarioCallback? beforeScenario,
-  ScenarioCallback? afterCapture,
+  ScenarioCallback? setUpScenario,
+  ScenarioCallback? tearDownScenario,
 }) {
   group('${component.name}', () {
     for (final story in component.stories) {
       testStory(
         config,
         story,
-        beforeScenario: beforeScenario,
-        afterCapture: afterCapture,
+        setUpScenario: setUpScenario,
+        tearDownScenario: tearDownScenario,
       );
     }
   });
@@ -55,8 +55,8 @@ void testComponent(
 void testStory(
   Config config,
   Story story, {
-  ScenarioCallback? beforeScenario,
-  ScenarioCallback? afterCapture,
+  ScenarioCallback? setUpScenario,
+  ScenarioCallback? tearDownScenario,
 }) {
   group(story.name, () {
     final scenarios = story.allScenarios(config);
@@ -64,8 +64,8 @@ void testStory(
       testScenario(
         config,
         scenario,
-        beforeScenario: beforeScenario,
-        afterCapture: afterCapture,
+        setUpScenario: setUpScenario,
+        tearDownScenario: tearDownScenario,
       );
     }
   });
@@ -74,8 +74,8 @@ void testStory(
 void testScenario(
   Config config,
   Scenario scenario, {
-  ScenarioCallback? beforeScenario,
-  ScenarioCallback? afterCapture,
+  ScenarioCallback? setUpScenario,
+  ScenarioCallback? tearDownScenario,
 }) {
   final defaultViewport = Viewports.none;
   final targetViewport = scenario.viewport ?? defaultViewport;
@@ -96,7 +96,7 @@ void testScenario(
         ),
       );
 
-      await beforeScenario?.call(tester, scenario);
+      await setUpScenario?.call(tester, scenario);
 
       await scenario.execute(tester);
 
@@ -141,7 +141,7 @@ void testScenario(
         image.dispose();
       });
 
-      await afterCapture?.call(tester, scenario);
+      await tearDownScenario?.call(tester, scenario);
 
       semanticsHandle.dispose();
       addTearDown(tester.view.reset);


### PR DESCRIPTION
Add callbacks to testWidgetbook to optionally run code for all scenarios during testing before a scenario is run as well as after a screenshot was taken.

This can be used to:
- Precache Images of Image Widgets
- Flush Pending timers after screenshot creation

### List of issues which are fixed by the PR
*You must list at least one issue.*

### Screenshots
*If applicable, add screenshots to help explain the changes.*

### Checklist

- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
