### PR TITLE
docs: fix broken and garbled code snippets

### DIFF
--- a/docs/addons/grid-addon.mdx
+++ b/docs/addons/grid-addon.mdx
@@ -29,17 +29,4 @@ Addons that should come after the `GridAddon`:
 
 ## Mode
 
-Each addon has a corresponding [Mode](/addons/modes) to lock its value in scenarios. For this addon, use `GridMode`:
-
-```dart
-final $Default = _Story(
-  scenarios: [
-    _Scenario(
-      name: 'Grid Enabled',
-      modes: [
-        GridMode(10), // [!code highlight]
-      ]
-    ),
-  ],
-)
-```
+The `GridAddon` has no adjustable value, so it has no corresponding [Mode](/addons/modes). The grid always renders behind every story and scenario.

--- a/docs/addons/semantics-addon.mdx
+++ b/docs/addons/semantics-addon.mdx
@@ -12,7 +12,7 @@ The addon is based on a minimal variant of Flutter's [`SemanticsDebugger`](https
 ## Usage
 
 ```dart title=widgetbook/lib/widgetbook.config.dart
-final config = Config)
+final config = Config(
   // ...
   addons: [
     SemanticsAddon(), // [!code highlight]

--- a/docs/addons/text-scale-addon.mdx
+++ b/docs/addons/text-scale-addon.mdx
@@ -59,15 +59,4 @@ final $Default = _Story(
     ),
   ],
 )
-
-  @override
-  Widget build(BuildContext context) {
-    return Widgetbook(
-      // ...
-      addons: [
-        TextScaleAddon(), // [!code highlight]
-      ],
-    );
-  }
-}
 ```

--- a/docs/addons/viewport-addon.mdx
+++ b/docs/addons/viewport-addon.mdx
@@ -54,11 +54,4 @@ final $Default = _Story(
     ),
   ],
 )
-          IosViewports.iPhone13, // [!code highlight]
-          IosViewports.iPhone12, // [!code highlight]
-        ]), // [!code highlight]
-      ],
-    );
-  }
-}
 ```

--- a/docs/args/overview.mdx
+++ b/docs/args/overview.mdx
@@ -128,7 +128,7 @@ final $Custom = _Story(
     return MyWidget(
       title: 'Custom Title',
       isEnabled: true,
-      count: args.number.value,
+      count: args.number,
       status: MyStatus.inactive,
     );
   },

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -110,7 +110,7 @@ final $Default = _Story(
       run: (tester, args) async {
         // You can simulate interactions here
         // For example, tap the button
-        // await tester.tap(find.text(args.label.value));
+        // await tester.tap(find.text(args.label));
 
         // Or you can also expect certain behaviors
         // expect(...);

--- a/docs/stories/overview.mdx
+++ b/docs/stories/overview.mdx
@@ -45,21 +45,21 @@ final $Primary = _Story(
     text: StringArg('Primary'),
     state: EnumArg<ButtonState>(ButtonState.primary, values: ButtonState.values),
   ),
-)
+);
 
 final $Secondary = _Story(
   args: _Args(
     text: StringArg('Secondary'),
     state: EnumArg<ButtonState>(ButtonState.secondary, values: ButtonState.values),
   ),
-)
+);
 
 final $Disabled = _Story(
   args: _Args(
     text: StringArg('Disabled'),
     state: EnumArg<ButtonState>(ButtonState.disabled, values: ButtonState.values),
   ),
-)
+);
 ```
 
 ## Stories for Screens


### PR DESCRIPTION
Several code samples did not compile or contained leftover/garbled lines:

- `grid-addon`: removed the `GridMode` example — `GridAddon` has no adjustable value, so there is no corresponding mode.
- `viewport-addon` and `text-scale-addon`: removed stray leftover code after the scenario examples.
- `semantics-addon`: fixed a typo (`Config)` → `Config(`).
- `stories/overview`: added the missing semicolons to the story declarations.
- `args/overview` and `quick-start`: a generated `args.<name>` getter already returns the value, so dropped the extra `.value`.
