### PR TITLE
docs(addons): remove non-existent addons from order lists

### DIFF
--- a/docs/addons/alignment-addon.mdx
+++ b/docs/addons/alignment-addon.mdx
@@ -44,12 +44,10 @@ Since the [order of addons](/addons/overview#order-of-addons) matters, here are 
 Addons that should come before the `AlignmentAddon`:
 
 - `ViewportAddon`
-- `DeviceFrameAddon`
 - `ThemeAddon`
 - `MaterialThemeAddon`
 - `CupertinoThemeAddon`
 - `GridAddon`
-- `InspectorAddon`
 
 Addons that should come after the `AlignmentAddon`:
 

--- a/docs/addons/grid-addon.mdx
+++ b/docs/addons/grid-addon.mdx
@@ -21,7 +21,6 @@ Since the [order of addons](/addons/overview#order-of-addons) matters, here are 
 Addons that should come before the `GridAddon`:
 
 - `ViewportAddon`
-- `DeviceFrameAddon`
 
 Addons that should come after the `GridAddon`:
 

--- a/docs/addons/text-scale-addon.mdx
+++ b/docs/addons/text-scale-addon.mdx
@@ -42,7 +42,6 @@ Since the [order of addons](/addons/overview#order-of-addons) matters, here are 
 Addons that should come before the `TextScaleAddon`:
 
 - `ViewportAddon`
-- `DeviceFrameAddon`
 
 ## Mode
 

--- a/docs/addons/theme-addon.mdx
+++ b/docs/addons/theme-addon.mdx
@@ -142,7 +142,6 @@ Since the [order of addons](/addons/overview#order-of-addons) matters, here are 
 Addons that should come before the `ThemeAddon`:
 
 - `ViewportAddon`
-- `DeviceFrameAddon`
 
 ## Mode
 

--- a/docs/addons/zoom-addon.mdx
+++ b/docs/addons/zoom-addon.mdx
@@ -20,7 +20,6 @@ Since the [order of addons](/addons/overview#order-of-addons) matters, here are 
 Addons that should come before the `ZoomAddon`:
 
 - `ViewportAddon`
-- `DeviceFrameAddon`
 - `AlignmentAddon`
 
 ## Mode


### PR DESCRIPTION
The addon "Order" sections listed `DeviceFrameAddon` and `InspectorAddon`, which don't exist in Widgetbook v4. Removes those stale references from the ordering guidance on the affected addon pages.
