### PR TITLE
fix(cli): `--api-url` no longer requires a trailing slash

### DIFF
--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **FIX**: Append a missing trailing slash to the `--api-url` value of `cloud build push`, so custom API URLs work without a trailing slash.
+- **FIX**: Append a missing trailing slash to the `--api-url` value of `cloud build push`, so custom API URLs work without a trailing slash. ([#1976](https://github.com/widgetbook/widgetbook/pull/1976))
 
 ## 4.0.0-beta.10
 

--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Append a missing trailing slash to the `--api-url` value of `cloud build push`, so custom API URLs work without a trailing slash.
+
 ## 4.0.0-beta.10
 
 - **CHORE**: Align version with `widgetbook` so both packages share `4.0.0-beta.10`.

--- a/packages/widgetbook_cli/lib/src/commands/build_push.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push.dart
@@ -83,9 +83,6 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
         hide: true,
         callback: (url) {
           if (url == null) return;
-          // Dio joins relative request paths (e.g. `v4/builds`) onto
-          // [baseUrl] via string concatenation, so a missing trailing
-          // slash would corrupt the URL.
           this.cloudClient.client.options.baseUrl = url.endsWith('/')
               ? url
               : '$url/';

--- a/packages/widgetbook_cli/lib/src/commands/build_push.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push.dart
@@ -83,7 +83,12 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
         hide: true,
         callback: (url) {
           if (url == null) return;
-          this.cloudClient.client.options.baseUrl = url;
+          // Dio joins relative request paths (e.g. `v4/builds`) onto
+          // [baseUrl] via string concatenation, so a missing trailing
+          // slash would corrupt the URL.
+          this.cloudClient.client.options.baseUrl = url.endsWith('/')
+              ? url
+              : '$url/';
         },
       )
       ..addFlag(

--- a/packages/widgetbook_cli/test/src/commands/build_push_test.dart
+++ b/packages/widgetbook_cli/test/src/commands/build_push_test.dart
@@ -24,6 +24,40 @@ void main() {
       when(() => context.repository).thenReturn(repository);
     });
 
+    group('api-url', () {
+      test('appends missing trailing slash to baseUrl', () {
+        final command = BuildPushCommand(context: context);
+
+        command.argParser.parse([
+          '--api-key',
+          'key',
+          '--api-url',
+          'https://staging.api.widgetbook.io',
+        ]);
+
+        expect(
+          command.cloudClient.client.options.baseUrl,
+          equals('https://staging.api.widgetbook.io/'),
+        );
+      });
+
+      test('keeps existing trailing slash in baseUrl', () {
+        final command = BuildPushCommand(context: context);
+
+        command.argParser.parse([
+          '--api-key',
+          'key',
+          '--api-url',
+          'https://staging.api.widgetbook.io/',
+        ]);
+
+        expect(
+          command.cloudClient.client.options.baseUrl,
+          equals('https://staging.api.widgetbook.io/'),
+        );
+      });
+    });
+
     group('parseResults', () {
       late ArgResults results;
       late BuildPushCommand command;


### PR DESCRIPTION
## Problem

`widgetbook cloud build push --api-url https://staging.api.widgetbook.io` fails with:

```
Failed host lookup: 'staging.api.widgetbook.iov4'
```

The value is assigned directly to Dio's `baseUrl`, and Dio joins relative request paths (e.g. `v4/builds`) onto it via string concatenation — so without a trailing slash the path gets glued onto the host.

## Solution

Append a trailing slash to the `--api-url` value if it is missing, so both `https://staging.api.widgetbook.io` and `https://staging.api.widgetbook.io/` work.

Verified against staging: without the fix the push fails as above; with the fix (no trailing slash) the build uploads and submits successfully.