### PR TITLE
chore(deps): bump flutter to 3.44

### DIFF
--- a/.github/workflows/widgetbook-annotation.yaml
+++ b/.github/workflows/widgetbook-annotation.yaml
@@ -17,4 +17,4 @@ jobs:
     uses: ./.github/workflows/_package.yml
     with:
       working_directory: packages/widgetbook_annotation
-      min_flutter_version: 3.38.1
+      min_flutter_version: 3.44.1

--- a/.github/workflows/widgetbook-cli.yaml
+++ b/.github/workflows/widgetbook-cli.yaml
@@ -17,4 +17,4 @@ jobs:
     uses: ./.github/workflows/_package.yml
     with:
       working_directory: packages/widgetbook_cli
-      min_flutter_version: 3.38.1
+      min_flutter_version: 3.44.1

--- a/.github/workflows/widgetbook-generator.yaml
+++ b/.github/workflows/widgetbook-generator.yaml
@@ -17,4 +17,4 @@ jobs:
     uses: ./.github/workflows/_package.yml
     with:
       working_directory: packages/widgetbook_generator
-      min_flutter_version: 3.38.1
+      min_flutter_version: 3.44.1

--- a/.github/workflows/widgetbook-test.yaml
+++ b/.github/workflows/widgetbook-test.yaml
@@ -17,4 +17,4 @@ jobs:
     uses: ./.github/workflows/_package.yml
     with:
       working_directory: packages/widgetbook_test
-      min_flutter_version: 3.38.1
+      min_flutter_version: 3.44.1

--- a/.github/workflows/widgetbook.yaml
+++ b/.github/workflows/widgetbook.yaml
@@ -17,4 +17,4 @@ jobs:
     uses: ./.github/workflows/_package.yml
     with:
       working_directory: packages/widgetbook
-      min_flutter_version: 3.38.1
+      min_flutter_version: 3.44.1

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **BREAKING**: Set minimum SDK version to 3.12.0 & minimum Flutter version to 3.44.0. ([#1924](https://github.com/widgetbook/widgetbook/pull/1924))
+- **BREAKING**: Set minimum Flutter version to 3.44.0. ([#1924](https://github.com/widgetbook/widgetbook/pull/1924))
 
 ## 3.23.0
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **BREAKING**: Set minimum SDK version to 3.12.0 & minimum Flutter version to 3.44.0. ([#1924](https://github.com/widgetbook/widgetbook/pull/1924))
+
 ## 3.23.0
 
 - **FEAT**: Add `defaultToNull` parameter to nullable knobs to make them start in a `null` _(i.e. unchecked)_ state while having a non-null initial value. ([#1790](https://github.com/widgetbook/widgetbook/pull/1790) - by [@youpelegrace](https://github.com/youpelegrace))

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -14,7 +14,7 @@ screenshots:
     path: assets/logo.webp
 
 environment:
-  sdk: ">=3.12.0 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
   flutter: ">=3.44.0"
 
 dependencies:

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -14,8 +14,8 @@ screenshots:
     path: assets/logo.webp
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.0"
+  sdk: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"
 
 dependencies:
   accessibility_tools: ^2.6.0

--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **BREAKING**: Set minimum SDK version to 3.11.0. ([#1924](https://github.com/widgetbook/widgetbook/pull/1924))
+
 ## 3.14.0
 
 - **REFACTOR**: Use `analyzer` 12.x. ([#1900](https://github.com/widgetbook/widgetbook/pull/1900))

--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -12,7 +12,7 @@ screenshots:
     path: assets/logo.webp
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
+  sdk: ">=3.11.0 <4.0.0"
 
 dependencies:
   analyzer: ^12.0.0


### PR DESCRIPTION
## Summary

- Bumps `min_flutter_version` from `3.38.1` to `3.44.1` (Dart 3.12.1) in all five package workflows so `check-min-version` jobs resolve `analyzer ^13.0.0` (which requires Dart 3.11+), unblocking #1923.
- Bumps `packages/widgetbook` minimum Flutter to `3.44.0` to support the newest Flutter, following the established cadence.
