### PR TITLE
docs: point DocBlock source link at the v4 branch

### DIFF
--- a/docs/docs/styling.mdx
+++ b/docs/docs/styling.mdx
@@ -109,7 +109,7 @@ See [Customize](/docs/customize) for per-component overrides and list manipulati
 
 The built-in DocBlocks are simple, most are under 20 lines. You can browse the source to see how they access component data and render content, then use them as a starting point for your own:
 
-[View DocBlock source on GitHub](https://github.com/widgetbook/widgetbook/tree/main/packages/widgetbook/lib/src/core/docs)
+[View DocBlock source on GitHub](https://github.com/widgetbook/widgetbook/tree/v4/packages/widgetbook/lib/src/core/docs)
 
 Patterns you'll find in the source:
 


### PR DESCRIPTION
The "View DocBlock source" link in the styling docs pointed at the `main` (v3) branch. Points it at the `v4` branch so it shows the source that matches the v4 documentation.
