### PR TITLE
docs(addons): update Theme/Locale/Builder examples to v4 API

### DIFF
--- a/docs/addons/builder-addon.mdx
+++ b/docs/addons/builder-addon.mdx
@@ -45,13 +45,12 @@ dependencies:
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:widgetbook/widgetbook.dart';
 
-class WidgetbookApp extends StatelessWidget {
-  const WidgetbookApp({super.key});
+import 'components.g.dart';
 
-  @override
-  Widget build(BuildContext context) {
-    return Widgetbook(
-      directories: directories,
+void main() {
+  runWidgetbook(
+    Config(
+      components: components,
       addons: [
         BuilderAddon(
           name: 'ScreenUtil',
@@ -60,16 +59,15 @@ class WidgetbookApp extends StatelessWidget {
               designSize: const Size(375, 812),
               minTextAdapt: true,
               splitScreenMode: true,
-              // This is needed to use the workbench [MediaQuery]
               useInheritedMediaQuery: true,
               builder: (context, child) => child!,
               child: child,
             );
           },
-        )
+        ),
       ],
-    );
-  }
+    ),
+  );
 }
 ```
 
@@ -88,13 +86,12 @@ dependencies:
 import 'package:accessibility_tools/accessibility_tools.dart';
 import 'package:widgetbook/widgetbook.dart';
 
-class WidgetbookApp extends StatelessWidget {
-  const WidgetbookApp({super.key});
+import 'components.g.dart';
 
-  @override
-  Widget build(BuildContext context) {
-    return Widgetbook(
-      directories: directories,
+void main() {
+  runWidgetbook(
+    Config(
+      components: components,
       addons: [
         BuilderAddon(
           name: 'Accessibility',
@@ -103,30 +100,11 @@ class WidgetbookApp extends StatelessWidget {
           ),
         ),
       ],
-    );
-  }
+    ),
+  );
 }
 ```
 
 ## Mode
 
-Each addon has a corresponding [Mode](/addons/modes) to lock its value in scenarios. For this addon, use `BuilderMode`:
-
-```dart
-final $Default = _Story(
-  scenarios: [
-    _Scenario(
-      name: 'Red Background',
-      modes: [
-        BuilderMode(
-          name: 'Red',
-          builder: (context, child) => ColoredBox(
-            color: Colors.red,
-            child: child,
-          ),
-        ), // [!code highlight]
-      ]
-    ),
-  ],
-)
-```
+The `BuilderAddon` has no adjustable value, so it has no corresponding [Mode](/addons/modes). Its `builder` always wraps every story and scenario.

--- a/docs/addons/locale-addon.mdx
+++ b/docs/addons/locale-addon.mdx
@@ -68,8 +68,8 @@ You need to export the `supportedLocales` and `localizationsDelegates` from your
      // ...
      addons: [
        LocaleAddon( // [!code highlight]
-         locales: AppLocalizations.supportedLocales,
-         localizationsDelegates: AppLocalizations.localizationsDelegates,
+         AppLocalizations.supportedLocales,
+         AppLocalizations.localizationsDelegates,
        ),
      ],
    );

--- a/docs/addons/theme-addon.mdx
+++ b/docs/addons/theme-addon.mdx
@@ -43,18 +43,10 @@ import 'package:my_app/themes.dart'; // For AppThemes
 final config = Config(
   // ...
   addons: [
-    MaterialThemeAddon( // [!code highlight]
-      themes: [ // [!code highlight]
-        WidgetbookTheme( // [!code highlight]
-          name: 'Light', // [!code highlight]
-          data: AppThemes.light(), // [!code highlight]
-        ), // [!code highlight]
-        WidgetbookTheme( // [!code highlight]
-          name: 'Dark', // [!code highlight]
-          data: AppThemes.dark(), // [!code highlight]
-        ), // [!code highlight]
-      ], // [!code highlight]
-    ), // [!code highlight]
+    MaterialThemeAddon({ // [!code highlight]
+      'Light': AppThemes.light(), // [!code highlight]
+      'Dark': AppThemes.dark(), // [!code highlight]
+    }), // [!code highlight]
   ],
 );
 ```
@@ -69,18 +61,10 @@ import 'package:my_app/themes.dart'; // For AppThemes
 final config = Config(
   // ...
   addons: [
-    CupertinoThemeAddon( // [!code highlight]
-      themes: [ // [!code highlight]
-        WidgetbookTheme( // [!code highlight]
-          name: 'Light', // [!code highlight]
-          data: AppThemes.light(), // [!code highlight]
-        ), // [!code highlight]
-        WidgetbookTheme( // [!code highlight]
-          name: 'Dark', // [!code highlight]
-          data: AppThemes.dark(), // [!code highlight]
-        ), // [!code highlight]
-      ], // [!code highlight]
-    ), // [!code highlight]
+    CupertinoThemeAddon({ // [!code highlight]
+      'Light': AppThemes.light(), // [!code highlight]
+      'Dark': AppThemes.dark(), // [!code highlight]
+    }), // [!code highlight]
   ],
 );
 ```
@@ -135,18 +119,12 @@ final config = Config(
   // ...
   addons: [
     ThemeAddon<AppThemeData>( // [!code highlight]
-      themes: [ // [!code highlight]
-        WidgetbookTheme( // [!code highlight]
-          name: 'Light', // [!code highlight]
-          data: AppThemes.light(), // [!code highlight]
-        ), // [!code highlight]
-        WidgetbookTheme( // [!code highlight]
-          name: 'Dark', // [!code highlight]
-          data: AppThemes.dark(), // [!code highlight]
-        ), // [!code highlight]
-      ], // [!code highlight]
-      themeBuilder: (context, theme, child) { // [!code highlight]
-        // Wrap use cases with the custom theme's InheritedWidget // [!code highlight]
+      { // [!code highlight]
+        'Light': AppThemes.light(), // [!code highlight]
+        'Dark': AppThemes.dark(), // [!code highlight]
+      }, // [!code highlight]
+      (context, theme, child) { // [!code highlight]
+        // Wrap stories with the custom theme's InheritedWidget // [!code highlight]
         return AppTheme( // [!code highlight]
           data: theme, // [!code highlight]
           child: child, // [!code highlight]

--- a/docs/docs/styling.mdx
+++ b/docs/docs/styling.mdx
@@ -98,7 +98,7 @@ final config = Config(
     const StoriesDocBlock(),
   ],
   addons: [
-    MaterialThemeAddon(themes: { /* ... */ }),
+    MaterialThemeAddon({ /* ... */ }),
   ],
 );
 ```


### PR DESCRIPTION
Several addon examples still used the v3 API and would not compile against v4:

- `MaterialThemeAddon` / `CupertinoThemeAddon` / `ThemeAddon` now take a positional map of themes instead of a `themes:` list of `WidgetbookTheme`s (and `ThemeAddon` takes a positional builder).
- `LocaleAddon` takes positional arguments instead of named `locales:` / `localizationsDelegates:`.
- The `flutter_screenutil` and `accessibility_tools` examples used the removed `Widgetbook(directories: ...)` widget; they now use `runWidgetbook(Config(...))`.
- Removed the `BuilderMode` section — `BuilderAddon` has no adjustable value, so there is no corresponding mode.

All examples now match the real v4 API in the package source.
