### PR TITLE
docs(cloud): fix broken Azure/Bitbucket links on Reviews page

### DIFF
--- a/docs/cloud/reviews/index.mdx
+++ b/docs/cloud/reviews/index.mdx
@@ -30,8 +30,8 @@ Both types of reviews are important to ensure the code is correct and the design
 **Prerequisite:** Make sure you have completed the setup of Widgetbook Cloud for 
 [GitHub](/cloud/guides/github/upload),
 [GitLab](/cloud/guides/gitlab/upload), 
-[Azure DevOps](cloud/guides/azure/upload), or
-[Bitbucket](cloud/guides/bitbucket/upload).
+[Azure DevOps](/cloud/guides/azure/upload), or
+[Bitbucket](/cloud/guides/bitbucket/upload).
 </Info>
 
 1. Submit a pull request (PR) with your changes using your version control system (e.g., GitHub, GitLab).


### PR DESCRIPTION
On the Reviews overview page, the Azure DevOps and Bitbucket prerequisite links were missing a leading slash. As relative links they resolved to `/cloud/reviews/cloud/guides/...` and returned a 404.

Adds the leading slash so they point at the correct pages (matching the GitHub/GitLab links right next to them).
