### PR TITLE
fix: reset image cache between scenarios in `testWidgetbook`

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- **FIX**: Reset the image cache between scenarios in `testWidgetbook` so a failed or still-pending image load in one story no longer leaks into and fails a later, unrelated one.
 - **FIX**: Rebuild the workbench preview when switching stories or changing knobs while a viewport is active. ([#1948](https://github.com/widgetbook/widgetbook/pull/1948))
 - **FIX**: Assign `$generatedName` to args created via the generated `_Args.fixed(...)` constructor, mirroring the default constructor. ([#1947](https://github.com/widgetbook/widgetbook/pull/1947))
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **FIX**: Reset the image cache between scenarios in `testWidgetbook` so a failed or still-pending image load in one story no longer leaks into and fails a later, unrelated one.
+- **FIX**: Reset the image cache between scenarios in `testWidgetbook` so a failed or still-pending image load in one story no longer leaks into and fails a later, unrelated one. ([#1977](https://github.com/widgetbook/widgetbook/pull/1977))
 - **FIX**: Rebuild the workbench preview when switching stories or changing knobs while a viewport is active. ([#1948](https://github.com/widgetbook/widgetbook/pull/1948))
 - **FIX**: Assign `$generatedName` to args created via the generated `_Args.fixed(...)` constructor, mirroring the default constructor. ([#1947](https://github.com/widgetbook/widgetbook/pull/1947))
 

--- a/packages/widgetbook/lib/src/test/test.dart
+++ b/packages/widgetbook/lib/src/test/test.dart
@@ -49,6 +49,16 @@ void testScenario(
   testWidgets(
     scenario.name,
     (tester) async {
+      // `imageCache` is a process-wide singleton shared by every scenario in
+      // the run. Evict it after each scenario — registered first so it runs
+      // even if the scenario below throws — so that a failed or still-pending
+      // image load in one story cannot surface in, and fail, a later one.
+      addTearDown(() {
+        final imageCache = PaintingBinding.instance.imageCache;
+        imageCache.clear();
+        imageCache.clearLiveImages();
+      });
+
       tester.view.physicalConstraints = targetViewport.viewConstraints;
       tester.view.devicePixelRatio = targetViewport.pixelRatio;
 

--- a/packages/widgetbook/lib/src/test/test.dart
+++ b/packages/widgetbook/lib/src/test/test.dart
@@ -49,10 +49,7 @@ void testScenario(
   testWidgets(
     scenario.name,
     (tester) async {
-      // `imageCache` is a process-wide singleton shared by every scenario in
-      // the run. Evict it after each scenario — registered first so it runs
-      // even if the scenario below throws — so that a failed or still-pending
-      // image load in one story cannot surface in, and fail, a later one.
+      // Reset the shared image cache so it doesn't leak between scenarios.
       addTearDown(() {
         final imageCache = PaintingBinding.instance.imageCache;
         imageCache.clear();

--- a/packages/widgetbook/test/test/image_cache_reset_test.dart
+++ b/packages/widgetbook/test/test/image_cache_reset_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/painting.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/test.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+/// A trivial widget; these stories are about the shared [ImageCache], not about
+/// what gets rendered.
+class _Box extends StatelessWidget {
+  const _Box();
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.square(dimension: 10);
+}
+
+class _BoxArgs extends StoryArgs<_Box> {
+  const _BoxArgs();
+
+  @override
+  List<Arg?> get list => const [];
+}
+
+class _BoxStory extends Story<_Box, _BoxArgs> {
+  _BoxStory({super.scenarios})
+    : super(
+        name: 'Default',
+        args: const _BoxArgs(),
+        builder: (context, args) => const _Box(),
+      );
+}
+
+/// An [ImageStreamCompleter] that never completes, so it stays as a pending
+/// entry in the [ImageCache] — a stand-in for an in-flight image load.
+class _NeverCompleter extends ImageStreamCompleter {}
+
+ImageCache get _imageCache => PaintingBinding.instance.imageCache;
+
+Future<void> main() async {
+  // Records what the *second* scenario sees in the shared cache at its start.
+  // If the harness isolates scenarios, this must be empty despite the first
+  // scenario polluting the cache.
+  final pendingSeenBySecondScenario = <int>[];
+
+  final polluting = Scenario<_Box, _BoxArgs>(
+    name: 'first scenario pollutes the shared image cache',
+    run: (tester, args) async {
+      _imageCache.putIfAbsent('leaked', _NeverCompleter.new);
+      expect(_imageCache.pendingImageCount, greaterThan(0));
+    },
+  );
+
+  final observing = Scenario<_Box, _BoxArgs>(
+    name: 'second scenario starts with a clean image cache',
+    run: (tester, args) async {
+      pendingSeenBySecondScenario.add(_imageCache.pendingImageCount);
+    },
+  );
+
+  final config = Config(
+    components: [
+      Component<_Box, _BoxArgs>(
+        name: 'Box',
+        stories: [
+          _BoxStory(scenarios: [polluting, observing]),
+        ],
+      ),
+    ],
+  );
+
+  await testWidgetbook(config);
+
+  // Runs after the two scenario tests registered by `testWidgetbook` above.
+  test('testWidgetbook resets the image cache between scenarios', () {
+    expect(
+      pendingSeenBySecondScenario,
+      [0],
+      reason: 'the pending image leaked from the first scenario into the second',
+    );
+  });
+}

--- a/packages/widgetbook/test/test/image_cache_reset_test.dart
+++ b/packages/widgetbook/test/test/image_cache_reset_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/painting.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widgetbook/test.dart';
@@ -74,7 +73,8 @@ Future<void> main() async {
     expect(
       pendingSeenBySecondScenario,
       [0],
-      reason: 'the pending image leaked from the first scenario into the second',
+      reason:
+          'the pending image leaked from the first scenario into the second',
     );
   });
 }


### PR DESCRIPTION
## Problem

`testWidgetbook` registers one `flutter test` case per scenario, but Flutter's image cache (`PaintingBinding.instance.imageCache`) is a single process-wide instance shared by every scenario in a run — and the harness never cleared it between scenarios.

Because of that, an image load that failed or was still pending in one story could surface during a **later, unrelated** story and fail its test. Since the error lands on a different story than the one that triggered it, the practical workaround was to exclude whole groups of components from snapshot testing.

A common trigger is `Image.network` (or any network-backed widget): under `flutter test` every HTTP request returns an empty `400`, the failed load ends up in the shared cache, and the error leaks into whichever scenario renders next.

## Fix

Clear the image cache (`clear()` + `clearLiveImages()`) in a tear-down registered at the start of each scenario's test, so it runs even if the scenario body throws. Every scenario now starts from a clean cache, and a failure in one scenario can no longer affect another.

## Tests

Added `test/test/image_cache_reset_test.dart`: a story with two scenarios where the first adds a pending entry to the shared `imageCache` and the second asserts the cache is empty at its start. It fails without the fix (the second scenario sees the leaked entry, `Actual: [1]`) and passes with it.

## Notes

Behavior-only fix — no public API change, so no docs update.
