### PR TITLE
docs: move image cache changelog entry to Unreleased

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **FEAT**: Add `excludeFromTests` to `Story` and `Scenario` to skip a story or scenario during `testWidgetbook` snapshot generation while keeping it browsable in the app. Excluded items are reported as skipped by `flutter test`. ([#1978](https://github.com/widgetbook/widgetbook/pull/1978))
+- **FIX**: Reset the image cache between scenarios in `testWidgetbook` so a failed or still-pending image load in one story no longer leaks into and fails a later, unrelated one. ([#1977](https://github.com/widgetbook/widgetbook/pull/1977))
 
 ## 4.0.0-beta.9
 
@@ -9,7 +10,6 @@
 
 ## 4.0.0-beta.8
 
-- **FIX**: Reset the image cache between scenarios in `testWidgetbook` so a failed or still-pending image load in one story no longer leaks into and fails a later, unrelated one. ([#1977](https://github.com/widgetbook/widgetbook/pull/1977))
 - **FIX**: Rebuild the workbench preview when switching stories or changing knobs while a viewport is active. ([#1948](https://github.com/widgetbook/widgetbook/pull/1948))
 - **FIX**: Assign `$generatedName` to args created via the generated `_Args.fixed(...)` constructor, mirroring the default constructor. ([#1947](https://github.com/widgetbook/widgetbook/pull/1947))
 


### PR DESCRIPTION
## Problem

The `4.0.0-beta.8` section of the widgetbook CHANGELOG lists the image-cache fix (#1977), but that change is **not** part of the beta.8 release. #1977 merged after `4.0.0-beta.9` was cut, so it isn't in any published version yet.

How it happened: #1977's branch was based on a pre-beta.8 CHANGELOG, where its entry sat at the top of `## Unreleased`, just above the `#1948` entry. By the time it merged, `#1948` had been released and moved under `## 4.0.0-beta.8`, so the squash inserted the #1977 line above it — landing it under beta.8.

Verified: the `chore(widgetbook): release v4.0.0-beta.8` commit's CHANGELOG lists only #1948 and #1947 under beta.8, and #1977's commit is not an ancestor of that release.

## Fix

Move the #1977 entry from `## 4.0.0-beta.8` to `## Unreleased`, so it is attributed to the next release.
