### PR TITLE
docs: remove dead review/limitations sidebar link

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -484,10 +484,6 @@
                   "href": "/cloud/reviews/notifications/slack"
                 }
               ]
-            },
-            {
-              "title": "Limitations",
-              "href": "/cloud/reviews/limitations"
             }
           ]
         },


### PR DESCRIPTION
The Reviews section of the sidebar had a `Limitations` entry linking to `/cloud/reviews/limitations`, but no such page exists, so it returned a 404.

Removes the broken entry.
