### PR TITLE
feat(widgetbook): add `wrapper` callback to `ScenarioConfig`

### DIFF
--- a/docs/testing/run-scenarios.mdx
+++ b/docs/testing/run-scenarios.mdx
@@ -78,6 +78,31 @@ final config = Config(
 
 The hooks fire for every scenario across every component and story when run via `testWidgetbook(config)`.
 
+## Wrapping Scenario Execution
+
+`Config.scenarioConfig` also accepts an optional `wrapper` callback that wraps the *entire* execution of every scenario — pumping the widget, `setUp`, the scenario's `run` callback, the snapshot capture, and `tearDown`. It receives the active `WidgetTester`, the current `Scenario`, and a `body` callback that performs all of the above; it must await `body` exactly once.
+
+Unlike `setUp`, which runs after the scenario's widget has already been pumped, the `wrapper` is on the call stack *before* the first frame is built. This makes it the right place for `Zone`-scoped configuration that must be visible inside your widgets' `build` methods — such as faking time with [`package:clock`](https://pub.dev/packages/clock), overriding `HttpOverrides`, or setting `Intl.defaultLocale`.
+
+For example, to render every scenario at a fixed point in time (so widgets calling `clock.now()` produce deterministic snapshots):
+
+```dart
+import 'package:clock/clock.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import 'components.g.dart';
+
+final config = Config(
+  components: components,
+  scenarioConfig: ScenarioConfig(
+    wrapper: (tester, scenario, body) =>
+        withClock(Clock.fixed(DateTime(2024, 6, 15)), body),
+  ),
+);
+```
+
+Note that wrapping `testWidgetbook(config)` itself in `withClock` does **not** work: the test framework executes each test body in its own `Zone`, which is not a child of the `Zone` that declared the tests. The `wrapper` hook exists precisely to re-apply your `Zone` setup inside each test body. For the same reason, addons cannot fake `clock.now()` — they inject widgets into the tree, while `package:clock` reads from the call stack.
+
 ## Generated Snapshot Artifacts
 
 By default, artifacts are written to:

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FEAT**: Add `wrapper` callback to `ScenarioConfig` that wraps each scenario's entire execution in `testWidgetbook`, enabling `Zone`-scoped setup such as faking time with `package:clock`. ([#1932](https://github.com/widgetbook/widgetbook/pull/1932))
+
 ## 4.0.0-beta.4
 
 - **BREAKING**: `ScenarioDefinition`s now cross with each story's local scenarios by default (`ScenarioStrategy.perScenario`), replacing the bare local scenarios with crossed variants. Use `strategy: ScenarioStrategy.perStory` for the previous standalone behavior. ([#1918](https://github.com/widgetbook/widgetbook/pull/1918) - by [@ABausG](https://github.com/ABausG))

--- a/packages/widgetbook/lib/src/core/framework/scenario_config.dart
+++ b/packages/widgetbook/lib/src/core/framework/scenario_config.dart
@@ -54,6 +54,17 @@ String defaultScenarioNameBuilder(
       : '${scenario.name} $scenarioNameSeparator ${definition.name}';
 }
 
+/// Callback wrapping the entire execution of a [Scenario] during
+/// [testWidgetbook].
+///
+/// Implementations must await `body` exactly once.
+typedef ScenarioWrapper =
+    Future<void> Function(
+      WidgetTester tester,
+      Scenario scenario,
+      Future<void> Function() body,
+    );
+
 /// Configuration applied to every [Scenario] discovered from a [Config].
 ///
 /// Exposes [definitions] that are expanded into [Scenario]s for every
@@ -65,6 +76,7 @@ class ScenarioConfig {
     this.nameBuilder = defaultScenarioNameBuilder,
     this.setUp,
     this.tearDown,
+    this.wrapper,
   });
 
   /// [ScenarioDefinition]s applied to every [Story] of every [Component],
@@ -90,4 +102,19 @@ class ScenarioConfig {
   /// Use it to reset state mutated by [setUp] or the scenario itself. Only
   /// applied during [testWidgetbook].
   final ScenarioCallback? tearDown;
+
+  /// Wraps the entire execution of each [Scenario]. Only applied during
+  /// [testWidgetbook].
+  ///
+  /// Since the wrapper stays on the call stack while the scenario runs,
+  /// `Zone`-scoped configuration becomes visible to the widgets, e.g.
+  /// faking time with `package:clock`:
+  ///
+  /// ```dart
+  /// ScenarioConfig(
+  ///   wrapper: (tester, scenario, body) =>
+  ///     withClock(Clock.fixed(DateTime(2024, 6, 15)), body),
+  /// )
+  /// ```
+  final ScenarioWrapper? wrapper;
 }

--- a/packages/widgetbook/lib/src/test/test.dart
+++ b/packages/widgetbook/lib/src/test/test.dart
@@ -54,60 +54,68 @@ void testScenario(
 
       final semanticsHandle = tester.binding.ensureSemantics();
 
-      final key = UniqueKey();
-      await tester.pumpWidget(
-        Builder(
-          key: key,
-          builder: (context) => scenario.buildWithConfig(context, config),
-        ),
-      );
-
-      await config.scenarioConfig.setUp?.call(tester, scenario);
-
-      await scenario.execute(tester);
-
-      final element = tester.element(find.byKey(key));
-      final imageFuture = captureImage(element, 1);
-
-      final semanticsNode = tester.getSemantics(find.byKey(key));
-
-      // Run on separate isolate as async operations cannot be run inside
-      // testWidgets directly.
-      final binding = TestWidgetsFlutterBinding.instance;
-      await binding.runAsync(() async {
-        final image = await imageFuture;
-        final byteData = await image.toByteData(format: ImageByteFormat.png);
-        final imageBytes = byteData!.buffer.asUint8List();
-
-        final jsonEncoder = const JsonEncoder.withIndent('  ');
-
-        final semanticsData = SemanticsTreeSerializer.toJson(
-          semanticsNode,
-        );
-
-        final metadata = ScenarioMetadata(
-          scenario: scenario,
-          imageBytes: imageBytes,
-          imageWidth: image.width,
-          imageHeight: image.height,
-          pixelRatio: targetViewport.pixelRatio,
-          semanticsData: semanticsData,
-        );
-
-        await metadata.directory.create(recursive: true);
-
-        await Future.wait([
-          metadata.imageFile.writeAsBytes(imageBytes, flush: true),
-          metadata.jsonFile.writeAsString(
-            jsonEncoder.convert(metadata),
-            flush: true,
+      Future<void> body() async {
+        final key = UniqueKey();
+        await tester.pumpWidget(
+          Builder(
+            key: key,
+            builder: (context) => scenario.buildWithConfig(context, config),
           ),
-        ]);
+        );
 
-        image.dispose();
-      });
+        await config.scenarioConfig.setUp?.call(tester, scenario);
 
-      await config.scenarioConfig.tearDown?.call(tester, scenario);
+        await scenario.execute(tester);
+
+        final element = tester.element(find.byKey(key));
+        final imageFuture = captureImage(element, 1);
+
+        final semanticsNode = tester.getSemantics(find.byKey(key));
+
+        // Run on separate isolate as async operations cannot be run inside
+        // testWidgets directly.
+        final binding = TestWidgetsFlutterBinding.instance;
+        await binding.runAsync(() async {
+          final image = await imageFuture;
+          final byteData = await image.toByteData(format: ImageByteFormat.png);
+          final imageBytes = byteData!.buffer.asUint8List();
+
+          final jsonEncoder = const JsonEncoder.withIndent('  ');
+
+          final semanticsData = SemanticsTreeSerializer.toJson(
+            semanticsNode,
+          );
+
+          final metadata = ScenarioMetadata(
+            scenario: scenario,
+            imageBytes: imageBytes,
+            imageWidth: image.width,
+            imageHeight: image.height,
+            pixelRatio: targetViewport.pixelRatio,
+            semanticsData: semanticsData,
+          );
+
+          await metadata.directory.create(recursive: true);
+
+          await Future.wait([
+            metadata.imageFile.writeAsBytes(imageBytes, flush: true),
+            metadata.jsonFile.writeAsString(
+              jsonEncoder.convert(metadata),
+              flush: true,
+            ),
+          ]);
+
+          image.dispose();
+        });
+
+        await config.scenarioConfig.tearDown?.call(tester, scenario);
+      }
+
+      // The wrapper must already be on the call stack when the widget is
+      // pumped, so that Zone values (e.g. package:clock's clock) are visible
+      // to the build methods of the scenario's widget tree.
+      final wrapper = config.scenarioConfig.wrapper;
+      await (wrapper == null ? body() : wrapper(tester, scenario, body));
 
       semanticsHandle.dispose();
       addTearDown(tester.view.reset);

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
 
 dev_dependencies:
   build_test: ^3.0.0
+  clock: ^1.1.1
   mocktail: ^1.0.0
   package_config: ^2.1.0
   test: ^1.24.0

--- a/packages/widgetbook/test/core/config/scenario_config/wrapper_test.dart
+++ b/packages/widgetbook/test/core/config/scenario_config/wrapper_test.dart
@@ -1,0 +1,76 @@
+import 'package:clock/clock.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/test.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+/// Renders the current time.
+///
+/// Uses `clock.now()` from `package:clock`, which returns `DateTime.now()`
+/// unless a fake clock is installed through the current `Zone` — calling
+/// `DateTime.now()` directly could not be faked.
+class _TimeText extends StatelessWidget {
+  const _TimeText();
+
+  @override
+  Widget build(BuildContext context) {
+    return Text('${clock.now()}');
+  }
+}
+
+class _TimeTextArgs extends StoryArgs<_TimeText> {
+  const _TimeTextArgs();
+
+  @override
+  List<Arg?> get list => const [];
+}
+
+class _TimeTextStory extends Story<_TimeText, _TimeTextArgs> {
+  _TimeTextStory({super.scenarios})
+    : super(
+        name: 'Default',
+        args: const _TimeTextArgs(),
+        builder: (context, args) => const _TimeText(),
+      );
+}
+
+void main() {
+  group(
+    '$ScenarioConfig.wrapper',
+    () {
+      final fakeTime = DateTime(2000);
+
+      // The scenario's name and `run` callback become the description and
+      // body of the `testWidgets` test that [testScenario] declares below;
+      // pumping the story happens inside [testScenario] itself.
+      final scenario = Scenario<_TimeText, _TimeTextArgs>(
+        name:
+            'given a wrapper with a fake clock, '
+            'then the story renders the fake time',
+        run: (tester, args) async {
+          expect(
+            find.text('$fakeTime'),
+            findsOneWidget,
+          );
+        },
+      );
+
+      final config = Config(
+        components: [
+          Component<_TimeText, _TimeTextArgs>(
+            name: 'TimeText',
+            stories: [
+              _TimeTextStory(scenarios: [scenario]),
+            ],
+          ),
+        ],
+        scenarioConfig: ScenarioConfig(
+          wrapper: (tester, scenario, body) =>
+              withClock(Clock.fixed(fakeTime), body),
+        ),
+      );
+
+      testScenario(config, scenario);
+    },
+  );
+}


### PR DESCRIPTION
In Widgetbook 3, users could fake time for all use cases by wrapping `runApp`
in `withClock(...)` from `package:clock`. In Widgetbook 4's test-based flow
this no longer works: `testWidgetbook` only *declares* tests, and the test
runner executes each body in a zone that is not a child of the declaration
zone. Additionally, `flutter_test` installs its own clock via `FakeAsync`,
and addons can't help since they inject widgets into the tree while
`package:clock` resolves through the call stack (`Zone`).

This PR adds a `wrapper` callback to `ScenarioConfig` (alongside `setUp` and
`tearDown` from #1917). It wraps each scenario's entire execution (pumping,
`setUp`, the scenario's `run`, the snapshot capture, and `tearDown`) inside
the `testWidgets` body, so `Zone`-scoped setup applies to the widgets:

```dart
final config = Config(
  components: components,
  scenarioConfig: ScenarioConfig(
    wrapper: (tester, scenario, body) =>
        withClock(Clock.fixed(DateTime(2024, 6, 15)), body),
  ),
);
```

Besides `package:clock`, the same hook covers `HttpOverrides`,
`Intl.defaultLocale`, or any other `Zone`-scoped configuration.
