### PR TITLE
chore: release v4.0.0-beta.6

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -37,8 +37,8 @@
   },
   "variables": {
     "versions": {
-      "cli": "4.0.0-beta.5",
-      "widgetbook": "4.0.0-beta.4"
+      "cli": "4.0.0-beta.6",
+      "widgetbook": "4.0.0-beta.6"
     }
   },
   "tabs": [

--- a/examples/feature_preview/pubspec.lock
+++ b/examples/feature_preview/pubspec.lock
@@ -579,7 +579,7 @@ packages:
       path: "../../packages/widgetbook"
       relative: true
     source: path
-    version: "4.0.0-beta.4"
+    version: "4.0.0-beta.6"
   yaml:
     dependency: transitive
     description:

--- a/examples/feature_preview/pubspec.yaml
+++ b/examples/feature_preview/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  widgetbook: ^4.0.0-beta.4
+  widgetbook: ^4.0.0-beta.6
 
 dev_dependencies:
   build_runner: ^2.10.1

--- a/examples/full_example/pubspec.lock
+++ b/examples/full_example/pubspec.lock
@@ -579,7 +579,7 @@ packages:
       path: "../../packages/widgetbook"
       relative: true
     source: path
-    version: "4.0.0-beta.4"
+    version: "4.0.0-beta.6"
   yaml:
     dependency: transitive
     description:

--- a/examples/full_example/pubspec.yaml
+++ b/examples/full_example/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  widgetbook: ^4.0.0-beta.4
+  widgetbook: ^4.0.0-beta.6
 
 dev_dependencies:
   build_runner: ^2.10.1

--- a/examples/monorepo_example/widgetbook/pubspec.lock
+++ b/examples/monorepo_example/widgetbook/pubspec.lock
@@ -586,7 +586,7 @@ packages:
       path: "../../../packages/widgetbook"
       relative: true
     source: path
-    version: "4.0.0-beta.4"
+    version: "4.0.0-beta.6"
   yaml:
     dependency: transitive
     description:

--- a/examples/monorepo_example/widgetbook/pubspec.yaml
+++ b/examples/monorepo_example/widgetbook/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   shared_ui:
     path: ../packages/shared_ui
-  widgetbook: ^4.0.0-beta.4
+  widgetbook: ^4.0.0-beta.6
 
 dev_dependencies:
   build_runner: ^2.10.1

--- a/examples/screen_util_example/pubspec.lock
+++ b/examples/screen_util_example/pubspec.lock
@@ -587,7 +587,7 @@ packages:
       path: "../../packages/widgetbook"
       relative: true
     source: path
-    version: "4.0.0-beta.4"
+    version: "4.0.0-beta.6"
   yaml:
     dependency: transitive
     description:

--- a/examples/screen_util_example/pubspec.yaml
+++ b/examples/screen_util_example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   # they are using `View.of` instead of `MediaQuery.of`
   # https://github.com/OpenFlutter/flutter_screenutil/commit/f7c551acd4cc82460c3a29ec5a7262d6ec678746
   flutter_screenutil: 5.9.1
-  widgetbook: ^4.0.0-beta.4
+  widgetbook: ^4.0.0-beta.6
 
 dev_dependencies:
   build_runner: ^2.10.1

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-beta.6
+
+- **CHORE**: Sync version with `widgetbook_cli`; `widgetbook` has no `4.0.0-beta.5` release, so it jumps from `4.0.0-beta.4` to `4.0.0-beta.6` to keep both packages on the same version.
+
 ## 4.0.0-beta.4
 
 - **BREAKING**: `ScenarioDefinition`s now cross with each story's local scenarios by default (`ScenarioStrategy.perScenario`), replacing the bare local scenarios with crossed variants. Use `strategy: ScenarioStrategy.perStory` for the previous standalone behavior. ([#1918](https://github.com/widgetbook/widgetbook/pull/1918) - by [@ABausG](https://github.com/ABausG))

--- a/packages/widgetbook/lib/metadata.dart
+++ b/packages/widgetbook/lib/metadata.dart
@@ -1,2 +1,2 @@
 /// The version as in pubspec.yaml
-const kWidgetbookVersion = '4.0.0-beta.4';
+const kWidgetbookVersion = '4.0.0-beta.6';

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -2,7 +2,7 @@ name: widgetbook
 description: >-
   Widgetbook is a sandbox for building widgets and screens in isolation.
   It helps you develop hard-to-reach states and edge cases without needing to run your app.
-version: 4.0.0-beta.4
+version: 4.0.0-beta.6
 homepage: https://www.widgetbook.io?utm_source=pub.dev&utm_medium=link&utm_campaign=widgetbook
 repository: https://github.com/widgetbook/widgetbook/tree/main/packages/widgetbook
 issue_tracker: https://github.com/widgetbook/widgetbook/issues

--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-beta.6
+
+- **CHORE**: Align version with `widgetbook` so both packages are released as `4.0.0-beta.6`.
+
 ## 4.0.0-beta.5
 
 - **FEAT**: Stream snapshots to Widgetbook Cloud in batches during `cloud build push` to support large builds. ([#1935](https://github.com/widgetbook/widgetbook/pull/1935))

--- a/packages/widgetbook_cli/lib/metadata.dart
+++ b/packages/widgetbook_cli/lib/metadata.dart
@@ -8,7 +8,7 @@ const cliDescription = 'Widgetbook CLI';
 const packageName = 'widgetbook_cli';
 
 /// The version as in pubspec.yaml
-const packageVersion = '4.0.0-beta.5';
+const packageVersion = '4.0.0-beta.6';
 
 /// The widgetbook package version to install via `widgetbook init`
-const widgetbookVersion = '4.0.0-beta.4';
+const widgetbookVersion = '4.0.0-beta.6';

--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widgetbook_cli
 description: CLI that can publish Widgetbook builds and reviews to Widgetbook Cloud.
-version: 4.0.0-beta.5
+version: 4.0.0-beta.6
 homepage: https://www.widgetbook.io?utm_source=pub.dev&utm_medium=link&utm_campaign=widgetbook_cli
 repository: https://github.com/widgetbook/widgetbook/tree/main/packages/widgetbook_cli
 issue_tracker: https://github.com/widgetbook/widgetbook/issues

--- a/sandbox/pubspec.lock
+++ b/sandbox/pubspec.lock
@@ -579,7 +579,7 @@ packages:
       path: "../packages/widgetbook"
       relative: true
     source: path
-    version: "4.0.0-beta.4"
+    version: "4.0.0-beta.6"
   yaml:
     dependency: transitive
     description:

--- a/sandbox/pubspec.yaml
+++ b/sandbox/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  widgetbook: ^4.0.0-beta.4
+  widgetbook: ^4.0.0-beta.6
 
 dev_dependencies:
   build_runner: ^2.10.1


### PR DESCRIPTION
Releases **widgetbook** and **widgetbook_cli** together so both packages share the same version going forward.

## Versions

| Package | Before | After |
| --- | --- | --- |
| `widgetbook` | `4.0.0-beta.4` | `4.0.0-beta.6` |
| `widgetbook_cli` | `4.0.0-beta.5` | `4.0.0-beta.6` |

`widgetbook` has no `4.0.0-beta.5` release — it jumps from `beta.4` to `beta.6` to stay in sync with `widgetbook_cli`. A `**CHORE**` changelog entry documents the sync in both packages.

## Changes

- Bumped `version` in both packages' `pubspec.yaml` and the `metadata.dart` version constants (incl. the `widgetbook init` target version).
- Added `## 4.0.0-beta.6` changelog sections (sync notes).
- Updated `docs.json` version variables.
- Bumped the `widgetbook` constraint + path-resolved lockfile version in example/sandbox apps.