### PR TITLE
docs(cloud): fix build upload steps and paths

### DIFF
--- a/docs/cloud/builds/upload.mdx
+++ b/docs/cloud/builds/upload.mdx
@@ -35,44 +35,50 @@ To follow the CI/CD setup guide select your Git provider below
 
 To create a Widgetbook Build, follow these steps inside your Widgetbook project:
 
-1. Run `build_runner` to generate the components registry (`components.g.dart`)
+<Steps>
+  <Step title="Generate the components registry">
+    ```bash
+    dart run build_runner build -d
+    ```
+  </Step>
 
-   ```bash
-   dart run build_runner build -d
-   ```
+  <Step title="Generate snapshots">
+    Run your Widgetbook tests to write the snapshot images and metadata to `build/.widgetbook`.
+    See [Run Scenarios](/testing/run-scenarios) for how to set up the test entry point.
 
-1. Generate snapshots by running your Widgetbook tests
+    ```bash
+    flutter test
+    ```
+  </Step>
 
-   This writes the snapshot images and metadata to `build/.widgetbook`.
-   See [Run Scenarios](/testing/run-scenarios) for how to set up the test entry point.
+  <Step title="Build the Widgetbook for the web">
+    ```bash
+    # Default target (i.e. `lib/main.dart`)
+    flutter build web
 
-   ```bash
-   flutter test
-   ```
+    # Custom target
+    flutter build web -t lib/main.widgetbook.dart
+    ```
+  </Step>
 
-1. Build the Widgetbook for the web
+  <Step title="Install the Widgetbook CLI">
+    Install the [Widgetbook CLI](/cli):
 
-   ```bash
-   # Default target (i.e. `lib/main.dart`)
-   flutter build web
+    ```bash
+    dart pub global activate widgetbook_cli {{ versions.cli }}
+    ```
+  </Step>
 
-   # Custom target
-   flutter build web -t lib/main.widgetbook.dart
-   ```
+  <Step title="Get your API key">
+    Copy your **API key** from the Widgetbook Cloud **project settings page**.
+  </Step>
 
-1. Install the [Widgetbook CLI](/cli)
-
-   ```bash
-   dart pub global activate widgetbook_cli {{ versions.cli }}
-   ```
-
-1. Get your **API key** from the Widgetbook Cloud's **project settings page**.
-
-1. Push the build to Widgetbook Cloud
-
-   ```bash
-   widgetbook cloud build push --api-key PROJECT_API_KEY
-   ```
+  <Step title="Push the build to Widgetbook Cloud">
+    ```bash
+    widgetbook cloud build push --api-key PROJECT_API_KEY
+    ```
+  </Step>
+</Steps>
 
 <Info>
 The `cloud build push` command uploads the following directories:

--- a/docs/cloud/builds/upload.mdx
+++ b/docs/cloud/builds/upload.mdx
@@ -35,10 +35,19 @@ To follow the CI/CD setup guide select your Git provider below
 
 To create a Widgetbook Build, follow these steps inside your Widgetbook project:
 
-1. Run `build_runner` to generate metadata about your stories and components
+1. Run `build_runner` to generate the components registry (`components.g.dart`)
 
    ```bash
    dart run build_runner build -d
+   ```
+
+1. Generate snapshots by running your Widgetbook tests
+
+   This writes the snapshot images and metadata to `build/.widgetbook`.
+   See [Run Scenarios](/testing/run-scenarios) for how to set up the test entry point.
+
+   ```bash
+   flutter test
    ```
 
 1. Build the Widgetbook for the web
@@ -66,9 +75,9 @@ To create a Widgetbook Build, follow these steps inside your Widgetbook project:
    ```
 
 <Info>
-The `cloud push` command uses the following directories:
+The `cloud build push` command uploads the following directories:
 
-1. `build/web/` to create a `.zip` archive that will be uploaded to Widgetbook Cloud.
-1. `.dart_tool/build/generated/[your_app_name]/` to send metadata, _about the generated stories_, that will be used for [Widgetbook Cloud Review](/cloud/reviews).
+1. `build/.widgetbook/` — the snapshot images and metadata used for [Widgetbook Cloud Reviews](/cloud/reviews).
+1. `build/web/` — the interactive Widgetbook build that you can browse online.
 
 </Info>

--- a/docs/cloud/guides/bitbucket/upload.mdx
+++ b/docs/cloud/guides/bitbucket/upload.mdx
@@ -36,7 +36,7 @@ If you want to use Widgetbook Cloud with your existing Bitbucket repository, her
               - flutter test
             artifacts:
               - widgetbook/build/web/**
-              - widgetbook/.dart_tool/build/generated/**
+              - widgetbook/build/.widgetbook/**
 
         - step:
             name: Deploy Widgetbook


### PR DESCRIPTION
The manual build-upload guide still described the old v3 flow, so following it produced a Cloud build with no snapshots.

Updates it for v4:
- Adds the missing `flutter test` step that generates snapshots into `build/.widgetbook`.
- Corrects the command name (`cloud push` → `cloud build push`).
- Fixes the description of which directories are uploaded (`build/.widgetbook` for snapshots + `build/web` for the interactive build — not `.dart_tool/build/generated` or a zip).
- Fixes the Bitbucket pipeline artifact path to `build/.widgetbook`.
