### PR TITLE
docs: add coding agents guide and widgetbook-v4 skill

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -222,6 +222,10 @@
         {
           "title": "Fields",
           "href": "/essentials/fields"
+        },
+        {
+          "title": "Coding Agents",
+          "href": "/essentials/coding-agents"
         }
       ]
     },

--- a/docs/essentials/coding-agents.mdx
+++ b/docs/essentials/coding-agents.mdx
@@ -1,0 +1,59 @@
+# Using Widgetbook with Coding Agents
+
+Widgetbook v4 generates a typed, readable story API and runs your scenarios under `flutter test`. That combination is what makes coding agents (Claude Code, Cursor, Copilot) effective on a design system: an agent can read your existing stories, mirror a widget change into a new story, run the snapshot tests, and iterate until they pass — a real feedback loop instead of guesswork.
+
+This page gives you two drop-in pieces:
+
+1. A **Claude Code skill** that teaches the agent the full v4 story API and workflow.
+2. A short **CLAUDE.md** section that points the agent at the skill and the non-negotiable rules.
+
+## 1. Install the skill (Claude Code)
+
+Claude Code auto-loads skills from `.claude/skills/` in your repo. Copy the `widgetbook-v4` skill into place:
+
+```
+your_app/
+└── .claude/
+    └── skills/
+        └── widgetbook-v4/
+            ├── SKILL.md
+            └── reference/
+                ├── api-reference.md
+                ├── component-stories.md
+                ├── figma-loop.md
+                ├── migration.md
+                └── cloud-and-ci.md
+```
+
+Grab the files from the Widgetbook repo: [skills/widgetbook-v4](https://github.com/widgetbook/widgetbook/tree/main/skills/widgetbook-v4). Commit them to your repo so your whole team's agents share the same instructions.
+
+Once the folder is in place, the skill activates automatically whenever you mention Widgetbook, stories, visual regression, or accessibility testing — no extra configuration.
+
+## 2. Add the Widgetbook section to CLAUDE.md
+
+`CLAUDE.md` at your repo root is loaded into every Claude Code session. Append this section — don't overwrite an existing `CLAUDE.md`, just add these lines:
+
+```markdown title="CLAUDE.md"
+## Widgetbook
+
+When you add or change a widget in `lib/`, reflect it in Widgetbook — don't leave a widget without a story or a story stale. Use the **widgetbook-v4** skill (in `.claude/skills/widgetbook-v4/`) for the full API and workflow. In short:
+
+- Add or update the widget's `*.stories.dart` in `widgetbook/lib/` (never in `lib/`), mirroring the widget's path.
+- Write a `_Scenario` for every meaningful state, plus a `meetsGuideline` accessibility scenario for interactive widgets.
+- Regenerate and test from inside `widgetbook/`: `dart run build_runner build -d` then `flutter test`.
+- Use your design-system widgets, not raw Material (e.g. an `AppButton` wrapper, not `ElevatedButton` directly).
+- Use design tokens (colors, spacing, radius), not hardcoded literals.
+```
+
+## What the agent will do
+
+With both pieces in place, when you ask the agent to add or change a widget it will:
+
+1. Mirror the change into a `*.stories.dart` in `widgetbook/lib/`, one story per meaningful state.
+2. Run `dart run build_runner build -d` and `flutter test` from `widgetbook/`, reading snapshot and layout failures (including `RenderFlex` overflows) and fixing them.
+3. If you provide a Figma node, compare the widget's design tokens against the design and flag mismatches.
+4. Iterate until the tests are green before opening a PR.
+
+## Other agents (Cursor, Copilot, …)
+
+The skill folder is a Claude Code convention, but the CLAUDE.md section above is plain guidance. Drop the same content into your agent's instructions file — `.cursor/rules` for Cursor, `.github/copilot-instructions.md` for GitHub Copilot — to get the same rules. The `SKILL.md` reference files are readable as plain Markdown context for any agent.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,15 @@
+# Skills
+
+Coding-agent skills to copy into your own project — not part of any published package.
+
+## widgetbook-v4
+
+A [Claude Code skill](https://docs.claude.com/en/docs/claude-code/skills) that teaches an agent the Widgetbook v4 story API and the write-stories → test → compare-to-Figma feedback loop.
+
+To use it, copy the folder into your app's `.claude/skills/` and commit it:
+
+```
+your_app/.claude/skills/widgetbook-v4/
+```
+
+See [Using Widgetbook with Coding Agents](https://docs.widgetbook.io/essentials/coding-agents) for the full setup, including the `CLAUDE.md` snippet.

--- a/skills/widgetbook-v4/SKILL.md
+++ b/skills/widgetbook-v4/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: widgetbook-v4
+description: Write, generate, and work with Widgetbook v4 stories, args, scenarios, and component documentation for Flutter design systems. Use this skill whenever the user mentions Widgetbook, wants to write stories for Flutter widgets, wants to set up UI testing with Scenarios, wants to add accessibility testing to widgets, wants to catch visual bugs like overflows, wants to make a Flutter widget match its Figma design, wants to use Widgetbook in an agentic engineering workflow, or asks about visual regression testing or design review for Flutter. Also use when the user wants to connect Widgetbook Cloud to a Flutter CI pipeline, or asks about the difference between v3 and v4.
+---
+
+# Widgetbook v4
+
+Widgetbook v4 generates a typed story API (`Meta`, `_Story`, `_Args`, `_Scenario`) from your Flutter widgets via `build_runner`, so stories are type-safe and readable by coding agents. Use it to catalogue widgets, snapshot every state, and verify UI against the design system and Figma.
+
+This file is the working set. Load a reference file only when the task needs it:
+
+- **`reference/api-reference.md`**: the full `Meta` / `Args` / `Scenario` / `Modes` / docs API, story-file conventions, a complete example, and the full mistakes list. Read before writing a non-trivial story or when unsure of a signature.
+- **`reference/component-stories.md`**: the fast-path recipe for adding a component — one story per state, the knobs-bag pattern, viewport defaults, dual registration, and the gotchas that cost the most iterations. Read before adding a new component's stories.
+- **`reference/figma-loop.md`**: the exact Figma MCP tool calls, node mapping, and recovery paths. Read when comparing against Figma.
+- **`reference/migration.md`**: v3 and old-beta migrations. Read when touching legacy stories.
+- **`reference/cloud-and-ci.md`**: Widgetbook Cloud and CI setup. Read for pipeline work.
+
+## Workspace rule (non-negotiable)
+
+The Widgetbook workspace is its own Flutter package that lives outside the app's `lib`, as a sibling `widgetbook/` folder. Never put Widgetbook or `*.stories.dart` inside `lib`. Story files live in `widgetbook/lib/`, mirroring the widget's path in the app. Run `dart run build_runner build -d` and `flutter test` from inside `widgetbook/`. Full layout and the app/workspace dependency setup are in `reference/api-reference.md`.
+
+## API essentials
+
+Enough to write a correct story. Full API in `reference/api-reference.md`.
+
+- **Meta** uses a constructor tear-off and must be `const`: `const meta = Meta(AppButton.new);`. Declare one `Meta` per constructor; every `Meta` in a file targets the same widget.
+- **Story**: `final $Primary = _Story(name: 'Primary', args: ...);`. Each story is a `$`-prefixed variable; set the display name with `name:`.
+- **Args**: `_Args(label: StringArg('Save'), onPressed: Arg.fixed(() {}))` produces interactive knobs. `_Args.fixed(label: 'Save', onPressed: () {})` takes raw values with no knobs and is the usual form inside scenarios. Callbacks are never interactive.
+- **Scenario**: one auto-snapshotted state, run under `flutter test`:
+  ```dart
+  scenarios: [_Scenario(name: 'Disabled', args: _Args.fixed(isEnabled: false))]
+  ```
+- **Accessibility**: assert Flutter's guideline matchers inside a scenario `run`:
+  ```dart
+  run: (tester, args) async {
+    final handle = tester.ensureSemantics();
+    await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+    await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+    await expectLater(tester, meetsGuideline(textContrastGuideline));
+    handle.dispose();
+  },
+  ```
+- Regenerate after any `Meta` or constructor change: `dart run build_runner build -d` inside `widgetbook/`.
+
+## The agentic feedback loop
+
+When you add or change a widget, run this loop until it converges. Do not stop early.
+
+1. **Reflect the change.** Add or update the widget's `*.stories.dart` in `widgetbook/lib/`. Add **one `$Story` per meaningful state** (each is browsable in the app; scenarios are test-only and don't show there), plus a `meetsGuideline` scenario if the widget is interactive. Register the component in BOTH the app config and the golden test. See `reference/component-stories.md`.
+
+2. **Run `flutter test`** from `widgetbook/`. It renders each scenario, writes a snapshot to `widgetbook/build/.widgetbook`, and fails on assertion errors and on layout errors including `RenderFlex` overflows. Read the named failure, fix it, and re-run until green.
+
+3. **Map the widget to its Figma node.** Code Connect does not support Flutter, so there is no automatic widget-to-node mapping. Get the node from the user: the `fileKey` and `nodeId` parsed from a Figma link they provide, or the current selection when they are in the Figma desktop app. If you have a link to the frame but not the exact node, call `get_metadata` to list the document's nodes and match by layer name, then confirm with the user. If no node is available, skip steps 4 and 5 and note in the PR that the design comparison was skipped.
+
+4. **Compare properties. This is the gate.** Call `get_variable_defs` for the node to get its tokens (colors, spacing, radius, typography), and `get_design_context` for structure when needed. Confirm the widget resolves the same design tokens, not just matching literals: if Figma specifies `colorScheme.error` at `#DC2626`, a hardcoded `Color(0xFFFF0000)` is a mismatch even when it looks close.
+
+5. **Compare the render. This is a sanity check.** Call `get_screenshot` for the node and compare it against the Widgetbook snapshot from step 2. Look for structural differences in layout, spacing, sizing, and typography. Do not chase a pixel-exact match; anti-aliasing and font hinting always differ, so the property check in step 4 is what decides parity.
+
+Iterate from step 1 until all three hold at once: `flutter test` is green with no overflow or layout errors, every token from `get_variable_defs` resolves to a token in the widget, and the render shows no structural difference from the Figma screenshot. Then open a PR. Tool details, node-id extraction, and recovery paths are in `reference/figma-loop.md`.
+
+## Screens are widgets too — catalogue them
+
+A screen (anything that returns a `Scaffold` or owns a full-page layout) is a widget in `lib/`, so the same rule applies: when you build or change a screen, give it a story. Do **not** leave an assembled screen as an untracked "composition" just because it only wires existing components together — if it's not in Widgetbook, no one can browse it and nothing snapshot-tests its layout. Build the screen by composing design-system widgets (extract any new repeated element as its own component with its own stories first), then catalogue the screen itself. Screens differ from leaf components in exactly two ways:
+
+- **Viewport — a screen needs a device frame, not `Viewports.none`.** A `Scaffold` cannot lay out under the unbounded constraints that `Viewports.none` produces. Pin a device with a `ViewportMode` on the story so it gets bounded constraints (the device must be listed in the `ViewportAddon` in `widgetbook.config.dart`):
+  ```dart
+  const component = ComponentMeta(name: 'Home', path: 'Screens');
+  const meta = Meta(HomeScreen.new);
+  final $Home = _Story(name: 'Home', modes: [ViewportMode(IosViewports.iPhone13ProMax)]);
+  ```
+  Register the screen's generated `<Name>Component` in the app `config` like any other component. Keep a Flutter import in the story file (e.g. `package:flutter/widgets.dart`) so the generated `Key` reference compiles.
+- **Testing — snapshot the screen in the golden test at its device viewport, and at the *narrowest* device you support.** Register the screen's generated `<Name>Component` in the golden test's `components` list like any other component (register in BOTH places — see the golden-registration mistake below). A full `Scaffold` won't fit the small component surface, so size the golden harness's root `SizedBox` to phone-portrait (e.g. `Size(390, 844)`); a too-small surface is the only reason to ever exclude a screen — enlarge it instead of dropping the snapshot. The golden `Config` also needs the same `ViewportAddon` (listing every device your screen stories pin) as `widgetbook.config.dart`, or the `ViewportMode` throws `Modes [ViewportMode] do not have a corresponding addon in config`.
+
+  A `RenderFlex` overflow hides at a comfortable width and only bites at the smallest one, so give every screen a **narrowest-supported-device story** (iPhone SE, 375px) next to its default device — that snapshot is what actually catches the overflow. A screen that lays out fine at 390px can overflow by a few pixels at 375px:
+  ```dart
+  final $Home = _Story(name: 'Home', modes: [ViewportMode(IosViewports.iPhone13ProMax)]);
+  final $HomeIPhoneSE = _Story(
+    name: 'Home · iPhone SE',
+    setup: (context, child, args) => Center(
+      child: SizedBox(
+        width: IosViewports.iPhoneSE.maxWidth,
+        height: IosViewports.iPhoneSE.maxHeight,
+        child: child,
+      ),
+    ),
+  );
+  ```
+  A plain `flutter_test` widget test that pumps the screen and asserts key content (`find.text(...)`, theme colours) is still worth keeping for semantics — but it is **not** a substitute: a single-width smoke test that only checks text presence sails straight past a small overflow.
+
+Everything else in the feedback loop is the same: regenerate, run `flutter test` until green, and compare the rendered screen against its Figma frame node. After adding or changing a screen, actually open its snapshots under `widgetbook/build/.widgetbook/<Screen>/…` and look — under `flutter test` text renders as filled Ahem boxes, so the snapshot verifies layout, spacing, sizing, and overflow, not glyphs.
+
+## Always do
+
+1. Run `grep -rE "= Meta\(" . --include="*.stories.dart" --exclude-dir=build` to list components.
+2. Read the story files relevant to the task.
+3. Use design-system widgets, never raw Material (no `ElevatedButton` when `AppButton` exists).
+4. Put the story in `widgetbook/lib/` (never `lib/`), immediately after writing the widget.
+5. Add one `$Story` per meaningful state (browsable), a `meetsGuideline` scenario for interactive widgets, and register the component in BOTH the app config and the golden test.
+6. Catalogue full **screens** too, not just leaf components: a story under `path: 'Screens'` at your default device **and** a second story at the narrowest device you support (iPhone SE, 375px), both registered in the golden test so each gets snapshot-tested for overflow. Keep a widget smoke test for content/semantics. See "Screens are widgets too".
+7. Run the feedback loop above to convergence.
+8. Only then open a PR.
+
+## Top mistakes
+
+- **Encoding browsable states as `scenarios`.** Scenarios only render under `flutter test`; the running app shows one render per `$Story`. Use one `$Story` per state. See `reference/component-stories.md`.
+- **Registering a component in only one place.** It must be in both the app `config` and the golden test's `components`, or its stories silently don't run (no error — the test count just doesn't rise).
+- **A device `ViewportMode` on a leaf-component story.** It frames a lone button in a phone canvas. Use `Viewports.none` (natural size) and bound the golden test's own root with a `SizedBox`. (Screens are the exception — they *require* a device `ViewportMode`; see "Screens are widgets too".)
+- **Leaving a full screen uncatalogued because it's "just a composition."** A screen is a widget in `lib/` — give it a story (`path: 'Screens'`, a device `ViewportMode`, a widget smoke test). If you built a screen and only catalogued its sub-components, you're not done.
+- **Snapshotting a screen at only one comfortable width.** Overflow hides at 390px and bites at 375px (iPhone SE). Give every screen a narrowest-device story and put it in the golden test — a single-width smoke test that only asserts text presence sails past an 11px `RenderFlex` overflow.
+- Widgetbook or a `*.stories.dart` placed inside `lib`. It belongs in the `widgetbook/` package.
+- `Meta<Widget>()` (old) instead of `Meta(Widget.new)`. Move any `name`, `path`, or `docsBuilder` to a `ComponentMeta`.
+- Wrapping values in `StringArg` or `BoolArg` inside `_Args.fixed(...)`; that form takes raw values.
+- Hardcoded colors or spacing instead of design tokens.
+
+Full mistakes list with rationale: `reference/api-reference.md`.

--- a/skills/widgetbook-v4/SKILL.md
+++ b/skills/widgetbook-v4/SKILL.md
@@ -48,6 +48,18 @@ When you add or change a widget, run this loop until it converges. Do not stop e
 
 1. **Reflect the change.** Add or update the widget's `*.stories.dart` in `widgetbook/lib/`. Add **one `$Story` per meaningful state** (each is browsable in the app; scenarios are test-only and don't show there), plus a `meetsGuideline` scenario if the widget is interactive. Register the component in BOTH the app config and the golden test. See `reference/component-stories.md`.
 
+  **Cover every mode the design defines.** If the Figma tokens come from a multi-mode collection — the Figma file might have **Light and Dark** mode — then every mode is part of the spec, and a mode you don't snapshot is a mode nothing tests. The golden `appBuilder` renders one theme (Light), so add a scenario per extra mode with a `MaterialThemeMode` so it is actually rendered and snapshotted under `flutter test`:
+
+   ```dart
+   _Scenario(
+     name: 'dark',
+     modes: [MaterialThemeMode('Dark', AppTheme.dark)],
+     args: _Args.fixed(/* the same meaningful state */),
+   ),
+   ```
+
+   The `MaterialThemeMode` only applies if a `MaterialThemeAddon` is registered in the golden `Config` (mirroring `widgetbook.config.dart`), or it throws `Modes [MaterialThemeMode] do not have a corresponding addon in config`. To guarantee the coverage across *all* components at once — so no author can forget it — register a global `ScenarioDefinition(name: 'Dark', modes: [MaterialThemeMode('Dark', AppTheme.dark)])` on `Config.scenarios` instead of a per-story scenario.
+
 2. **Run `flutter test`** from `widgetbook/`. It renders each scenario, writes a snapshot to `widgetbook/build/.widgetbook`, and fails on assertion errors and on layout errors including `RenderFlex` overflows. Read the named failure, fix it, and re-run until green.
 
 3. **Map the widget to its Figma node.** Code Connect does not support Flutter, so there is no automatic widget-to-node mapping. Get the node from the user: the `fileKey` and `nodeId` parsed from a Figma link they provide, or the current selection when they are in the Figma desktop app. If you have a link to the frame but not the exact node, call `get_metadata` to list the document's nodes and match by layer name, then confirm with the user. If no node is available, skip steps 4 and 5 and note in the PR that the design comparison was skipped.
@@ -104,6 +116,7 @@ Everything else in the feedback loop is the same: regenerate, run `flutter test`
 
 - **Encoding browsable states as `scenarios`.** Scenarios only render under `flutter test`; the running app shows one render per `$Story`. Use one `$Story` per state. See `reference/component-stories.md`.
 - **Registering a component in only one place.** It must be in both the app `config` and the golden test's `components`, or its stories silently don't run (no error — the test count just doesn't rise).
+- **Snapshotting only one theme mode.** The golden `appBuilder` renders Light, so a Light-only suite passes while Dark is broken — exactly how a status surface that reads a fixed primitive (correct in Light) instead of a `context.colors` token (which follows the theme) ships unnoticed. When the design defines Light **and** Dark, snapshot both (per-story `MaterialThemeMode` scenario, or a global `ScenarioDefinition`). The mirror trap: a color on a surface that does *not* theme (e.g. a pill on an always-dark gradient card) should keep the fixed primitive — using a theming token there breaks it in Dark. Decide by whether the surface behind the color themes.
 - **A device `ViewportMode` on a leaf-component story.** It frames a lone button in a phone canvas. Use `Viewports.none` (natural size) and bound the golden test's own root with a `SizedBox`. (Screens are the exception — they *require* a device `ViewportMode`; see "Screens are widgets too".)
 - **Leaving a full screen uncatalogued because it's "just a composition."** A screen is a widget in `lib/` — give it a story (`path: 'Screens'`, a device `ViewportMode`, a widget smoke test). If you built a screen and only catalogued its sub-components, you're not done.
 - **Snapshotting a screen at only one comfortable width.** Overflow hides at 390px and bites at 375px (iPhone SE). Give every screen a narrowest-device story and put it in the golden test — a single-width smoke test that only asserts text presence sails past an 11px `RenderFlex` overflow.

--- a/skills/widgetbook-v4/reference/api-reference.md
+++ b/skills/widgetbook-v4/reference/api-reference.md
@@ -1,0 +1,262 @@
+# Widgetbook v4 API reference
+
+Full detail behind the essentials in `SKILL.md`. Read the section you need.
+
+## Workspace structure
+
+The Widgetbook workspace is its own Flutter package and lives outside the app's `lib`, as a sibling `widgetbook/` folder. Do not put Widgetbook or story files inside `lib`. This is a deliberate change from v3, where Widgetbook could sit inside `lib`, `test`, or a `widgetbook` folder with no defined convention. v4 fixes a single structure so dependencies, code generation, and builds stay predictable.
+
+```
+my_app/
+├── lib/               # app code, no Widgetbook here
+├── test/
+├── widgetbook/        # separate Widgetbook workspace package
+│   ├── lib/           # *.stories.dart live here
+│   └── pubspec.yaml   # widgetbook_workspace; depends on the app
+└── pubspec.yaml       # app; lists widgetbook_workspace as a dev_dependency
+```
+
+There is an intentional cyclic dependency: the workspace depends on the app so it can catalogue the app's widgets, and the app depends on the workspace as a dev dependency so tests can reuse stories. Scaffold with `dart pub global activate widgetbook_cli` then `widgetbook init`. Run `dart run build_runner build -d` and `flutter test` from inside `widgetbook/`.
+
+## Meta
+
+`Meta` declares which widget a story file belongs to, using a constructor tear-off. It is the anchor for all generated types in the file. The widget type is inferred from the tear-off, so no type argument is needed. `Meta` must be `const` because the generator resolves the tear-off via constant evaluation.
+
+```dart
+import 'package:widgetbook/widgetbook.dart';
+
+part 'app_button.stories.g.dart';
+
+const meta = Meta(AppButton.new);
+```
+
+Run `dart run build_runner build -d` inside `widgetbook/` after adding or changing a `Meta`. It generates `_Story`, `_Args`, and `_Scenario` for that widget.
+
+### Multiple constructors per component
+
+A component can catalogue more than one constructor. Declare one `const Meta` per constructor, each targeting the same widget. Named and factory constructors get generated types prefixed with the PascalCase constructor name (`_IconStory`, `_IconArgs`, `_IconScenario`, `_IconDefaults`). Each story is a `$`-prefixed variable; set its display name with `name:`.
+
+```dart
+const meta = Meta(AppButton.new);
+const iconMeta = Meta(AppButton.icon);
+
+final $Default = _Story(name: 'Default', args: _Args(label: StringArg('Save')));
+final $Icon = _IconStory(name: 'Icon', args: _IconArgs(icon: Arg.fixed(Icons.save)));
+```
+
+### Component-level customization with `ComponentMeta`
+
+To set a component's `name`, `path`, or `docsBuilder`, declare an optional `ComponentMeta` (at most one per file) alongside the `Meta`. Use `final` when `docsBuilder` holds a closure, otherwise `const`. Do not declare a parameterless `ComponentMeta`.
+
+```dart
+final component = ComponentMeta(
+  name: 'Card',
+  path: '[containers]/card',
+  docsBuilder: (blocks) => blocks.replaceFirst<DartCommentDocBlock>(
+    const TextDocBlock('A rounded card container.'),
+  ),
+);
+
+const meta = Meta(CustomCard.new);
+```
+
+## Stories
+
+A story is a named variant of a widget:
+
+```dart
+final $Default = _Story(name: 'Default');
+```
+
+## Args
+
+By default, Args are generated from the widget's constructor, one typed `Arg` per parameter. To generate Args from a custom class instead, pass `argsType:` to `Meta`, for example `Meta(AppButton.new, argsType: AppButtonArgs.new)`. Use this when the constructor is a poor testable interface (complex objects, callbacks, providers, mocking). `argsType` also selects a specific constructor of the args class, e.g. `argsType: AppButtonArgs.compact`.
+
+| Constructor parameter type | Arg type |
+|---|---|
+| `String` | `StringArg('value')` |
+| `bool` | `BoolArg(true)` |
+| `int` | `IntArg(0)` |
+| `double` | `DoubleArg(0.0)` |
+| `enum` | `EnumArg(MyEnum.value)` |
+| callbacks / fixed values | `Arg.fixed(value)` |
+
+### `_Args(...)` vs `_Args.fixed(...)`
+
+`_Args(...)` is typed and interactive. Wrap each value in its `Arg` type. These render as knobs in the story viewer. Use it at the story level so people can adjust the widget. Values that should not be interactive use `Arg.fixed(value)`, and callbacks always use `Arg.fixed(() {})`.
+
+```dart
+final $Primary = _Story(
+  name: 'Primary',
+  args: _Args(
+    label: StringArg('Confirm'),
+    variant: EnumArg(ButtonVariant.primary),
+    isEnabled: BoolArg(true),
+    onPressed: Arg.fixed(() {}),
+  ),
+);
+```
+
+`_Args.fixed(...)` is raw and non-interactive. Pass plain values with no `Arg` wrappers, and bare closures for callbacks. There are no knobs. This is the usual form inside scenarios, where each scenario pins one configuration to snapshot.
+
+```dart
+args: _Args.fixed(label: 'This is a very long label', onPressed: () {}),
+```
+
+Inside a scenario's `run` callback, values are still accessed through the arg wrapper, e.g. `args.label.value`.
+
+## Modes
+
+Modes are reusable addon configurations: the exact theme, locale, or viewport to apply when rendering a story.
+
+```dart
+final $Button = _Story(
+  name: 'Button',
+  modes: [
+    MaterialThemeMode('Light', ThemeData.light()),
+    MaterialThemeMode('Dark', ThemeData.dark()),
+  ],
+);
+```
+
+## Scenarios
+
+Scenarios are story-level test configurations. Each defines a set of args and modes to render and snapshot automatically. They are the v4 equivalent of golden tests, defined next to the story, and typically use `_Args.fixed(...)`.
+
+```dart
+final $Primary = _Story(
+  name: 'Primary',
+  scenarios: [
+    _Scenario(name: 'Enabled', args: _Args.fixed(label: 'Click Me', isEnabled: true)),
+    _Scenario(
+      name: 'Disabled dark',
+      modes: [MaterialThemeMode('Dark', ThemeData.dark())],
+      args: _Args.fixed(label: 'Click Me', isEnabled: false),
+    ),
+  ],
+);
+```
+
+Run with `flutter test`. Snapshots land in `widgetbook/build/.widgetbook`.
+
+### Global scenarios
+
+To apply a scenario configuration to every story (for example, always snapshot a Dark variant), define it once in `widgetbook.config.dart` using `ScenarioDefinition` on `Config.scenarios`:
+
+```dart
+final config = Config(
+  scenarios: [
+    ScenarioDefinition(name: 'Dark', modes: [MaterialThemeMode('Dark', ThemeData.dark())]),
+  ],
+);
+```
+
+Use global scenarios for cross-cutting configurations (themes, locales, text scale). Keep per-story scenarios for widget-specific states (loading, error, expired).
+
+## Interaction testing
+
+Scenarios support a `run` callback for interaction tests. With Widgetbook Cloud these run on every PR.
+
+```dart
+_Scenario(
+  name: 'Incremented counter',
+  run: (tester, args) async {
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+    expect(find.text('${args.initialValue.value + 1}'), findsOneWidget);
+  },
+),
+```
+
+## Accessibility testing
+
+Because scenarios run under `flutter test`, assert accessibility guidelines in the same pass with Flutter's `meetsGuideline` matchers (from `flutter_test`), inside a scenario's `run`. Wrap the assertions in a semantics handle and dispose it.
+
+```dart
+_Scenario(
+  name: 'Reject action accessible',
+  args: _Args.fixed(label: 'Reject', onPressed: () {}),
+  run: (tester, args) async {
+    final handle = tester.ensureSemantics();
+    await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+    await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+    await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+    await expectLater(tester, meetsGuideline(textContrastGuideline));
+    handle.dispose();
+  },
+),
+```
+
+The four matchers cover the common WCAG failures for touch UI: tap target size (Android and iOS), a screen-reader label on every interactive element, and text contrast. On failure the output names the offending node and what it expected, which you can act on directly.
+
+## Component documentation
+
+v4 generates docs from your widgets and stories via `DocBlock`s. Configure globally in `Config` or per-component in `ComponentMeta`. Dart doc comments on the widget class are surfaced automatically via `DartCommentDocBlock`.
+
+```dart
+final config = Config(
+  components: components,
+  docsBuilder: () => [
+    const ComponentNameDocBlock(),
+    const DartCommentDocBlock(),
+    const StoriesDocBlock(),
+  ],
+);
+```
+
+## Story file conventions
+
+- **Location and naming:** story files live in `widgetbook/lib/`, outside the app's `lib`. Name them `my_widget.stories.dart` and mirror the widget's path, e.g. `widgetbook/lib/components/app_button.stories.dart`.
+- **Part directive:** always include `part 'my_widget.stories.g.dart';` right after imports.
+- **One widget per file:** every `Meta` in a file targets the same widget. One `const Meta` per constructor, at most one `ComponentMeta`.
+- **Doc comment on the widget class:** write a Dart doc comment on the class explaining purpose and usage constraints. It becomes the component documentation.
+- **Scenario coverage:** cover the states that matter for visual regression (enabled, disabled, loading, error, empty). Use existing stories as the benchmark for thorough.
+- **Accessibility coverage:** for interactive components, add at least one scenario asserting the `meetsGuideline` matchers.
+- **Callbacks:** in `_Args(...)` use `Arg.fixed(() {})`; in `_Args.fixed(...)` pass a bare `() {}`.
+
+### Complete example
+
+```dart
+import 'package:widgetbook/widgetbook.dart';
+import 'package:app/components/status_banner.dart';
+
+part 'status_banner.stories.g.dart';
+
+/// Displays an inline status message.
+/// Used at the top of forms and list screens.
+/// Always set isDismissible: false for blocking errors.
+const meta = Meta(StatusBanner.new);
+
+final $Default = _Story(
+  name: 'Default',
+  scenarios: [
+    _Scenario(
+      name: 'Info',
+      args: _Args.fixed(type: BannerType.info, message: 'Changes saved', isDismissible: true),
+    ),
+    _Scenario(
+      name: 'Success',
+      args: _Args.fixed(type: BannerType.success, message: 'Upload complete', isDismissible: true),
+    ),
+    _Scenario(
+      name: 'Error',
+      args: _Args.fixed(type: BannerType.error, message: 'Upload failed', isDismissible: false),
+    ),
+  ],
+);
+```
+
+## Common mistakes
+
+- **Widgetbook or a story inside `lib`.** It belongs in the `widgetbook/` package.
+- **Forgetting the part directive.** Without `part 'my_widget.stories.g.dart';`, build_runner has nowhere to write generated types and the file will not compile.
+- **Using raw Material widgets.** Scan the story files first and use the design-system widget.
+- **A Default story with no scenarios.** No scenarios means no automated snapshot coverage.
+- **Confusing `_Args` and `_Args.fixed`.** `_Args(...)` takes wrapped `Arg` values and produces knobs. `_Args.fixed(...)` takes raw values with no knobs and is the scenario form. Do not wrap values in `StringArg` or `BoolArg` when using `_Args.fixed`.
+- **Non-fixed callback arg.** Callbacks cannot be interactive. In `_Args(...)` use `Arg.fixed(() {})`; in `_Args.fixed(...)` pass a bare `() {}`.
+- **Skipping accessibility scenarios.** Interactive components should assert `meetsGuideline` so touch-target and labeling regressions are caught in `flutter test`.
+- **Not running build_runner after a constructor change.** Adding, renaming, or removing a constructor parameter requires `dart run build_runner build -d` before writing stories, or the generated `_Args` is stale.
+- **Using `flutter pub run build_runner`.** Deprecated. Use `dart run build_runner build -d`.
+- **The old `Meta<Widget>()` form.** See `reference/migration.md`.
+- **Saying "props".** Flutter widgets have constructor parameters, not props.
+- **Assuming `_Args` equals the constructor.** With a custom `argsType:`, `_Args` may differ. Read the story file first.

--- a/skills/widgetbook-v4/reference/cloud-and-ci.md
+++ b/skills/widgetbook-v4/reference/cloud-and-ci.md
@@ -1,0 +1,12 @@
+# Widgetbook Cloud and CI
+
+Widgetbook Cloud hosts your catalogue and turns the snapshots from `flutter test` into reviewable visual pull requests. It runs golden tests across states, themes, devices, and text scales, surfaces accessibility changes between builds, and can show each widget next to its Figma design.
+
+To connect it to a Flutter CI pipeline:
+
+1. Create a project in Widgetbook Cloud and connect your Git repository.
+2. Add the Widgetbook CLI to your CI job (`dart pub global activate widgetbook_cli`).
+3. On each pull request, run `flutter test` from `widgetbook/` to generate snapshots into `widgetbook/build/.widgetbook`, then push the build with `widgetbook cloud build push`.
+4. Cloud compares the pushed build against the base branch and posts a visual review on the PR, including golden diffs, accessibility changes, and Figma review where configured.
+
+Store your Cloud API key as a CI secret rather than committing it. See the Widgetbook Cloud documentation for the exact CLI flags and ready-made workflow files (GitHub Actions, GitLab CI, and others).

--- a/skills/widgetbook-v4/reference/component-stories.md
+++ b/skills/widgetbook-v4/reference/component-stories.md
@@ -1,0 +1,123 @@
+# Component stories: the fast path
+
+How to add a component's stories so it is browsable, snapshot-tested, and right the first time. Read alongside `api-reference.md` (the API surface) — this file is the *shape* and the *traps* that otherwise cost several iterations.
+
+## The shape that works
+
+**One `$Story` per meaningful state/variant.** In the running app the navigator shows one render per story, using that story's default args. Scenarios do **not** appear in the app — they only render under `flutter test`. So anything you want to *browse* (each state, each type) must be its own `$Story`, not a scenario.
+
+- Set each story's state through story-level `args:` (interactive `_Args(...)`), so it renders that state live *and* stays tweakable from the knobs panel.
+- Reserve `scenarios` for test-only concerns: the accessibility assertion, or an extra snapshot you don't need as a nav entry.
+- Don't add a "Playground" catch-all unless you specifically want a blank knob sandbox — each state story already exposes the knobs.
+
+```dart
+final $Filled = _Story(name: 'Filled', args: _Args(value: StringArg('jane@example.com')));
+final $Focus  = _Story(name: 'Focus',  args: _Args(autofocus: BoolArg(true)));
+final $Error  = _Story(name: 'Error',  args: _Args(errorText: StringArg('Required')));
+```
+
+**Make every state reachable from args, not `run`.** Give the widget the props it needs to *show* a state statically — e.g. `initialValue` (seed text → Filled) and `autofocus` (→ Focus). Then each state is one `$Story` with fixed args and renders identically in the app and in snapshots. A `run` step only executes under `flutter test`, so a state built with `run` looks empty in the live app.
+
+**Widgets with callbacks/controllers need a knobs bag.** A constructor with `onChanged`, a controller, or a focus node is a poor `Args` source. Define a plain data class of just the visual inputs, point `Meta` at it with `argsType:`, and assemble the real widget in a `defaults` builder — which **must return the widget type**, no wrappers:
+
+```dart
+class MyFieldKnobs {
+  const MyFieldKnobs({this.label = '', this.value = '', this.enabled = true});
+  final String label; final String value; final bool enabled;
+}
+const meta = Meta(MyField.new, argsType: MyFieldKnobs.new);
+final defaults = _Defaults(
+  builder: (context, args) => MyField(              // return MyField — not SizedBox(child: MyField(...))
+    label: args.label.isEmpty ? null : args.label,
+    initialValue: args.value.isEmpty ? null : args.value,
+    enabled: args.enabled,
+    onChanged: (_) {},
+  ),
+);
+```
+
+## Register in BOTH places
+
+Adding a component touches two files, and forgetting the second is silent:
+
+1. `widgetbook/lib/widgetbook.config.dart` — for the running app.
+2. the golden test's `Config.components` (e.g. `widgetbook/test/widgetbook_test.dart`) — for `flutter test`.
+
+The test harness keeps its own component list; a component registered only in the config renders **zero** snapshots with no error — the test count just doesn't rise. After registering, run `flutter test` and confirm the count went up. **Better setup:** export the component list from `config` and import it in the test (`components: config.components`) so there is one source of truth — the test still needs its own `appBuilder`/surface, but the list is shared.
+
+## Viewport: none by default
+
+Don't put a `ViewportMode` on a single-component story — it frames a lone button in a phone-sized canvas. Let components render at their natural size:
+
+- **App config**: `addons: [ViewportAddon([Viewports.none])]` (add devices to the list for optional framing).
+- **Story**: no viewport at all.
+
+`Viewports.none` produces *unbounded* constraints, and a `MaterialApp`/`Scaffold` cannot lay out unbounded — so the **golden test bounds its own root** with a fixed `SizedBox`:
+
+```dart
+appBuilder: (context, child) => SizedBox(
+  width: 400, height: 320,               // establishes bounds under `none`
+  child: MaterialApp(
+    theme: AppTheme.light,
+    home: Scaffold(body: Center(child: child)),
+  ),
+),
+```
+
+A `ViewportMode` on a story applies in **both** the app and the test, so you can't set `none` there without breaking the golden render. Keep the viewport out of the story; bound the test surface instead.
+
+## Screens / full-page widgets
+
+A full screen (a `Scaffold` or any widget that owns its page layout) is the one case that inverts the "viewport: none" rule — it **must** have a device viewport, and it **does** go in the golden test (at a phone-sized surface). A screen is where responsive overflow lives, so it needs the visual snapshot most.
+
+- **Story:** a `$Story` with a device `ViewportMode`, catalogued under `path: 'Screens'`. `Viewports.none` is unbounded and a `Scaffold` can't lay out in it, so pin a real device:
+  ```dart
+  const component = ComponentMeta(name: 'Home', path: 'Screens');
+  const meta = Meta(HomeScreen.new);
+  final $Home = _Story(name: 'Home', modes: [ViewportMode(IosViewports.iPhone13ProMax)]);
+  ```
+  The device must be present in the `ViewportAddon` of **both** the app `config` and the golden test's `Config`, or the `ViewportMode` throws `Modes [ViewportMode] do not have a corresponding addon in config`. Register `<Name>Component` in both component lists. Keep a Flutter import (`package:flutter/widgets.dart`) in the story file so the generated `Key` reference resolves.
+- **Add a narrowest-device story.** Overflow hides at a comfortable width and only bites at the smallest one, so pin a second story to the smallest device you support (iPhone SE, 375px) via `setup` — this is the snapshot that catches a `RenderFlex` overflow a 390px render sails right past:
+  ```dart
+  final $HomeIPhoneSE = _Story(
+    name: 'Home · iPhone SE',
+    setup: (context, child, args) => Center(
+      child: SizedBox(
+        width: IosViewports.iPhoneSE.maxWidth,
+        height: IosViewports.iPhoneSE.maxHeight,
+        child: child,
+      ),
+    ),
+  );
+  ```
+- **Size the golden harness for screens.** A full `Scaffold` won't fit a small component surface, so set the golden test's root `SizedBox` to phone-portrait (e.g. `Size(390, 844)`); leaf components are small and simply centre within it.
+- **Keep a plain widget test for semantics** — pump the screen at a device size and assert content (`find.text(...)`, theme colours):
+  ```dart
+  testWidgets('HomeScreen renders its sections', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(MaterialApp(theme: AppTheme.light, home: const HomeScreen()));
+    expect(find.text('Good morning, Alex'), findsOneWidget);
+  });
+  ```
+  It's a useful content/semantics check but **not** a substitute for the narrow-device snapshot — a single-width test that only asserts text presence passes straight over an 11px overflow.
+
+## Accessibility
+
+Assert `labeledTapTargetGuideline` + `textContrastGuideline` always. Assert tap-target-size (`androidTapTargetGuideline` 48dp / `iOSTapTargetGuideline` 44dp) only for a size the component actually meets — a 44px field or an `sm` button fails these by design, so skip them or assert on a size/state that passes, and note why in a comment. Put the assertion in a `run` scenario on the most-interactive state.
+
+## Gotchas (symptom → cause → fix)
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| New component renders 0 snapshots; count doesn't rise | Registered in the app config but not the golden test's `components` | Add `<Name>Component` to both (or share one list) |
+| States "all look the same" in the running app | States encoded as `scenarios` (test-only) | One `$Story` per state, state set via story-level `args` |
+| A state built with `run` looks empty in the app | `run` executes only under `flutter test` | Express the state via args (`initialValue`, `autofocus`, `errorText`, …) |
+| `Modes [ViewportMode] do not have a corresponding addon` (in the app, or in `flutter test` once a screen is in the golden) | Story uses `ViewportMode`, but that `Config`'s `ViewportAddon` doesn't list the device | Add the device to the `ViewportAddon` in **both** the app `config` and the golden test's `Config` |
+| `BoxConstraints(unconstrained)` / unbounded crash in `flutter test` | `Viewports.none` is unbounded; an app can't lay out in it | Bound the golden test's root with a fixed `SizedBox` |
+| `_Defaults(builder:)` won't compile ("can't return 'SizedBox'") | The builder must return the widget type | Don't wrap; give the widget the prop it needs |
+| `EnumArg(E.x)` → "Required named parameter 'values'" | beta API | `EnumArg(E.x, values: E.values)` |
+| "The class 'Story' is abstract" | Instantiated `Story<...>` directly | Use the generated `_Story`, or a concrete subclass (e.g. `FoundationStory`) |
+| A `$Story` with `scenarios` loses its auto "Default" snapshot | Explicit scenarios replace the auto one | Add an explicit `default` scenario if you want both |

--- a/skills/widgetbook-v4/reference/figma-loop.md
+++ b/skills/widgetbook-v4/reference/figma-loop.md
@@ -1,0 +1,44 @@
+# Figma comparison loop
+
+Detail behind steps 3 to 5 of the feedback loop in `SKILL.md`. This uses Figma's Dev Mode MCP server. The relevant read tools are `get_metadata`, `get_variable_defs`, `get_design_context`, and `get_screenshot`.
+
+## Node mapping (no Code Connect on Flutter)
+
+Figma Code Connect does not support Flutter, so there is no automatic mapping from a Flutter widget to a Figma node, and `get_code_connect_map` will not resolve your widgets. Establish the node another way:
+
+- **User-provided link.** Ask the user for the Figma link to the frame or component. A URL like `figma.com/design/<fileKey>/<name>?node-id=2840-17` gives you the `fileKey` and the `nodeId` (`2840-17`, which the API also accepts as `2840:17`).
+- **Current selection.** On the Figma desktop app, the MCP server can read the current selection, so the user can select the node and you operate on the selection.
+- **Search by name.** If you have a file link but not the node, call `get_metadata` (without a `nodeId` it returns the document's pages; with a page id it returns that page's node map). Match the widget to a node by layer name, then confirm the choice with the user before comparing.
+
+If none of these yields a node, skip the comparison and record in the PR that the design check was skipped. Do not invent a node id.
+
+## Step 4: property comparison (the gate)
+
+Call `get_variable_defs` for the node. It returns the variables and styles the design uses (colors, spacing, radius, typography) as name and value pairs. For each one, confirm the Flutter widget resolves the corresponding design token rather than a matching literal:
+
+- Figma fill bound to `colorScheme.error` (`#DC2626`) requires `Theme.of(context).colorScheme.error` or your `AppColors.error` token, not `Color(0xFFFF0000)`, even if the hex is close.
+- Figma spacing bound to a spacing variable requires your `AppSpacing` token, not a raw `EdgeInsets.all(16)`.
+
+Use `get_design_context` when you also need structure: the auto-layout direction, alignment, hierarchy, and nesting. It returns a React and Tailwind representation by default, so read it for structure and token references, not as code to port. If the response is large or truncated, narrow to the specific child node and re-fetch.
+
+Parity passes when every token reported by `get_variable_defs` maps to the same token in the widget. This is the gate because it is deterministic and environment-independent, unlike pixels.
+
+## Step 5: visual comparison (sanity check)
+
+Call `get_screenshot` for the node to get its rendered image, and compare it against the Widgetbook snapshot from `widgetbook/build/.widgetbook`. Check for structural differences: wrong layout direction, missing or extra elements, misaligned groups, obviously wrong sizing or type scale.
+
+Do not treat this as a pixel diff. The two images come from different rendering stacks, so anti-aliasing, font hinting, and sub-pixel layout will always differ. If the property gate in step 4 passes but the screenshot shows a structural difference, that difference is the bug to fix. If the property gate passes and the screenshot differs only in rendering texture, parity holds.
+
+## Exit condition
+
+Converge only when all three hold at once:
+
+1. `flutter test` is green with no failing assertions and no overflow or layout errors.
+2. Every token from `get_variable_defs` resolves to the same token in the widget.
+3. The `get_screenshot` image shows no structural difference from the Widgetbook snapshot.
+
+## Practical notes
+
+- **Rate limits.** The read tools are rate limited per the Figma plan. Fetch a node's context once and reuse it across the loop rather than re-fetching every iteration.
+- **Desktop vs remote server.** Selection-based prompting works only on the desktop server. The remote server needs a link to a frame or layer. Either way, prefer an explicit `nodeId` so runs are reproducible.
+- **Write tools.** Do not call any Figma tool that writes to the canvas unless the user explicitly asks. The comparison loop is read-only.

--- a/skills/widgetbook-v4/reference/figma-loop.md
+++ b/skills/widgetbook-v4/reference/figma-loop.md
@@ -21,6 +21,8 @@ Call `get_variable_defs` for the node. It returns the variables and styles the d
 
 Use `get_design_context` when you also need structure: the auto-layout direction, alignment, hierarchy, and nesting. It returns a React and Tailwind representation by default, so read it for structure and token references, not as code to port. If the response is large or truncated, narrow to the specific child node and re-fetch.
 
+**Resolve per-mode tokens through the theme, not a primitive.** `get_variable_defs` reports one value per variable — the value for the mode the node is currently in (usually Light). A variable that belongs to a multi-mode collection (the Figma file might have a mode for Light **and** Dark) has a *different* value in the other mode, so binding to a fixed primitive is correct in one mode and wrong in the other. Such a token must be read through the theme (`context.colors.x`), never `AppColors.x`. The one exception is a color whose surface does not itself theme — e.g. a pill on an always-dark gradient card stays legible in both modes only if it keeps the fixed light primitive; a theming token would darken it wrongly. Decide by whether the surface behind the color themes, and confirm the choice by snapshotting both modes (see `SKILL.md` step 1).
+
 Parity passes when every token reported by `get_variable_defs` maps to the same token in the widget. This is the gate because it is deterministic and environment-independent, unlike pixels.
 
 ## Step 5: visual comparison (sanity check)
@@ -33,8 +35,8 @@ Do not treat this as a pixel diff. The two images come from different rendering 
 
 Converge only when all three hold at once:
 
-1. `flutter test` is green with no failing assertions and no overflow or layout errors.
-2. Every token from `get_variable_defs` resolves to the same token in the widget.
+1. `flutter test` is green with no failing assertions and no overflow or layout errors — including the snapshot of every mode the design defines (e.g. a Dark `MaterialThemeMode` scenario), not Light alone.
+2. Every token from `get_variable_defs` resolves to the same token in the widget, resolved correctly for every mode in the collection.
 3. The `get_screenshot` image shows no structural difference from the Widgetbook snapshot.
 
 ## Practical notes

--- a/skills/widgetbook-v4/reference/migration.md
+++ b/skills/widgetbook-v4/reference/migration.md
@@ -1,0 +1,25 @@
+# Migration reference
+
+## From Widgetbook v3
+
+| v3 | v4 | Notes |
+|---|---|---|
+| `@UseCase(name: 'Default')` | `final $Default = _Story(name: 'Default')` | Run build_runner to generate `_Story` |
+| `context.knobs.text(label: 'X')` | `StringArg('value')` in `_Args` | Args are generated from the constructor |
+| `context.knobs.boolean(label: 'X')` | `BoolArg(true)` | |
+| Addons only | Addons + Modes | Modes define concrete addon configurations |
+| Widgetbook in `lib` / `test` / `widgetbook` | dedicated `widgetbook/` workspace package outside `lib` | See workspace structure in `reference/api-reference.md` |
+
+Full v3 guide: https://docs.widgetbook.io/~v4/v4-migration
+
+## From earlier v4 betas (the `Meta<T>()` form)
+
+Earlier betas used a generic `Meta` and a separate `MetaWithArgs`. Current v4 uses a constructor tear-off.
+
+- Replace `const meta = Meta<Widget>();` with `const meta = Meta(Widget.new);`. `Meta` must be `const`.
+- Replace `const meta = MetaWithArgs<Widget, Args>();` with `const meta = Meta(Widget.new, argsType: Args.new);`.
+- If the old `Meta` passed `name`, `path`, or `docsBuilder`, move those to a separate `ComponentMeta` (see `reference/api-reference.md`) and keep `const meta = Meta(Widget.new);` alongside it.
+- Optionally add one `Meta` per additional constructor, e.g. `const iconMeta = Meta(Widget.icon);`.
+- Run `dart run build_runner build -d` inside `widgetbook/`. This replaces the deprecated `flutter pub run build_runner build`.
+
+`_Story`, `_Args`, and `_Scenario` usage for the default constructor is unchanged. For named constructors the generated types are prefixed with the PascalCase constructor name (`_IconStory`, `_IconArgs`, `_IconScenario`).


### PR DESCRIPTION
## What

Adds documentation and a copy-paste skill for using Widgetbook v4 with coding agents (Claude Code, Cursor, Copilot).

- **New docs page** `docs/essentials/coding-agents.mdx` (added to the Essentials sidebar) — a workflow guide: install the skill, add a light-touch `## Widgetbook` section to `CLAUDE.md`, and let the agent run the write-stories → test → compare-to-Figma loop. Deliberately framed around the workflow rather than "AI writes your stories."
- **New `skills/widgetbook-v4/`** — the Claude Code skill (SKILL.md + reference files) that teaches the v4 story API and feedback loop. Users copy it into their own `.claude/skills/`. Includes a `skills/README.md` explaining what the folder is for.

## Why here

`skills/` is top-level and tracked because `.claude/` is gitignored — the skill has to be committed for the docs page to link to it. It's app-agnostic (no design-system-specific naming) so any Widgetbook user can drop it in.

## Notes

- Distribution channel is docs copy-paste for now; `widgetbook init` scaffolding and an official plugin are possible follow-ups sharing this same source.
- The in-page GitHub link resolves once this lands on `v4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)