### PR TITLE
docs: reference v4 components.g.dart in telemetry page

### DIFF
--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -21,8 +21,8 @@ To opt-out from telemetry:
 
 ## Collected Data
 
-A new telemetry report after you run the `build_runner build` command,
-if the `*.directories.g.dart` file has changed.
+A new telemetry report is sent after you run the `build_runner build` command,
+if the `components.g.dart` file has changed.
 
 We send the following information, which **has no personal data**:
 


### PR DESCRIPTION
The telemetry page referenced `*.directories.g.dart`, which was the v3 generated file. In v4 the generated registry is `components.g.dart` (this is the file the telemetry builder watches).

Updates the filename and completes the sentence (it was missing a verb).
