### PR TITLE
refactor(widgetbook): replace Config.scenarios with Config.scenarioConfig

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -110,15 +110,17 @@ If you want to define global scenarios for all stories in you widgetbook, you ca
 ```dart
 final config = Config(
   // ...
-  scenarios: [
-    ScenarioDefinition(
-      name: 'Dark',
-      modes: [MaterialThemeMode('Dark', ThemeData.dark())],
-    ),
-    ScenarioDefinition(
-      name: 'Light',
-      modes: [MaterialThemeMode('Light', ThemeData.light())],
-    ),
-  ],
+  scenarioConfig: ScenarioConfig(
+    definitions: [
+      ScenarioDefinition(
+        name: 'Dark',
+        modes: [MaterialThemeMode('Dark', ThemeData.dark())],
+      ),
+      ScenarioDefinition(
+        name: 'Light',
+        modes: [MaterialThemeMode('Light', ThemeData.light())],
+      ),
+    ],
+  ),
 );
 ```

--- a/docs/testing/create-scenario.mdx
+++ b/docs/testing/create-scenario.mdx
@@ -116,7 +116,7 @@ final config = Config(
 
 Global scenario definitions are applied to every story. During execution, Widgetbook builds the effective list as:
 
-- all global scenario definitions from `config.scenarios`
+- all global scenario definitions from `config.scenarioConfig.definitions`
 - followed by local scenarios defined in the story
 
 Each global definition becomes its own scenario per story; global definitions are not merged into a single local scenario object.

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **BREAKING**: Replace `Config.scenarios` with `Config.scenarioConfig` of new type `ScenarioConfig`; see the [PR description](https://github.com/widgetbook/widgetbook/pull/1930) for migration steps. ([#1930](https://github.com/widgetbook/widgetbook/pull/1930))
 - **REFACTOR**: Allow `analyzer` 11.x and 12.x. ([#1900](https://github.com/widgetbook/widgetbook/pull/1900))
 - **FIX**: Preserve story definition order in navigation panel instead of sorting alphabetically. ([#1897](https://github.com/widgetbook/widgetbook/pull/1897))
 - **BREAKING**: Rename `SetupBuilder`'s second parameter from `TWidget widget` to `Widget child`, enabling `InheritedWidget`s injected by `setup` to be resolved in the story `builder`'s `BuildContext`. ([#1896](https://github.com/widgetbook/widgetbook/pull/1896))

--- a/packages/widgetbook/lib/src/core/framework/config.dart
+++ b/packages/widgetbook/lib/src/core/framework/config.dart
@@ -60,7 +60,7 @@ class Config {
     this.themeMode = ThemeMode.system,
     this.header,
     this.scrollBehavior = const MaterialScrollBehavior(),
-    this.scenarios = const [],
+    this.scenarioConfig = const ScenarioConfig(),
     this.docsBuilder = defaultDocsBuilder,
   });
 
@@ -70,9 +70,11 @@ class Config {
   /// The list of [Component]s that will be displayed in Widgetbook.
   final List<Component> components;
 
-  /// For each [ScenarioDefinition] a [Scenario] will be created for every
-  /// [Story] of every [Component].
-  final List<ScenarioDefinition> scenarios;
+  /// Global [ScenarioConfig] applied to every [Story] of every [Component].
+  ///
+  /// Each [ScenarioDefinition] in [ScenarioConfig.definitions] becomes a
+  /// [Scenario] on every [Story].
+  final ScenarioConfig scenarioConfig;
 
   /// A wrapper builder method for all [Component]s.
   final AppBuilder appBuilder;

--- a/packages/widgetbook/lib/src/core/framework/framework.dart
+++ b/packages/widgetbook/lib/src/core/framework/framework.dart
@@ -9,6 +9,7 @@ export 'integration.dart';
 export 'meta.dart';
 export 'mode.dart';
 export 'scenario.dart';
+export 'scenario_config.dart';
 export 'scenario_definition.dart';
 export 'story.dart';
 export 'story_args.dart';

--- a/packages/widgetbook/lib/src/core/framework/scenario_config.dart
+++ b/packages/widgetbook/lib/src/core/framework/scenario_config.dart
@@ -1,0 +1,23 @@
+/// @docImport 'config.dart';
+library;
+
+import 'component.dart';
+import 'scenario.dart';
+import 'scenario_definition.dart';
+import 'story.dart';
+
+/// Configuration applied to every [Scenario] discovered from a [Config].
+///
+/// Currently exposes [definitions] that are expanded into a [Scenario] for
+/// every [Story] of every [Component]. Acts as the home for future
+/// scenario-level configuration.
+class ScenarioConfig {
+  const ScenarioConfig({
+    this.definitions = const [],
+  });
+
+  /// [ScenarioDefinition]s applied to every [Story] of every [Component].
+  ///
+  /// For each definition, a [Scenario] is created on every [Story].
+  final List<ScenarioDefinition> definitions;
+}

--- a/packages/widgetbook/lib/src/core/framework/story.dart
+++ b/packages/widgetbook/lib/src/core/framework/story.dart
@@ -201,7 +201,7 @@ abstract class Story<TWidget extends Widget, TArgs extends StoryArgs<TWidget>> {
   /// If no scenarios are defined, a default scenario is returned.
   List<Scenario<TWidget, TArgs>> allScenarios(Config config) {
     final localScenarios = scenarios;
-    final globalScenarios = config.scenarios.map(
+    final globalScenarios = config.scenarioConfig.definitions.map(
       (definition) => Scenario<TWidget, TArgs>(
         type: ScenarioType.global,
         name: definition.name,

--- a/sandbox/lib/widgetbook.config.dart
+++ b/sandbox/lib/widgetbook.config.dart
@@ -46,26 +46,28 @@ final config = Config(
     ),
     SemanticsAddon(),
   ],
-  scenarios: [
-    ScenarioDefinition(
-      name: 'Dark',
-      modes: [
-        ThemeMode<MultiThemeData>(
-          'Dark',
-          multiDarkTheme,
-          multiThemeBuilder,
-        ),
-      ],
-    ),
-    ScenarioDefinition(
-      name: 'Light',
-      modes: [
-        ThemeMode<MultiThemeData>(
-          'Light',
-          multiLightTheme,
-          multiThemeBuilder,
-        ),
-      ],
-    ),
-  ],
+  scenarioConfig: ScenarioConfig(
+    definitions: [
+      ScenarioDefinition(
+        name: 'Dark',
+        modes: [
+          ThemeMode<MultiThemeData>(
+            'Dark',
+            multiDarkTheme,
+            multiThemeBuilder,
+          ),
+        ],
+      ),
+      ScenarioDefinition(
+        name: 'Light',
+        modes: [
+          ThemeMode<MultiThemeData>(
+            'Light',
+            multiLightTheme,
+            multiThemeBuilder,
+          ),
+        ],
+      ),
+    ],
+  ),
 );


### PR DESCRIPTION
## Summary

- Introduces `ScenarioConfig` to hold scenario-level configuration on `Config`.
- Replaces `Config.scenarios: List<ScenarioDefinition>` with `Config.scenarioConfig: ScenarioConfig`, moving the previous list to `ScenarioConfig.definitions`.

### Migration

```dart
// before
Config(
  scenarios: [
    ScenarioDefinition(name: 'Dark', modes: [...]),
  ],
)

// after
Config(
  scenarioConfig: ScenarioConfig(
    definitions: [
      ScenarioDefinition(name: 'Dark', modes: [...]),
    ],
  ),
)
```
