### PR TITLE
fix(generator): assign `$generatedName` to fixed args

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Assign `$generatedName` to args created via the generated `_Args.fixed(...)` constructor, mirroring the default constructor. Reading `arg.name` on a fixed arg (e.g. when the UI renders a scenario's args table) no longer throws a `LateInitializationError`. ([#1947](https://github.com/widgetbook/widgetbook/pull/1947))
+
 ## 4.0.0-beta.7
 
 - **BREAKING**: Support multiple constructors per component via one `Meta` per constructor tear-off. See the [PR description](https://github.com/widgetbook/widgetbook/pull/1931) for migration steps. ([#1931](https://github.com/widgetbook/widgetbook/pull/1931))

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **FIX**: Assign `$generatedName` to args created via the generated `_Args.fixed(...)` constructor, mirroring the default constructor. Reading `arg.name` on a fixed arg (e.g. when the UI renders a scenario's args table) no longer throws a `LateInitializationError`. ([#1947](https://github.com/widgetbook/widgetbook/pull/1947))
+- **FIX**: Assign `$generatedName` to args created via the generated `_Args.fixed(...)` constructor, mirroring the default constructor. ([#1947](https://github.com/widgetbook/widgetbook/pull/1947))
 
 ## 4.0.0-beta.7
 

--- a/packages/widgetbook/lib/src/generator/framework/args_class_builder.dart
+++ b/packages/widgetbook/lib/src/generator/framework/args_class_builder.dart
@@ -76,42 +76,57 @@ class ArgsClassBuilder {
                 ),
               )
               ..initializers.addAll(
-                params.map(
-                  (param) => refer('this')
+                params.map((param) {
+                  final fixedValue = param.type.isNullable
+                      ? refer(param.displayName)
+                            .equalTo(literalNull)
+                            .conditional(
+                              literalNull,
+                              InvokeExpression.newOf(
+                                refer('Arg.fixed'),
+                                [refer(param.displayName)],
+                              ),
+                            )
+                      : InvokeExpression.newOf(
+                          refer('Arg.fixed'),
+                          switch (param) {
+                            // For non-constant value, like DateTime.now()
+                            // they are initialized here instead of the
+                            // default value of the parameter
+                            _
+                                when param.type.isPrimitive &&
+                                    !param.type.meta.isConst =>
+                              [
+                                refer(
+                                  param.displayName,
+                                ).ifNullThen(
+                                  param.type.meta.defaultValue,
+                                ),
+                              ],
+                            _ => [refer(param.displayName)],
+                          },
+                        );
+
+                  // Route the fixed value through `$initArg` so the Arg's
+                  // `$generatedName` is assigned, mirroring the default
+                  // constructor. Without this, reading `arg.name` on a fixed
+                  // arg throws a LateInitializationError (e.g. when the UI
+                  // renders a scenario's args table).
+                  final initialized = refer('\$initArg').call([
+                    literalString(param.displayName),
+                    fixedValue,
+                    literalNull,
+                  ]);
+
+                  return refer('this')
                       .property('${param.displayName}Arg')
                       .assign(
                         param.type.isNullable
-                            ? refer(param.displayName)
-                                  .equalTo(literalNull)
-                                  .conditional(
-                                    literalNull,
-                                    InvokeExpression.newOf(
-                                      refer('Arg.fixed'),
-                                      [refer(param.displayName)],
-                                    ),
-                                  )
-                            : InvokeExpression.newOf(
-                                refer('Arg.fixed'),
-                                switch (param) {
-                                  // For non-constant value, like DateTime.now()
-                                  // they are initialized here instead of the
-                                  // default value of the parameter
-                                  _
-                                      when param.type.isPrimitive &&
-                                          !param.type.meta.isConst =>
-                                    [
-                                      refer(
-                                        param.displayName,
-                                      ).ifNullThen(
-                                        param.type.meta.defaultValue,
-                                      ),
-                                    ],
-                                  _ => [refer(param.displayName)],
-                                },
-                              ),
+                            ? initialized
+                            : initialized.nullChecked,
                       )
-                      .code,
-                ),
+                      .code;
+                }),
               ),
           ),
         ])

--- a/packages/widgetbook/lib/src/generator/framework/args_class_builder.dart
+++ b/packages/widgetbook/lib/src/generator/framework/args_class_builder.dart
@@ -107,11 +107,9 @@ class ArgsClassBuilder {
                           },
                         );
 
-                  // Route the fixed value through `$initArg` so the Arg's
-                  // `$generatedName` is assigned, mirroring the default
-                  // constructor. Without this, reading `arg.name` on a fixed
-                  // arg throws a LateInitializationError (e.g. when the UI
-                  // renders a scenario's args table).
+                  // Route through `$initArg` (like the default constructor) so
+                  // the arg's name is assigned; otherwise reading `Arg.name` on
+                  // a fixed arg throws a LateInitializationError.
                   final initialized = refer('\$initArg').call([
                     literalString(param.displayName),
                     fixedValue,

--- a/packages/widgetbook/test/core/framework/fixed_args_name_test.dart
+++ b/packages/widgetbook/test/core/framework/fixed_args_name_test.dart
@@ -30,8 +30,7 @@ void main() {
     });
 
     test(
-      '`.fixed` constructor exposes parameter names too '
-      '(currently FAILS — reproduces #1)',
+      '`.fixed` constructor exposes parameter names too (regression for #1)',
       () {
         final args = PrimitiveWidgetArgs.fixed(
           label: 'Hello',
@@ -40,8 +39,9 @@ void main() {
         );
 
         // This is exactly what `ResponsiveLayout.buildScenarioInfo` does when
-        // it renders the "Args" table for a scenario/story. It throws today
-        // because `$generatedName` was never initialized for fixed args.
+        // it renders the "Args" table for a scenario/story. Before the fix it
+        // threw a LateInitializationError because `$generatedName` was never
+        // assigned for fixed args.
         final names =
             args.list.whereType<Arg>().map((arg) => arg.name).toList();
 

--- a/packages/widgetbook/test/core/framework/fixed_args_name_test.dart
+++ b/packages/widgetbook/test/core/framework/fixed_args_name_test.dart
@@ -1,27 +1,16 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widgetbook/widgetbook.dart';
 
-// Drives the *generated* args class of an existing generator fixture, so this
-// test is tied to real generator output rather than a hand-written mimic. When
-// the generator is fixed (and goldens are regenerated), `PrimitiveWidgetArgs`
-// here updates automatically and the failing test below turns green.
+// Uses a generated args class from the generator fixtures, so the test runs
+// against real generator output.
 import '../../generator/primitive/primitive.stories.dart';
 
 void main() {
-  // Reproduces issue #1: building a story/scenario with the generated
-  // `_Args.fixed(...)` constructor and then reading an arg's `name` throws
-  //
-  //   LateInitializationError: Field '$generatedName' has not been initialized.
-  //     Arg.name           (lib/src/core/framework/arg.dart)
-  //     ResponsiveLayout.buildScenarioInfo
-  //       (lib/src/core/layout/responsive_layout.dart)
-  //
-  // Root cause: the generated `.fixed` constructor assigns each field with a
-  // bare `Arg.fixed(value)` (-> `ConstArg`, whose `_name` is null) and never
-  // routes through `$initArg(...)`, which is what assigns `$generatedName`.
-  // The default constructor does call `$initArg(...)`, so its args are fine.
+  // `StoryArgs.list` includes args from both the default and `.fixed`
+  // constructors, and the UI reads `Arg.name` for each of them (e.g. to label
+  // a scenario's args). So `name` must resolve for both.
   group('Arg.name for generated StoryArgs', () {
-    test('default constructor exposes parameter names (control)', () {
+    test('default constructor exposes parameter names', () {
       final args = PrimitiveWidgetArgs();
 
       final names = args.list.whereType<Arg>().map((arg) => arg.name).toList();
@@ -29,24 +18,16 @@ void main() {
       expect(names, containsAll(['label', 'count', 'isActive']));
     });
 
-    test(
-      '`.fixed` constructor exposes parameter names too (regression for #1)',
-      () {
-        final args = PrimitiveWidgetArgs.fixed(
-          label: 'Hello',
-          count: 1,
-          isActive: true,
-        );
+    test('fixed constructor exposes parameter names', () {
+      final args = PrimitiveWidgetArgs.fixed(
+        label: 'Hello',
+        count: 1,
+        isActive: true,
+      );
 
-        // This is exactly what `ResponsiveLayout.buildScenarioInfo` does when
-        // it renders the "Args" table for a scenario/story. Before the fix it
-        // threw a LateInitializationError because `$generatedName` was never
-        // assigned for fixed args.
-        final names =
-            args.list.whereType<Arg>().map((arg) => arg.name).toList();
+      final names = args.list.whereType<Arg>().map((arg) => arg.name).toList();
 
-        expect(names, containsAll(['label', 'count', 'isActive']));
-      },
-    );
+      expect(names, containsAll(['label', 'count', 'isActive']));
+    });
   });
 }

--- a/packages/widgetbook/test/core/framework/fixed_args_name_test.dart
+++ b/packages/widgetbook/test/core/framework/fixed_args_name_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+// Drives the *generated* args class of an existing generator fixture, so this
+// test is tied to real generator output rather than a hand-written mimic. When
+// the generator is fixed (and goldens are regenerated), `PrimitiveWidgetArgs`
+// here updates automatically and the failing test below turns green.
+import '../../generator/primitive/primitive.stories.dart';
+
+void main() {
+  // Reproduces issue #1: building a story/scenario with the generated
+  // `_Args.fixed(...)` constructor and then reading an arg's `name` throws
+  //
+  //   LateInitializationError: Field '$generatedName' has not been initialized.
+  //     Arg.name           (lib/src/core/framework/arg.dart)
+  //     ResponsiveLayout.buildScenarioInfo
+  //       (lib/src/core/layout/responsive_layout.dart)
+  //
+  // Root cause: the generated `.fixed` constructor assigns each field with a
+  // bare `Arg.fixed(value)` (-> `ConstArg`, whose `_name` is null) and never
+  // routes through `$initArg(...)`, which is what assigns `$generatedName`.
+  // The default constructor does call `$initArg(...)`, so its args are fine.
+  group('Arg.name for generated StoryArgs', () {
+    test('default constructor exposes parameter names (control)', () {
+      final args = PrimitiveWidgetArgs();
+
+      final names = args.list.whereType<Arg>().map((arg) => arg.name).toList();
+
+      expect(names, containsAll(['label', 'count', 'isActive']));
+    });
+
+    test(
+      '`.fixed` constructor exposes parameter names too '
+      '(currently FAILS — reproduces #1)',
+      () {
+        final args = PrimitiveWidgetArgs.fixed(
+          label: 'Hello',
+          count: 1,
+          isActive: true,
+        );
+
+        // This is exactly what `ResponsiveLayout.buildScenarioInfo` does when
+        // it renders the "Args" table for a scenario/story. It throws today
+        // because `$generatedName` was never initialized for fixed args.
+        final names =
+            args.list.whereType<Arg>().map((arg) => arg.name).toList();
+
+        expect(names, containsAll(['label', 'count', 'isActive']));
+      },
+    );
+  });
+}

--- a/packages/widgetbook/test/generator/custom_args/custom_args.stories.g.dart
+++ b/packages/widgetbook/test/generator/custom_args/custom_args.stories.g.dart
@@ -39,7 +39,7 @@ class NumericBadgeInputArgs extends StoryArgs<LabelBadge> {
     : this.numberArg = $initArg('number', number, IntArg(0))!;
 
   NumericBadgeInputArgs.fixed({int number = 0})
-    : this.numberArg = Arg.fixed(number);
+    : this.numberArg = $initArg('number', Arg.fixed(number), null)!;
 
   final Arg<int> numberArg;
 

--- a/packages/widgetbook/test/generator/default_values/default_values.stories.g.dart
+++ b/packages/widgetbook/test/generator/default_values/default_values.stories.g.dart
@@ -62,11 +62,11 @@ class DefaultsWidgetArgs extends StoryArgs<DefaultsWidget> {
     int count = 42,
     double ratio = 3.14,
     bool isEnabled = true,
-  }) : this.keyArg = key == null ? null : Arg.fixed(key),
-       this.labelArg = Arg.fixed(label),
-       this.countArg = Arg.fixed(count),
-       this.ratioArg = Arg.fixed(ratio),
-       this.isEnabledArg = Arg.fixed(isEnabled);
+  }) : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+       this.labelArg = $initArg('label', Arg.fixed(label), null)!,
+       this.countArg = $initArg('count', Arg.fixed(count), null)!,
+       this.ratioArg = $initArg('ratio', Arg.fixed(ratio), null)!,
+       this.isEnabledArg = $initArg('isEnabled', Arg.fixed(isEnabled), null)!;
 
   final Arg<Key?>? keyArg;
 

--- a/packages/widgetbook/test/generator/doc_comment/doc_comment.stories.g.dart
+++ b/packages/widgetbook/test/generator/doc_comment/doc_comment.stories.g.dart
@@ -49,8 +49,8 @@ class DocCommentWidgetArgs extends StoryArgs<DocCommentWidget> {
       this.labelArg = $initArg('label', label, StringArg(''))!;
 
   DocCommentWidgetArgs.fixed({Key? key, String label = ''})
-    : this.keyArg = key == null ? null : Arg.fixed(key),
-      this.labelArg = Arg.fixed(label);
+    : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+      this.labelArg = $initArg('label', Arg.fixed(label), null)!;
 
   final Arg<Key?>? keyArg;
 

--- a/packages/widgetbook/test/generator/doc_comment_code/doc_comment_code.stories.g.dart
+++ b/packages/widgetbook/test/generator/doc_comment_code/doc_comment_code.stories.g.dart
@@ -52,8 +52,8 @@ class DocCommentCodeWidgetArgs extends StoryArgs<DocCommentCodeWidget> {
       this.labelArg = $initArg('label', label, StringArg(''))!;
 
   DocCommentCodeWidgetArgs.fixed({Key? key, String label = ''})
-    : this.keyArg = key == null ? null : Arg.fixed(key),
-      this.labelArg = Arg.fixed(label);
+    : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+      this.labelArg = $initArg('label', Arg.fixed(label), null)!;
 
   final Arg<Key?>? keyArg;
 

--- a/packages/widgetbook/test/generator/enums/enums.stories.g.dart
+++ b/packages/widgetbook/test/generator/enums/enums.stories.g.dart
@@ -47,8 +47,8 @@ class EnumWidgetArgs extends StoryArgs<EnumWidget> {
       )!;
 
   EnumWidgetArgs.fixed({Key? key, Priority priority = Priority.low})
-    : this.keyArg = key == null ? null : Arg.fixed(key),
-      this.priorityArg = Arg.fixed(priority);
+    : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+      this.priorityArg = $initArg('priority', Arg.fixed(priority), null)!;
 
   final Arg<Key?>? keyArg;
 

--- a/packages/widgetbook/test/generator/generic/generic.stories.g.dart
+++ b/packages/widgetbook/test/generator/generic/generic.stories.g.dart
@@ -45,8 +45,8 @@ class GenericWidgetArgs<T extends num> extends StoryArgs<GenericWidget<T>> {
       this.valueArg = $initArg('value', value, null)!;
 
   GenericWidgetArgs.fixed({Key? key, required T value})
-    : this.keyArg = key == null ? null : Arg.fixed(key),
-      this.valueArg = Arg.fixed(value);
+    : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+      this.valueArg = $initArg('value', Arg.fixed(value), null)!;
 
   final Arg<Key?>? keyArg;
 

--- a/packages/widgetbook/test/generator/generic_bound/generic_bound.stories.g.dart
+++ b/packages/widgetbook/test/generator/generic_bound/generic_bound.stories.g.dart
@@ -45,8 +45,8 @@ class BoundWidgetArgs<D, T extends BaseItem<D>>
       this.itemArg = $initArg('item', item, null)!;
 
   BoundWidgetArgs.fixed({Key? key, required T item})
-    : this.keyArg = key == null ? null : Arg.fixed(key),
-      this.itemArg = Arg.fixed(item);
+    : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+      this.itemArg = $initArg('item', Arg.fixed(item), null)!;
 
   final Arg<Key?>? keyArg;
 

--- a/packages/widgetbook/test/generator/generic_bound_dynamic/generic_bound_dynamic.stories.g.dart
+++ b/packages/widgetbook/test/generator/generic_bound_dynamic/generic_bound_dynamic.stories.g.dart
@@ -50,8 +50,8 @@ class DynamicBoundWidgetArgs<D, T extends Map<dynamic, D>>
       this.mappingArg = $initArg('mapping', mapping, null)!;
 
   DynamicBoundWidgetArgs.fixed({Key? key, required T mapping})
-    : this.keyArg = key == null ? null : Arg.fixed(key),
-      this.mappingArg = Arg.fixed(mapping);
+    : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+      this.mappingArg = $initArg('mapping', Arg.fixed(mapping), null)!;
 
   final Arg<Key?>? keyArg;
 

--- a/packages/widgetbook/test/generator/generic_bound_nullable/generic_bound_nullable.stories.g.dart
+++ b/packages/widgetbook/test/generator/generic_bound_nullable/generic_bound_nullable.stories.g.dart
@@ -53,8 +53,8 @@ class NullableBoundWidgetArgs<D, T extends BaseItem<D?>>
       this.itemArg = $initArg('item', item, null)!;
 
   NullableBoundWidgetArgs.fixed({Key? key, required T item})
-    : this.keyArg = key == null ? null : Arg.fixed(key),
-      this.itemArg = Arg.fixed(item);
+    : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+      this.itemArg = $initArg('item', Arg.fixed(item), null)!;
 
   final Arg<Key?>? keyArg;
 

--- a/packages/widgetbook/test/generator/multi_constructor/multi_constructor.stories.g.dart
+++ b/packages/widgetbook/test/generator/multi_constructor/multi_constructor.stories.g.dart
@@ -56,8 +56,8 @@ class MultiConstructorWidgetArgs extends StoryArgs<MultiConstructorWidget> {
       this.countArg = $initArg('count', count, IntArg(0))!;
 
   MultiConstructorWidgetArgs.fixed({Key? key, int count = 0})
-    : this.keyArg = key == null ? null : Arg.fixed(key),
-      this.countArg = Arg.fixed(count);
+    : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+      this.countArg = $initArg('count', Arg.fixed(count), null)!;
 
   final Arg<Key?>? keyArg;
 
@@ -102,8 +102,8 @@ class MultiConstructorWidgetOtherArgs
       this.labelArg = $initArg('label', label, StringArg(''))!;
 
   MultiConstructorWidgetOtherArgs.fixed({Key? key, String label = ''})
-    : this.keyArg = key == null ? null : Arg.fixed(key),
-      this.labelArg = Arg.fixed(label);
+    : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+      this.labelArg = $initArg('label', Arg.fixed(label), null)!;
 
   final Arg<Key?>? keyArg;
 

--- a/packages/widgetbook/test/generator/nullable/nullable.stories.g.dart
+++ b/packages/widgetbook/test/generator/nullable/nullable.stories.g.dart
@@ -48,9 +48,17 @@ class NullableWidgetArgs extends StoryArgs<NullableWidget> {
       this.countArg = $initArg('count', count, NullableIntArg(null))!;
 
   NullableWidgetArgs.fixed({Key? key, String? label = null, int? count = null})
-    : this.keyArg = key == null ? null : Arg.fixed(key),
-      this.labelArg = label == null ? null : Arg.fixed(label),
-      this.countArg = count == null ? null : Arg.fixed(count);
+    : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+      this.labelArg = $initArg(
+        'label',
+        label == null ? null : Arg.fixed(label),
+        null,
+      ),
+      this.countArg = $initArg(
+        'count',
+        count == null ? null : Arg.fixed(count),
+        null,
+      );
 
   final Arg<Key?>? keyArg;
 

--- a/packages/widgetbook/test/generator/primitive/primitive.stories.g.dart
+++ b/packages/widgetbook/test/generator/primitive/primitive.stories.g.dart
@@ -60,10 +60,10 @@ class PrimitiveWidgetArgs extends StoryArgs<PrimitiveWidget> {
     String label = '',
     int count = 0,
     bool isActive = false,
-  }) : this.keyArg = key == null ? null : Arg.fixed(key),
-       this.labelArg = Arg.fixed(label),
-       this.countArg = Arg.fixed(count),
-       this.isActiveArg = Arg.fixed(isActive);
+  }) : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+       this.labelArg = $initArg('label', Arg.fixed(label), null)!,
+       this.countArg = $initArg('count', Arg.fixed(count), null)!,
+       this.isActiveArg = $initArg('isActive', Arg.fixed(isActive), null)!;
 
   final Arg<Key?>? keyArg;
 

--- a/packages/widgetbook/test/generator/static_methods/static_methods.stories.g.dart
+++ b/packages/widgetbook/test/generator/static_methods/static_methods.stories.g.dart
@@ -56,8 +56,8 @@ class StaticMethodWidgetArgs extends StoryArgs<StaticMethodWidget> {
   StaticMethodWidgetArgs.fixed({
     Key? key,
     Widget Function(BuildContext) builder = StaticMethodWidget._defaultBuilder,
-  }) : this.keyArg = key == null ? null : Arg.fixed(key),
-       this.builderArg = Arg.fixed(builder);
+  }) : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+       this.builderArg = $initArg('builder', Arg.fixed(builder), null)!;
 
   final Arg<Key?>? keyArg;
 

--- a/packages/widgetbook/test/generator/variants/variants.stories.g.dart
+++ b/packages/widgetbook/test/generator/variants/variants.stories.g.dart
@@ -55,8 +55,8 @@ class VariantButtonArgs extends StoryArgs<VariantButton> {
       this.labelArg = $initArg('label', label, StringArg(''))!;
 
   VariantButtonArgs.fixed({Key? key, String label = ''})
-    : this.keyArg = key == null ? null : Arg.fixed(key),
-      this.labelArg = Arg.fixed(label);
+    : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+      this.labelArg = $initArg('label', Arg.fixed(label), null)!;
 
   final Arg<Key?>? keyArg;
 
@@ -107,9 +107,13 @@ class VariantButtonIconArgs extends StoryArgs<VariantButton> {
        this.sizeArg = $initArg('size', size, DoubleArg(24))!;
 
   VariantButtonIconArgs.fixed({Key? key, IconData? icon, double size = 24})
-    : this.keyArg = key == null ? null : Arg.fixed(key),
-      this.iconArg = icon == null ? null : Arg.fixed(icon),
-      this.sizeArg = Arg.fixed(size);
+    : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+      this.iconArg = $initArg(
+        'icon',
+        icon == null ? null : Arg.fixed(icon),
+        null,
+      ),
+      this.sizeArg = $initArg('size', Arg.fixed(size), null)!;
 
   final Arg<Key?>? keyArg;
 
@@ -153,8 +157,8 @@ class VariantButtonOutlinedArgs extends StoryArgs<VariantButton> {
       this.labelArg = $initArg('label', label, StringArg(''))!;
 
   VariantButtonOutlinedArgs.fixed({Key? key, String label = ''})
-    : this.keyArg = key == null ? null : Arg.fixed(key),
-      this.labelArg = Arg.fixed(label);
+    : this.keyArg = $initArg('key', key == null ? null : Arg.fixed(key), null),
+      this.labelArg = $initArg('label', Arg.fixed(label), null)!;
 
   final Arg<Key?>? keyArg;
 

--- a/packages/widgetbook/test/generator/with_defaults/with_defaults.stories.g.dart
+++ b/packages/widgetbook/test/generator/with_defaults/with_defaults.stories.g.dart
@@ -44,7 +44,7 @@ class DefaultsVarInputArgs extends StoryArgs<DefaultsVarWidget> {
     : this.labelArg = $initArg('label', label, StringArg(''))!;
 
   DefaultsVarInputArgs.fixed({String label = ''})
-    : this.labelArg = Arg.fixed(label);
+    : this.labelArg = $initArg('label', Arg.fixed(label), null)!;
 
   final Arg<String> labelArg;
 


### PR DESCRIPTION
## Problem

Building a story/scenario with the generated `_Args.fixed(...)` constructor and
then reading an arg's `name` throws:

```
LateInitializationError: Field '$generatedName' has not been initialized.
  package:widgetbook/src/core/framework/arg.dart 52:31  Arg.name
  ResponsiveLayout.buildScenarioInfo
    package:widgetbook/src/core/layout/responsive_layout.dart
```

This happens in the running app whenever the scenario info panel renders the
"Args" table for a story/scenario that uses `_Args.fixed(...)` (e.g. the Quick
Start example).

## Cause

The generated `.fixed` constructor assigned each field with a bare
`Arg.fixed(value)` (→ `ConstArg`, whose `_name` is `null`) and never routed
through `$initArg(...)`, which is what assigns `Arg.$generatedName`. The default
constructor does call `$initArg(...)`, so its args resolve `name` fine — only
the `.fixed` path was affected.

## Fix

In `ArgsClassBuilder`, wrap each fixed value in `$initArg('name', …, null)`
(with `!` for non-nullable fields), mirroring the default constructor. Generated
`.fixed` constructors now look like:

```dart
// before
this.labelArg = Arg.fixed(label),
// after
this.labelArg = $initArg('label', Arg.fixed(label), null)!,
```

Generator goldens regenerated accordingly.

## Tests

- Adds `test/core/framework/fixed_args_name_test.dart`, which drives the
  generated `PrimitiveWidgetArgs` from the `primitive` fixture: the default
  constructor exposes arg names (control) and the `.fixed` constructor now does
  too (regression for this issue). The first commit adds the test as a failing
  reproduction; the second applies the fix and turns it green.
- `dart analyze lib`: clean. `flutter test` and `dart test test/generator/
  --platform vm`: all pass.