### PR TITLE
docs(contribution): fix invalid dart format command in workflow guide

### DIFF
--- a/docs/contribution/workflow.mdx
+++ b/docs/contribution/workflow.mdx
@@ -48,7 +48,7 @@ detailed walkthrough of the process:
   tool.
 
   ```bash
-  dart format -w .
+  dart format .
   ```
 
 ### 4. Analyze Your Code


### PR DESCRIPTION
`dart format` has no `-w` flag — it overwrites files in place by default (`dart format -w .` errors out). Fixes the command in the contribution workflow guide to `dart format .` (same fix already applied to the quick guide).
