### PR TITLE
fix: rebuild workbench preview on story switch and knob change

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **FIX**: Rebuild the workbench preview when switching stories or changing knobs while a viewport is active. ([#1948](https://github.com/widgetbook/widgetbook/pull/1948))
 - **FIX**: Assign `$generatedName` to args created via the generated `_Args.fixed(...)` constructor, mirroring the default constructor. ([#1947](https://github.com/widgetbook/widgetbook/pull/1947))
 
 ## 4.0.0-beta.7

--- a/packages/widgetbook/lib/src/core/addons/viewport_addon/viewport.dart
+++ b/packages/widgetbook/lib/src/core/addons/viewport_addon/viewport.dart
@@ -68,9 +68,14 @@ class Viewport extends StatelessWidget {
                 // the device frame, otherwise they would use the navigator from
                 // the app builder, causing these routes to fill the whole
                 // workbench and not just the device frame.
-                onGenerateRoute: (_) => PageRouteBuilder(
-                  pageBuilder: (context, _, __) => child,
-                ),
+                //
+                // Uses `pages` (not `onGenerateRoute`) so the route tracks
+                // [child] on rebuild instead of capturing it once, which left
+                // the preview stuck when switching stories or changing knobs.
+                onDidRemovePage: (_) {},
+                pages: [
+                  MaterialPage<void>(child: child),
+                ],
               ),
             ),
           ),

--- a/packages/widgetbook/test/core/workbench/knob_rebuild_test.dart
+++ b/packages/widgetbook/test/core/workbench/knob_rebuild_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/src/core/workbench/workbench.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import '../../helper/helper.dart';
+
+// Regression for the preview not reflecting a knob change. Shares the root
+// cause with `story_switch_test`: an active [ViewportAddon] places the use case
+// inside the `Viewport`'s nested `Navigator`, which used to pin the child and
+// ignore later rebuilds — whether triggered by navigation or a knob change.
+
+class _LabelArgs extends StoryArgs<Widget> {
+  _LabelArgs() : labelArg = StringArg('A', name: 'label');
+
+  final StringArg labelArg;
+
+  String get label => labelArg.value;
+
+  @override
+  List<Arg?> get list => [labelArg];
+}
+
+class _KnobStory extends Story<Widget, _LabelArgs> {
+  _KnobStory({required super.name, required super.args})
+    : super(
+        builder: (context, a) => Text(a.label),
+      );
+}
+
+const _viewport = ViewportData(
+  name: 'Square',
+  width: 480,
+  height: 480,
+  pixelRatio: 2.0,
+  platform: TargetPlatform.android,
+);
+
+void main() {
+  group(
+    'Knob changes rebuild the workbench preview',
+    () {
+      testWidgets(
+        'when a knob value changes, '
+        'then the preview reflects the new knob value',
+        (tester) async {
+          final args = _LabelArgs();
+          final story = _KnobStory(name: 'Default', args: args);
+
+          // Creating the component wires `story.component`, so `story.path`
+          // resolves below.
+          final component = Component<Widget, _LabelArgs>(
+            path: 'widgets',
+            name: 'Button',
+            stories: [story],
+          );
+
+          final state = WidgetbookState(
+            path: story.path,
+            config: Config(
+              home: const Placeholder(),
+              addons: [
+                ViewportAddon([_viewport]),
+              ],
+              components: [component],
+            ),
+          );
+
+          await tester.pumpWidgetWithState(
+            state: state,
+            builder: (_) => const Workbench(),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.text('A'), findsOneWidget);
+          expect(find.text('B'), findsNothing);
+
+          state.updateQueryGroup(
+            args.labelArg.groupName,
+            args.labelArg.valueToQueryGroup('B'),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.text('B'), findsOneWidget);
+          expect(find.text('A'), findsNothing);
+        },
+      );
+    },
+  );
+}

--- a/packages/widgetbook/test/core/workbench/story_switch_test.dart
+++ b/packages/widgetbook/test/core/workbench/story_switch_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/src/core/routing/routing.dart';
+import 'package:widgetbook/src/core/state/state.dart';
+import 'package:widgetbook/src/core/theme/theme.dart';
+import 'package:widgetbook/src/core/workbench/workbench.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import '../../helper/helper.dart';
+
+// Regression for the preview staying stuck on the previous story when switching
+// between stories. An active [ViewportAddon] is required: it places the use case
+// inside the `Viewport`'s nested `Navigator`, where it used to get pinned.
+// The knob-change variant of the same root cause lives in `knob_rebuild_test`.
+
+class _NoArgs extends StoryArgs<Widget> {
+  const _NoArgs();
+
+  @override
+  List<Arg?> get list => const [];
+}
+
+class _TextStory extends Story<Widget, _NoArgs> {
+  _TextStory({
+    required super.name,
+    required String label,
+  }) : super(
+         args: const _NoArgs(),
+         builder: (context, args) => Text(label),
+       );
+}
+
+const _viewport = ViewportData(
+  name: 'Square',
+  width: 480,
+  height: 480,
+  pixelRatio: 2.0,
+  platform: TargetPlatform.android,
+);
+
+void main() {
+  Config buildConfig({
+    required _TextStory buttonStory,
+    required _TextStory counterStory,
+  }) {
+    return Config(
+      home: const Placeholder(),
+      addons: [
+        ViewportAddon([_viewport]),
+      ],
+      components: [
+        Component<Widget, _NoArgs>(
+          path: 'widgets',
+          name: 'Button',
+          stories: [buttonStory],
+        ),
+        Component<Widget, _NoArgs>(
+          path: 'widgets',
+          name: 'Counter',
+          stories: [counterStory],
+        ),
+      ],
+    );
+  }
+
+  group(
+    'Story navigation rebuilds the workbench preview',
+    () {
+      testWidgets(
+        'when `updatePath` switches from one story to another, '
+        'then the preview shows the newly selected story',
+        (tester) async {
+          final buttonStory = _TextStory(name: 'Default', label: 'ButtonStory');
+          final counterStory = _TextStory(
+            name: 'Default',
+            label: 'CounterStory',
+          );
+
+          // Build the config first so `Component` wires up `story.component`
+          // before we read `story.path`.
+          final config = buildConfig(
+            buttonStory: buttonStory,
+            counterStory: counterStory,
+          );
+          final state = WidgetbookState(
+            path: buttonStory.path,
+            config: config,
+          );
+
+          await tester.pumpWidgetWithState(
+            state: state,
+            builder: (_) => const Workbench(),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.text('ButtonStory'), findsOneWidget);
+          expect(find.text('CounterStory'), findsNothing);
+
+          state.updatePath(counterStory.path);
+          await tester.pumpAndSettle();
+
+          expect(find.text('CounterStory'), findsOneWidget);
+          expect(find.text('ButtonStory'), findsNothing);
+        },
+      );
+
+      // Pumped through the full production stack: `MaterialApp.router` ->
+      // `AppRouterDelegate` -> `ResponsiveLayout` -> `Workbench`.
+      testWidgets(
+        'given the full router stack, '
+        'when navigating between two story leaves, '
+        'then the workbench preview reflects the new story',
+        (tester) async {
+          final buttonStory = _TextStory(name: 'Default', label: 'ButtonStory');
+          final counterStory = _TextStory(
+            name: 'Default',
+            label: 'CounterStory',
+          );
+
+          final config = buildConfig(
+            buttonStory: buttonStory,
+            counterStory: counterStory,
+          );
+
+          final state = WidgetbookState(config: config);
+          final router = AppRouter(state: state, uri: Uri.parse('/'));
+
+          await tester.pumpWidget(
+            WidgetbookTheme(
+              data: Themes.dark,
+              child: WidgetbookScope(
+                state: state,
+                child: MaterialApp.router(
+                  debugShowCheckedModeBanner: false,
+                  routerConfig: router,
+                ),
+              ),
+            ),
+          );
+
+          state.updatePath(buttonStory.path);
+          await tester.pumpAndSettle();
+          expect(find.text('ButtonStory'), findsOneWidget);
+          expect(find.text('CounterStory'), findsNothing);
+
+          state.updatePath(counterStory.path);
+          await tester.pumpAndSettle();
+
+          expect(find.text('CounterStory'), findsOneWidget);
+          expect(find.text('ButtonStory'), findsNothing);
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Problem

When a viewport is active, the workbench preview can get stuck on the previous use case: switching stories keeps rendering the old story, and changing a knob keeps the old value.

## Cause

The use case is rendered inside `Viewport`, which hosts a nested `Navigator` (so dialogs stay within the device frame). It was built imperatively:

```dart
onGenerateRoute: (_) => PageRouteBuilder(
  pageBuilder: (context, _, __) => child, // captured once
),
```

`onGenerateRoute` runs once and the route closes over the current `child`, so later rebuilds with a new `child` are ignored.

## Fix

Host the use case as a declarative `MaterialPage`, so the route tracks `child` on rebuild. Dialogs still push imperatively on top, so device-frame behaviour is unchanged.

## Tests

`test/core/workbench/story_switch_test.dart` and `knob_rebuild_test.dart` cover switching stories (direct and through the full router stack) and changing a knob — all failing before this change.

## Credit

Supersedes #1912 by @dario-digregorio, who reported and diagnosed the bug and provided the repro. Credited as co-author on the commit. This PR fixes it at the source in `Viewport`, which also covers the knob-rebuild case.