### PR TITLE
docs(contribution): use valid dart format/analyze commands

### DIFF
--- a/docs/contribution/quick-guide.mdx
+++ b/docs/contribution/quick-guide.mdx
@@ -28,8 +28,8 @@
 1. Synchronize your fork with the main repo.
 2. Create a new branch: `git checkout -b your-branch-name`
 3. Implement and test your changes.
-4. Format code: `dart fmt -w .`
-5. Analyze code: `dart analyzer --fatal-infos --fatal-warnings .`
+4. Format code: `dart format .`
+5. Analyze code: `dart analyze --fatal-infos --fatal-warnings .`
 6. Commit your changes with a meaningful message.
 7. Update or add documentation as needed.
 8. Ensure all tests pass: `flutter test`


### PR DESCRIPTION
The contribution quick guide listed two commands that don't exist:

- `dart fmt -w .` → `dart format .` (`dart fmt` is not a command, and `dart format` has no `-w` flag — it overwrites in place by default).
- `dart analyzer ...` → `dart analyze ...` (the command is `dart analyze`).
