### PR TITLE
chore(cli): bump xml to 7.x

### DIFF
--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **BREAKING**: Set minimum SDK version to 3.11.0. ([#1924](https://github.com/widgetbook/widgetbook/pull/1924))
 - **REFACTOR**: Use `analyzer` 13.x.
+- **REFACTOR**: Use `xml` 7.x.
 
 ## 3.14.0
 

--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   process: ^5.0.3
   pub_updater: ">=0.4.0 <1.0.0"
   retry: ^3.1.2
-  xml: ^6.5.0
+  xml: ^7.0.0
   yaml: ^3.1.2
 
 dev_dependencies:


### PR DESCRIPTION
## Summary

- Bumps `xml` from `^6.5.0` to `^7.0.0` in `widgetbook_cli`, fixing the pana `Support up-to-date dependencies` deduction that was failing the check (`--exit-code-threshold 0`).
- Reviewed the [xml 7.0.0 migration notes](https://pub.dev/packages/xml/changelog) — the breaking changes (deprecated `namespace` arguments → `namespaceUri`/`namespacePrefix`, lower-level parser namespace handling, node movement semantics) do not affect this package. The only usage is `XmlDocument.parse(body)` + `toXmlString(pretty: true, indent: '  ')` + `XmlParserException` in `lib/src/storage/storage_exception.dart`, none of which changed between 6.x and 7.x.
