### PR TITLE
docs: supply required `args` in Quick Start story examples

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -66,8 +66,21 @@ part 'custom_button.stories.g.dart';
 
 const meta = Meta(CustomButton.new);
 
-final $Default = _Story();  // [!code highlight]
+final $Default = _Story(
+  args: _Args(  // [!code highlight]
+    label: StringArg('Button'),  // [!code highlight]
+    onPressed: Arg.fixed(() {}),  // [!code highlight]
+  ),  // [!code highlight]
+);
 ```
+
+The generated `_Args` class holds one entry per widget parameter. Any parameter
+without a usable default — like `CustomButton`'s required `onPressed` callback —
+must be supplied through `args`, so a bare `_Story()` will not compile for this
+widget. Wrap a value in an [Arg](/args/overview) type such as `StringArg` to expose
+it as an adjustable knob in Widgetbook's UI, or in `Arg.fixed(...)` to pin it
+(handy for callbacks). Widgets whose parameters are all optional or have defaults
+can still use `_Story()` with no `args`.
 
 ## Create your first Scenario
 
@@ -82,6 +95,10 @@ part 'custom_button.stories.g.dart';
 const meta = Meta(CustomButton.new);
 
 final $Default = _Story(
+  args: _Args(  // [!code highlight]
+    label: StringArg('Button'),  // [!code highlight]
+    onPressed: Arg.fixed(() {}),  // [!code highlight]
+  ),  // [!code highlight]
   scenarios: [
     _Scenario(
       name: 'Long Label',


### PR DESCRIPTION
## Problem

The v4 Quick Start shows the `CustomButton` story as:

```dart
final $Default = _Story();
```

and the scenario example as `_Story(scenarios: [...])` — both without `args`.
Neither compiles for `CustomButton`:

```
error • The named parameter 'args' is required, but there's no corresponding argument • missing_required_argument
```

`CustomButton.onPressed` is a `VoidCallback` — non-primitive, non-nullable, and
has no default — so `requiresArg` is true and the generated `_Story` declares
`required super.args`. (This is by design and not new: beta.4 generates the same
`required super.args`; the docs example just never supplied it.)

## Fix

Docs-only. Provide `args: _Args(...)` in both Quick Start story snippets and add
a short note explaining when `args` is required and when a bare `_Story()` is
still valid (widgets whose parameters are all optional or have defaults).

The corrected snippets were verified to generate and pass `flutter test` against
`widgetbook 4.0.0-beta.7` (Flutter 3.44 / Dart 3.12).

## Notes

- Docs-only change — no package code touched, so no CHANGELOG entry.