### PR TITLE
docs(stories): link the up-to-date v4 LLM prompt

### DIFF
--- a/docs/stories/generate-with-llm.mdx
+++ b/docs/stories/generate-with-llm.mdx
@@ -7,7 +7,7 @@ Large Language Models (LLMs) can help automate this process by generating storie
 
 ## Prompt
 
-You can find the recommended prompt in the [`prompt.md (outdated)`](https://github.com/widgetbook/widgetbook/tree/main/docs/assets/guides/stories-llm-generation/prompt.md) file.
+You can find the recommended prompt in the [`prompt.md`](https://github.com/widgetbook/widgetbook/tree/v4/docs/assets/guides/stories-llm-generation/prompt.md) file.
 
 <Info>
   We'd love your feedback on this prompt! Feel free to [start a


### PR DESCRIPTION
The "Generate Stories with LLMs" page linked the prompt from the `main` (v3) branch and labelled it "(outdated)", even though the up-to-date v4 prompt lives on the `v4` branch at the same path.

Points the link at the `v4` branch and drops the "(outdated)" label.
