### PR TITLE
docs: replace v3 'use case' terminology with 'story'

### DIFF
--- a/docs/addons/alignment-addon.mdx
+++ b/docs/addons/alignment-addon.mdx
@@ -1,6 +1,6 @@
 # Alignment Addon
 
-Wraps all stories with an [`Align`](https://api.flutter.dev/flutter/widgets/Align-class.html) widget. This is useful when you want to center all your use cases without having to wrap each one of them manually.
+Wraps all stories with an [`Align`](https://api.flutter.dev/flutter/widgets/Align-class.html) widget. This is useful when you want to center all your stories without having to wrap each one of them manually.
 
 Without this addon, all your stories will be aligned in the top-left corner, unless you wrap them in a `Center` widget or similar.
 

--- a/docs/addons/overview.mdx
+++ b/docs/addons/overview.mdx
@@ -1,8 +1,8 @@
 # Introduction to Addons
 
-Addons in Widgetbook provide a flexible and customizable way to enhance your development environment. They allow you to wrap all your use cases with configurable widgets that can be controlled via Widgetbook's UI.
+Addons in Widgetbook provide a flexible and customizable way to enhance your development environment. They allow you to wrap all your stories with configurable widgets that can be controlled via Widgetbook's UI.
 
-For example, if you want to center all your use cases using the [`Align`](https://api.flutter.dev/flutter/widgets/Align-class.html) widget, you can use the [`AlignmentAddon`](/addons/alignment-addon) instead of manually wrapping each use case.
+For example, if you want to center all your stories using the [`Align`](https://api.flutter.dev/flutter/widgets/Align-class.html) widget, you can use the [`AlignmentAddon`](/addons/alignment-addon) instead of manually wrapping each story.
 
 ```dart title=widgetbook/lib/widgetbook.config.dart
 final config = Config(

--- a/docs/cloud/reviews/figma.mdx
+++ b/docs/cloud/reviews/figma.mdx
@@ -6,7 +6,7 @@ Widgetbook Cloud Review helps verify that developers meet **design requirements*
 
 ## Guide
 
-To display a "View in Figma" button in your reviews, add the Figma URL to your use cases:
+To display a "View in Figma" button in your reviews, add the Figma URL to your stories:
 
 1. In your Figma design file, navigate to the component that matches your widget.
 1. Copy the link to the component by right-clicking and selecting `Copy/Paste as` > `Copy Link`.
@@ -19,7 +19,7 @@ To display a "View in Figma" button in your reviews, add the Figma URL to your u
    )
    ```
 
-1. Re-run `build_runner` to update the use case metadata:
+1. Re-run `build_runner` to update the story metadata:
 
    ```bash
    dart run build_runner build -d

--- a/docs/cloud/reviews/index.mdx
+++ b/docs/cloud/reviews/index.mdx
@@ -45,4 +45,4 @@ Both types of reviews are important to ensure the code is correct and the design
 To give reviewers more power, you can use the following features:
 
 1. [**Figma Reviews**](/cloud/reviews/figma): Compare the implementation with the Figma design.
-1. [**Multi Snapshot Reviews**](/cloud/snapshots/overview): Generate snapshots for each use case in multiple configurations (e.g., themes, locales, devices) to ensure UI consistency across all configurations.
+1. [**Multi Snapshot Reviews**](/cloud/snapshots/overview): Generate snapshots for each story in multiple configurations (e.g., themes, locales, devices) to ensure UI consistency across all configurations.

--- a/docs/cloud/reviews/submit.mdx
+++ b/docs/cloud/reviews/submit.mdx
@@ -27,7 +27,7 @@ The available statuses are:
 
 <Image src="/assets/cloud/reviews/mark-as-viewed.png" zoom />
 
-Click the "mark as viewed" button in the top-right of a use case diff to mark changes as reviewed.
+Click the "mark as viewed" button in the top-right of a story diff to mark changes as reviewed.
 If you are iterating on a pull request, the diff will remain marked as viewed as long as no new changes are introduced. 
 When changes occur, the viewed state resets and you must review the changes again.
 
@@ -44,4 +44,4 @@ Changes are highlighted in pink, making it easy to spot even small differences.
 
 <Image src="/assets/cloud/reviews/add-comment.png" zoom />
 
-Use the comment section of a use case diff to provide detailed feedback to the author of the pull request.
+Use the comment section of a story diff to provide detailed feedback to the author of the pull request.


### PR DESCRIPTION
Replaces the leftover v3 term "use case(s)" with the v4 term "story/stories" across the addon and Cloud review docs (8 occurrences in 5 files). One genuine English usage ("a common use case is…") in the Args page is intentionally left unchanged.
