### PR TITLE
docs: fix page titles and heading levels

### DIFF
--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -17,3 +17,6 @@ The CLI provides the following commands:
 - [init](/cli/commands/init)
 - [cloud build push](/cli/commands/cloud-build-push)
 - [coverage](/cli/commands/coverage)
+- `upgrade` — update the CLI to the latest version
+
+Run `widgetbook --version` to print the installed CLI version.

--- a/docs/cloud/guides/azure/enforce-reviews.mdx
+++ b/docs/cloud/guides/azure/enforce-reviews.mdx
@@ -1,4 +1,4 @@
-## Enforcing reviews
+# Enforce reviews with Azure DevOps
 
 Depending on your goals and workflow, you may want to enforce reviews for all changes in your project, requiring an accepted Widgetbook review for each pull request with changes.
 

--- a/docs/cloud/guides/azure/upload.mdx
+++ b/docs/cloud/guides/azure/upload.mdx
@@ -1,4 +1,4 @@
-# Widgetbook Cloud x Azure
+# Upload builds with Azure Pipelines
 
 If you want to use Widgetbook Cloud with your existing Azure DevOps project, here's a step-by-step guide to help you get started.
 

--- a/docs/cloud/guides/bitbucket/self-hosted.mdx
+++ b/docs/cloud/guides/bitbucket/self-hosted.mdx
@@ -1,4 +1,4 @@
-# Widgetbook Cloud x Self-hosted Bitbucket
+# Use Widgetbook Cloud with self-hosted Bitbucket
 
 If you want to use Widgetbook Cloud with your self-hosted Bitbucket instance (e.g. `bitbucket.acme.com`), here's a pre-requisite guide to help you get started, then you can follow our normal [Bitbucket setup guide](/cloud/guides/bitbucket/upload).
 

--- a/docs/cloud/guides/bitbucket/upload.mdx
+++ b/docs/cloud/guides/bitbucket/upload.mdx
@@ -1,4 +1,4 @@
-# Widgetbook Cloud x Bitbucket
+# Upload builds with Bitbucket Pipelines
 
 If you want to use Widgetbook Cloud with your existing Bitbucket repository, here's a step-by-step guide to help you get started.
 

--- a/docs/cloud/guides/codemagic/upload.mdx
+++ b/docs/cloud/guides/codemagic/upload.mdx
@@ -1,4 +1,4 @@
-# Widgetbook Cloud x Codemagic
+# Upload builds with Codemagic
 
 Codemagic is just a CI/CD platform, which means it needs to be accompanied by a version control system (i.e. [GitHub](/cloud/guides/github/upload), [GitLab](/cloud/guides/gitlab/upload), [Azure](/cloud/guides/azure/upload) or [Bitbucket](/cloud/guides/bitbucket/upload)). In this guide, we will just be showing the workflow setup, but you need to check other version control system guides to make the [Widgetbook Cloud Reviews](/cloud/reviews) work.
 

--- a/docs/cloud/guides/github/enforce-reviews.mdx
+++ b/docs/cloud/guides/github/enforce-reviews.mdx
@@ -1,4 +1,4 @@
-## Enforcing reviews
+# Enforce reviews with GitHub
 
 Depending on your goals and workflow, you may want to enforce reviews for all changes in your project, requiring an accepted Widgetbook review for each pull request with changes.
 

--- a/docs/cloud/guides/github/upload.mdx
+++ b/docs/cloud/guides/github/upload.mdx
@@ -1,4 +1,4 @@
-# Upload builds with GitHub Actions 
+# Widgetbook Cloud x GitHub
 
 If you want to use Widgetbook Cloud with your existing GitHub repository, here's a step-by-step guide to help you get started.
 

--- a/docs/cloud/guides/github/upload.mdx
+++ b/docs/cloud/guides/github/upload.mdx
@@ -1,4 +1,4 @@
-# Widgetbook Cloud x GitHub
+# Upload builds with GitHub Actions
 
 If you want to use Widgetbook Cloud with your existing GitHub repository, here's a step-by-step guide to help you get started.
 

--- a/docs/cloud/guides/gitlab/self-managed.mdx
+++ b/docs/cloud/guides/gitlab/self-managed.mdx
@@ -1,4 +1,4 @@
-# Widgetbook Cloud x Self-managed GitLab
+# Use Widgetbook Cloud with self-managed GitLab
 
 <Info>
   This guide works for both **GitLab self-managed** and **GitLab Dedicated**.

--- a/docs/cloud/guides/gitlab/upload.mdx
+++ b/docs/cloud/guides/gitlab/upload.mdx
@@ -1,4 +1,4 @@
-# Widgetbook Cloud x GitLab
+# Upload builds with GitLab CI/CD
 
 If you want to use Widgetbook Cloud with your existing GitLab repository, here's a step-by-step guide to help you get started.
 

--- a/docs/cloud/reviews/figma.mdx
+++ b/docs/cloud/reviews/figma.mdx
@@ -4,7 +4,7 @@ Widgetbook Cloud Review helps verify that developers meet **design requirements*
 
 <Image src="/assets/cloud/figma-review.png" zoom />
 
-### Guide
+## Guide
 
 To display a "View in Figma" button in your reviews, add the Figma URL to your use cases:
 

--- a/docs/cloud/reviews/request-reviewer.mdx
+++ b/docs/cloud/reviews/request-reviewer.mdx
@@ -8,7 +8,7 @@
 Invite teammates to participate in a Widgetbook Cloud visual pull request by requesting them as reviewers. 
 Requested reviewers are added to the reviewers list with a status of `Pending` until they submit their decision.
 
-### How to request reviewers
+## How to request reviewers
 
 <Steps>
   <Step title="Open the reviews context menu">

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,4 +1,4 @@
-# Overview
+# Why Widgetbook?
 
 Widgetbook is a sandbox for building **widgets and screens in isolation**. 
 It helps you develop and share hard-to-reach states and edge cases without needing to run your whole app. 


### PR DESCRIPTION
Small page-title / heading fixes so pages are easier to find and scan (and so the auto-generated navigation and llms.txt sections read correctly):

- Home page H1 now matches its sidebar label ("Why Widgetbook?" instead of "Overview").
- GitHub upload guide title now follows the "Widgetbook Cloud x <provider>" pattern used by the other providers.
- The GitHub and Azure "Enforce reviews" pages now start with a real H1 instead of jumping straight to an H2.
- Figma Reviews and Request a Reviewer no longer skip from H1 to H3.
- The CLI overview now lists the `upgrade` command and the `--version` flag.
