### PR TITLE
feat: exclude stories and scenarios from snapshot testing

### DIFF
--- a/docs/testing/run-scenarios.mdx
+++ b/docs/testing/run-scenarios.mdx
@@ -104,6 +104,46 @@ final config = Config(
 
 Note that wrapping `testWidgetbook(config)` itself in `withClock` does **not** work: the test framework executes each test body in its own `Zone`, which is not a child of the `Zone` that declared the tests. The `wrapper` hook exists precisely to re-apply your `Zone` setup inside each test body. For the same reason, addons cannot fake `clock.now()` — they inject widgets into the tree, while `package:clock` reads from the call stack.
 
+## Excluding Stories and Scenarios from Testing
+
+Some stories cannot render under `flutter test` — for example widgets backed by
+a native plugin (video, PDF) or ones that must load a real network resource. You
+can keep them **browsable in the Widgetbook app** while skipping them during
+testing by setting `excludeFromTests`.
+
+Set it on a story to skip all of its scenarios:
+
+```dart
+final $Default = _Story(
+  excludeFromTests: true,
+);
+```
+
+Or on an individual scenario:
+
+```dart
+final $Default = _Story(
+  scenarios: [
+    _Scenario(
+      name: 'Live data',
+      excludeFromTests: true,
+    ),
+  ],
+);
+```
+
+Excluded stories and scenarios are reported as skipped when you run
+`flutter test`, so no snapshot is produced and nothing is uploaded to Widgetbook
+Cloud. `excludeFromTests` only affects `testWidgetbook`; the story or scenario
+still appears in the running Widgetbook app.
+
+<Info>
+  Prefer mocking the missing dependency (see [Wrapping Scenario
+  Execution](#wrapping-scenario-execution) for `HttpOverrides` and plugin fakes)
+  so you keep visual-regression coverage. Reach for `excludeFromTests` only when
+  a scenario genuinely cannot render in a headless test.
+</Info>
+
 ## Generated Snapshot Artifacts
 
 By default, artifacts are written to:

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FEAT**: Add `excludeFromTests` to `Story` and `Scenario` to skip a story or scenario during `testWidgetbook` snapshot generation while keeping it browsable in the app. Excluded items are reported as skipped by `flutter test`. ([#1978](https://github.com/widgetbook/widgetbook/pull/1978))
+
 ## 4.0.0-beta.9
 
 - **FIX**: Accept `designLink` in generated story constructors, so stories can link their Figma design for Cloud reviews. ([#1971](https://github.com/widgetbook/widgetbook/pull/1971))

--- a/packages/widgetbook/lib/src/core/framework/scenario.dart
+++ b/packages/widgetbook/lib/src/core/framework/scenario.dart
@@ -42,6 +42,7 @@ class Scenario<TWidget extends Widget, TArgs extends StoryArgs<TWidget>>
     List<Mode>? modes,
     TArgs? args,
     this.run,
+    this.excludeFromTests = false,
     super.mergeModes,
   }) : _modes = modes,
        _args = args,
@@ -62,6 +63,15 @@ class Scenario<TWidget extends Widget, TArgs extends StoryArgs<TWidget>>
   /// It can be used to interact with the widget, e.g. to open a dropdown
   /// or to trigger an animation.
   final Future<void> Function(WidgetTester tester, TArgs args)? run;
+
+  /// Whether to exclude this scenario from snapshot generation in
+  /// `testWidgetbook`.
+  ///
+  /// Excluded scenarios still appear in the running Widgetbook app; they are
+  /// only skipped during testing, so no snapshot is produced and Widgetbook
+  /// Cloud never receives one. Crossed variants inherit this value from the
+  /// local scenario they are based on. Defaults to `false`.
+  final bool excludeFromTests;
 
   TArgs get args => _args ?? story.args;
 
@@ -118,6 +128,7 @@ class Scenario<TWidget extends Widget, TArgs extends StoryArgs<TWidget>>
           : mergeModes(definition.modes, _modes),
       args: _args,
       run: run,
+      excludeFromTests: excludeFromTests,
       mergeModes: mergeModes,
     )..story = story;
   }

--- a/packages/widgetbook/lib/src/core/framework/story.dart
+++ b/packages/widgetbook/lib/src/core/framework/story.dart
@@ -38,6 +38,7 @@ abstract class Story<TWidget extends Widget, TArgs extends StoryArgs<TWidget>> {
     required this.args,
     required this.builder,
     this.scenarios = const [],
+    this.excludeFromTests = false,
   }) : this._name = name,
        assert(name != 'Docs', 'Story name cannot be "Docs"') {
     scenarios.forEach((scenario) {
@@ -53,6 +54,17 @@ abstract class Story<TWidget extends Widget, TArgs extends StoryArgs<TWidget>> {
   final TArgs args;
   final SetupBuilder<TWidget, TArgs> setup;
   final List<Scenario<TWidget, TArgs>> scenarios;
+
+  /// Whether to exclude this story from snapshot generation in `testWidgetbook`.
+  ///
+  /// Excluded stories still appear in the running Widgetbook app; they are only
+  /// skipped during testing, so no snapshot is produced and Widgetbook Cloud
+  /// never receives one. Defaults to `false`.
+  ///
+  /// Use this for stories that cannot render under `flutter test` (e.g. native
+  /// plugins or network-dependent widgets). Individual scenarios can be
+  /// excluded via [Scenario.excludeFromTests].
+  final bool excludeFromTests;
 
   /// Defines how the [TWidget] is built using the provided [TArgs].
   final StoryWidgetBuilder<TWidget, TArgs> builder;

--- a/packages/widgetbook/lib/src/generator/framework/story_class_builder.dart
+++ b/packages/widgetbook/lib/src/generator/framework/story_class_builder.dart
@@ -143,6 +143,12 @@ class StoryClassBuilder {
                     ..named = true
                     ..toSuper = true,
                 ),
+                Parameter(
+                  (b) => b
+                    ..name = 'excludeFromTests'
+                    ..named = true
+                    ..toSuper = true,
+                ),
               ]);
 
               final superInitializers = {

--- a/packages/widgetbook/lib/src/test/test.dart
+++ b/packages/widgetbook/lib/src/test/test.dart
@@ -37,12 +37,16 @@ void testStory(
   Config config,
   Story story,
 ) {
-  group(story.name, () {
-    final scenarios = story.allScenarios(config);
-    for (final scenario in scenarios) {
-      testScenario(config, scenario);
-    }
-  });
+  group(
+    story.name,
+    () {
+      final scenarios = story.allScenarios(config);
+      for (final scenario in scenarios) {
+        testScenario(config, scenario);
+      }
+    },
+    skip: story.excludeFromTests ? 'Excluded from snapshots' : null,
+  );
 }
 
 void testScenario(
@@ -139,6 +143,9 @@ void testScenario(
       semanticsHandle.dispose();
       addTearDown(tester.view.reset);
     },
+    // `null` (not `false`) so a non-excluded scenario inside an excluded story
+    // still inherits the story group's `skip`.
+    skip: scenario.excludeFromTests ? true : null,
   );
 }
 

--- a/packages/widgetbook/test/generator/custom_args/custom_args.stories.g.dart
+++ b/packages/widgetbook/test/generator/custom_args/custom_args.stories.g.dart
@@ -29,6 +29,7 @@ class LabelBadgeStory extends Story<LabelBadge, NumericBadgeInputArgs> {
     NumericBadgeInputArgs? args,
     StoryWidgetBuilder<LabelBadge, NumericBadgeInputArgs>? builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          args: args ?? NumericBadgeInputArgs(),
          builder: builder ?? defaults.builder!,

--- a/packages/widgetbook/test/generator/default_values/default_values.stories.g.dart
+++ b/packages/widgetbook/test/generator/default_values/default_values.stories.g.dart
@@ -30,6 +30,7 @@ class DefaultsWidgetStory extends Story<DefaultsWidget, DefaultsWidgetArgs> {
     DefaultsWidgetArgs? args,
     StoryWidgetBuilder<DefaultsWidget, DefaultsWidgetArgs>? builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          args: args ?? DefaultsWidgetArgs(),
          builder:

--- a/packages/widgetbook/test/generator/doc_comment/doc_comment.stories.g.dart
+++ b/packages/widgetbook/test/generator/doc_comment/doc_comment.stories.g.dart
@@ -35,6 +35,7 @@ class DocCommentWidgetStory
     DocCommentWidgetArgs? args,
     StoryWidgetBuilder<DocCommentWidget, DocCommentWidgetArgs>? builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          args: args ?? DocCommentWidgetArgs(),
          builder:

--- a/packages/widgetbook/test/generator/doc_comment_code/doc_comment_code.stories.g.dart
+++ b/packages/widgetbook/test/generator/doc_comment_code/doc_comment_code.stories.g.dart
@@ -38,6 +38,7 @@ class DocCommentCodeWidgetStory
     DocCommentCodeWidgetArgs? args,
     StoryWidgetBuilder<DocCommentCodeWidget, DocCommentCodeWidgetArgs>? builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          args: args ?? DocCommentCodeWidgetArgs(),
          builder:

--- a/packages/widgetbook/test/generator/enums/enums.stories.g.dart
+++ b/packages/widgetbook/test/generator/enums/enums.stories.g.dart
@@ -29,6 +29,7 @@ class EnumWidgetStory extends Story<EnumWidget, EnumWidgetArgs> {
     EnumWidgetArgs? args,
     StoryWidgetBuilder<EnumWidget, EnumWidgetArgs>? builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          args: args ?? EnumWidgetArgs(),
          builder:

--- a/packages/widgetbook/test/generator/generic/generic.stories.g.dart
+++ b/packages/widgetbook/test/generator/generic/generic.stories.g.dart
@@ -32,6 +32,7 @@ class GenericWidgetStory<T extends num>
     required super.args,
     StoryWidgetBuilder<GenericWidget<T>, GenericWidgetArgs<T>>? builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          builder:
              builder ??

--- a/packages/widgetbook/test/generator/generic_bound/generic_bound.stories.g.dart
+++ b/packages/widgetbook/test/generator/generic_bound/generic_bound.stories.g.dart
@@ -31,6 +31,7 @@ class BoundWidgetStory<D, T extends BaseItem<D>>
     required super.args,
     StoryWidgetBuilder<BoundWidget<D, T>, BoundWidgetArgs<D, T>>? builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          builder:
              builder ??

--- a/packages/widgetbook/test/generator/generic_bound_dynamic/generic_bound_dynamic.stories.g.dart
+++ b/packages/widgetbook/test/generator/generic_bound_dynamic/generic_bound_dynamic.stories.g.dart
@@ -36,6 +36,7 @@ class DynamicBoundWidgetStory<D, T extends Map<dynamic, D>>
     StoryWidgetBuilder<DynamicBoundWidget<D, T>, DynamicBoundWidgetArgs<D, T>>?
     builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          builder:
              builder ??

--- a/packages/widgetbook/test/generator/generic_bound_nullable/generic_bound_nullable.stories.g.dart
+++ b/packages/widgetbook/test/generator/generic_bound_nullable/generic_bound_nullable.stories.g.dart
@@ -39,6 +39,7 @@ class NullableBoundWidgetStory<D, T extends BaseItem<D?>>
     >?
     builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          builder:
              builder ??

--- a/packages/widgetbook/test/generator/multi_constructor/multi_constructor.stories.g.dart
+++ b/packages/widgetbook/test/generator/multi_constructor/multi_constructor.stories.g.dart
@@ -42,6 +42,7 @@ class MultiConstructorWidgetStory
     StoryWidgetBuilder<MultiConstructorWidget, MultiConstructorWidgetArgs>?
     builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          args: args ?? MultiConstructorWidgetArgs(),
          builder:
@@ -88,6 +89,7 @@ class MultiConstructorWidgetOtherStory
     StoryWidgetBuilder<MultiConstructorWidget, MultiConstructorWidgetOtherArgs>?
     builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          args: args ?? MultiConstructorWidgetOtherArgs(),
          builder:

--- a/packages/widgetbook/test/generator/nullable/nullable.stories.g.dart
+++ b/packages/widgetbook/test/generator/nullable/nullable.stories.g.dart
@@ -30,6 +30,7 @@ class NullableWidgetStory extends Story<NullableWidget, NullableWidgetArgs> {
     NullableWidgetArgs? args,
     StoryWidgetBuilder<NullableWidget, NullableWidgetArgs>? builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          args: args ?? NullableWidgetArgs(),
          builder:

--- a/packages/widgetbook/test/generator/primitive/primitive.stories.g.dart
+++ b/packages/widgetbook/test/generator/primitive/primitive.stories.g.dart
@@ -32,6 +32,7 @@ class PrimitiveWidgetStory extends Story<PrimitiveWidget, PrimitiveWidgetArgs> {
     PrimitiveWidgetArgs? args,
     StoryWidgetBuilder<PrimitiveWidget, PrimitiveWidgetArgs>? builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          args: args ?? PrimitiveWidgetArgs(),
          builder:

--- a/packages/widgetbook/test/generator/static_methods/static_methods.stories.g.dart
+++ b/packages/widgetbook/test/generator/static_methods/static_methods.stories.g.dart
@@ -34,6 +34,7 @@ class StaticMethodWidgetStory
     StaticMethodWidgetArgs? args,
     StoryWidgetBuilder<StaticMethodWidget, StaticMethodWidgetArgs>? builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          args: args ?? StaticMethodWidgetArgs(),
          builder:

--- a/packages/widgetbook/test/generator/variants/variants.stories.g.dart
+++ b/packages/widgetbook/test/generator/variants/variants.stories.g.dart
@@ -44,6 +44,7 @@ class VariantButtonStory extends Story<VariantButton, VariantButtonArgs> {
     VariantButtonArgs? args,
     StoryWidgetBuilder<VariantButton, VariantButtonArgs>? builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          args: args ?? VariantButtonArgs(),
          builder: builder ?? defaults.builder!,
@@ -86,6 +87,7 @@ class VariantButtonIconStory
     VariantButtonIconArgs? args,
     StoryWidgetBuilder<VariantButton, VariantButtonIconArgs>? builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          args: args ?? VariantButtonIconArgs(),
          builder:
@@ -148,6 +150,7 @@ class VariantButtonOutlinedStory
     VariantButtonOutlinedArgs? args,
     StoryWidgetBuilder<VariantButton, VariantButtonOutlinedArgs>? builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          args: args ?? VariantButtonOutlinedArgs(),
          builder: builder ?? outlinedDefaults.builder!,

--- a/packages/widgetbook/test/generator/with_defaults/with_defaults.stories.g.dart
+++ b/packages/widgetbook/test/generator/with_defaults/with_defaults.stories.g.dart
@@ -33,6 +33,7 @@ class DefaultsVarWidgetStory
     DefaultsVarInputArgs? args,
     StoryWidgetBuilder<DefaultsVarWidget, DefaultsVarInputArgs>? builder,
     super.scenarios,
+    super.excludeFromTests,
   }) : super(
          args: args ?? DefaultsVarInputArgs(),
          builder: builder ?? defaults.builder!,

--- a/packages/widgetbook/test/test/exclude_from_tests_test.dart
+++ b/packages/widgetbook/test/test/exclude_from_tests_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/test.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+/// A trivial widget; these stories are about which scenarios get executed,
+/// not about what is rendered.
+class _Box extends StatelessWidget {
+  const _Box();
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.square(dimension: 10);
+}
+
+class _BoxArgs extends StoryArgs<_Box> {
+  const _BoxArgs();
+
+  @override
+  List<Arg?> get list => const [];
+}
+
+class _BoxStory extends Story<_Box, _BoxArgs> {
+  _BoxStory({super.name, super.scenarios, super.excludeFromTests})
+    : super(
+        args: const _BoxArgs(),
+        builder: (context, args) => const _Box(),
+      );
+}
+
+/// Names of the scenarios whose `run` callback actually executed. A skipped
+/// scenario never runs, so its name will be absent.
+final executed = <String>{};
+
+Scenario<_Box, _BoxArgs> _scenario(String name, {bool excluded = false}) {
+  return Scenario<_Box, _BoxArgs>(
+    name: name,
+    excludeFromTests: excluded,
+    run: (tester, args) async => executed.add(name),
+  );
+}
+
+Future<void> main() async {
+  final config = Config(
+    components: [
+      Component<_Box, _BoxArgs>(
+        name: 'Included',
+        stories: [
+          _BoxStory(
+            name: 'Story',
+            scenarios: [
+              _scenario('included scenario'),
+              _scenario('excluded scenario', excluded: true),
+            ],
+          ),
+        ],
+      ),
+      Component<_Box, _BoxArgs>(
+        name: 'Excluded',
+        stories: [
+          _BoxStory(
+            name: 'Story',
+            excludeFromTests: true,
+            scenarios: [_scenario('scenario in excluded story')],
+          ),
+        ],
+      ),
+    ],
+  );
+
+  await testWidgetbook(config);
+
+  // Runs after the scenario tests registered by `testWidgetbook` above.
+  test('excludeFromTests skips excluded scenarios and stories', () {
+    expect(
+      executed,
+      {'included scenario'},
+      reason:
+          'only the non-excluded scenario of the non-excluded story should run',
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Adds `excludeFromTests` to `Story` and `Scenario` so you can skip specific stories or scenarios during `testWidgetbook` snapshot generation, while they stay browsable in the running Widgetbook app.

## Why

`testWidgetbook` renders every story and scenario under `flutter test`. Some widgets can't render in that headless environment — e.g. native-plugin-backed widgets (video, PDF) or ones that must load a real network resource. Until now, the only way to keep those out of snapshot testing was to omit the whole component from `Config.components`; there was no per-story or per-scenario control.

## What

- New `bool excludeFromTests` (default `false`) on both `Story` and `Scenario`.
- When set, `testWidgetbook` reports the story/scenario as **skipped** in `flutter test`, so no snapshot is written and nothing reaches Widgetbook Cloud.
- It only affects `testWidgetbook` — the story/scenario still appears in the running app (`runWidgetbook`).
- Crossed scenario variants inherit the flag from the local scenario they are based on.
- The story-level flag is forwarded through the generated story constructor (goldens regenerated); scenario-level needs no generator change.

```dart
// whole story
final $Default = _Story(excludeFromTests: true);

// single scenario
final $Default = _Story(
  scenarios: [
    _Scenario(name: 'Live data', excludeFromTests: true),
  ],
);
```

## Notes

- Prefer mocking the missing dependency (`HttpOverrides`, a fake plugin platform interface) via `ScenarioConfig.wrapper` to keep visual-regression coverage; `excludeFromTests` is the fallback for when a scenario genuinely cannot render headlessly.
- Implementation detail: the inner `testWidgets` passes `skip: null` (not `false`) for non-excluded scenarios, so they still inherit an excluded story group's `skip`.

## Tests & docs

- `test/test/exclude_from_tests_test.dart` verifies an excluded story and an excluded scenario are skipped while the rest run.
- New "Excluding Stories and Scenarios from Testing" section in `docs/testing/run-scenarios.mdx`.
