### PR TITLE
refactor(generator,cli): allow analyzer 13.x

### DIFF
--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **BREAKING**: Set minimum SDK version to 3.11.0. ([#1924](https://github.com/widgetbook/widgetbook/pull/1924))
+- **REFACTOR**: Use `analyzer` 13.x.
 
 ## 3.14.0
 

--- a/packages/widgetbook_cli/lib/src/analyzer/collectors/component_collector.dart
+++ b/packages/widgetbook_cli/lib/src/analyzer/collectors/component_collector.dart
@@ -14,9 +14,9 @@ class ComponentCollector extends CollectorAstVisitor<String, Annotation> {
   @override
   String mapNode(Annotation node) {
     final typeArg = node.arguments!.arguments
-        .whereType<NamedExpression>()
-        .firstWhere((arg) => arg.name.label.name == 'type');
+        .whereType<NamedArgument>()
+        .firstWhere((arg) => arg.name.lexeme == 'type');
 
-    return typeArg.expression.toString();
+    return typeArg.argumentExpression.toString();
   }
 }

--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
   sdk: ">=3.11.0 <4.0.0"
 
 dependencies:
-  analyzer: ^12.0.0
+  analyzer: ^13.0.0
   args: ^2.6.0
   ci: ^0.1.0
   collection: ^1.18.0

--- a/packages/widgetbook_generator/CHANGELOG.md
+++ b/packages/widgetbook_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **REFACTOR**: Allow `analyzer` 13.x.
+
 ## 3.23.0
 
 - **REFACTOR**: Allow `analyzer` 11.x and 12.x. ([#1900](https://github.com/widgetbook/widgetbook/pull/1900))

--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
   sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=8.2.0 <13.0.0"
+  analyzer: ">=8.2.0 <14.0.0"
   build: ^4.0.0
   code_builder: ^4.5.0
   collection: ^1.15.0


### PR DESCRIPTION
## Summary

- Bump `analyzer` to `^13.0.0` in `widgetbook_cli`.
- Widen `analyzer` constraint to `>=8.2.0 <14.0.0` in `widgetbook_generator`.
- Migrate `ComponentCollector` to the analyzer 13 AST: `NamedExpression` → `NamedArgument` (whose `name` is a `Token` and whose expression accessor is `argumentExpression`).

See the [analyzer 13.0.0 changelog](https://pub.dev/packages/analyzer/changelog) for the breaking AST changes.