### PR TITLE
feat: add `--empty` flag to widgetbook init

### DIFF
--- a/docs/cli/commands/init.mdx
+++ b/docs/cli/commands/init.mdx
@@ -17,7 +17,16 @@ widgetbook init
 
 The CLI accepts the following arguments.
 
-| Argument    | Mandatory | Default\* | Description                                              |
-| ----------- | --------- | --------- | -------------------------------------------------------- |
-| `--package` | ➖        | `./`      | Directory of the app or the design system package        |
-| `--output`  | ➖        | `./`      | Directory where the widgetbook workspace will be created |
+| Argument    | Mandatory | Default\* | Description                                                          |
+| ----------- | --------- | --------- | ------------------------------------------------------------------- |
+| `--package` | ➖        | `./`      | Directory of the app or the design system package                   |
+| `--output`  | ➖        | `./`      | Directory where the widgetbook workspace will be created            |
+| `--empty`   | ➖        | `false`   | Create the workspace without generating stories for existing widgets |
+
+Use `--empty` to scaffold a Widgetbook workspace without any generated stories,
+for example when you want to write your first stories manually or with a coding
+agent.
+
+```bash
+widgetbook init --empty
+```

--- a/packages/widgetbook_cli/lib/src/commands/init.dart
+++ b/packages/widgetbook_cli/lib/src/commands/init.dart
@@ -32,6 +32,12 @@ class InitCommand extends CliCommand<InitArgs> {
         'output',
         help: 'Directory where the widgetbook workspace will be created',
         defaultsTo: './',
+      )
+      ..addFlag(
+        'empty',
+        help: 'Create the workspace without generating stories for the '
+            'existing widgets',
+        negatable: false,
       );
   }
 
@@ -49,10 +55,12 @@ class InitCommand extends CliCommand<InitArgs> {
     }
 
     final outputDir = results['output'] as String;
+    final empty = results['empty'] as bool;
 
     return InitArgs(
       packageDir: packageDir,
       outputDir: outputDir,
+      empty: empty,
     );
   }
 
@@ -105,7 +113,29 @@ class InitCommand extends CliCommand<InitArgs> {
 
     setupProgress.complete('Workspace is set up at $widgetbookDir');
 
-    final widgets = await _getWidgets(args.packageDir);
+    if (!args.empty) {
+      await _generateStories(args.packageDir, widgetbookDir);
+    }
+
+    final buildProgress = logger.progress('Building stories');
+
+    await processManager.runFlutter(
+      workingDirectory: widgetbookDir,
+      [
+        'pub',
+        'run',
+        'build_runner',
+        'build',
+      ],
+    );
+
+    buildProgress.complete('Stories are built successfully');
+
+    return ExitCode.success.code;
+  }
+
+  Future<void> _generateStories(String packageDir, String widgetbookDir) async {
+    final widgets = await _getWidgets(packageDir);
     // One source file can contain multiple widgets.
     // So we group them by their source file path, and add
     // an index to the stories filename in case of conflicts.
@@ -149,22 +179,6 @@ class InitCommand extends CliCommand<InitArgs> {
         (template) => template.create(widgetbookDir),
       ),
     );
-
-    final buildProgress = logger.progress('Building stories');
-
-    await processManager.runFlutter(
-      workingDirectory: widgetbookDir,
-      [
-        'pub',
-        'run',
-        'build_runner',
-        'build',
-      ],
-    );
-
-    buildProgress.complete('Stories are built successfully');
-
-    return ExitCode.success.code;
   }
 
   Future<Set<WidgetInfo>> _getWidgets(String packageDir) async {

--- a/packages/widgetbook_cli/lib/src/commands/init.dart
+++ b/packages/widgetbook_cli/lib/src/commands/init.dart
@@ -35,7 +35,8 @@ class InitCommand extends CliCommand<InitArgs> {
       )
       ..addFlag(
         'empty',
-        help: 'Create the workspace without generating stories for the '
+        help:
+            'Create the workspace without generating stories for the '
             'existing widgets',
         negatable: false,
       );

--- a/packages/widgetbook_cli/lib/src/commands/init_args.dart
+++ b/packages/widgetbook_cli/lib/src/commands/init_args.dart
@@ -2,6 +2,7 @@ final class InitArgs {
   const InitArgs({
     required this.packageDir,
     required this.outputDir,
+    required this.empty,
   });
 
   /// The path to the app or the package that has the widgets.
@@ -9,4 +10,8 @@ final class InitArgs {
 
   /// The path to where widgetbook should be initialized.
   final String outputDir;
+
+  /// Whether to skip generating stories for the existing widgets, leaving an
+  /// empty workspace that is wired up to use Widgetbook.
+  final bool empty;
 }

--- a/packages/widgetbook_cli/test/src/commands/init_test.dart
+++ b/packages/widgetbook_cli/test/src/commands/init_test.dart
@@ -1,0 +1,53 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:widgetbook_cli/src/commands/init.dart';
+
+import '../../helper/mocks.dart';
+
+void main() {
+  group('widgetbook init', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('wb_init_test');
+      File(
+        p.join(tempDir.path, 'pubspec.yaml'),
+      ).writeAsStringSync('name: demo\n');
+    });
+
+    tearDown(() => tempDir.deleteSync(recursive: true));
+
+    InitCommand buildCommand() => InitCommand(context: MockContext());
+
+    test('parses --empty flag', () async {
+      final command = buildCommand();
+      final results = command.argParser.parse([
+        '--package',
+        tempDir.path,
+        '--empty',
+      ]);
+
+      final args = await command.parseResults(MockContext(), results);
+
+      expect(args.empty, isTrue);
+      expect(args.packageDir, tempDir.path);
+    });
+
+    test('defaults --empty to false', () async {
+      final command = buildCommand();
+      final results = command.argParser.parse([
+        '--package',
+        tempDir.path,
+      ]);
+
+      final args = await command.parseResults(MockContext(), results);
+
+      expect(args.empty, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Adds an `--empty` flag to `widgetbook init` that scaffolds a Widgetbook workspace without generating stories for the existing widgets.

## Why
`init` currently analyzes the target package and generates a `.stories.dart` file per widget. For onboarding flows where the first stories are written manually or by a coding agent, a clean workspace with no stories is a better starting point.

## What
- `--empty` (default `false`) skips widget analysis and story-template generation.
- Everything else is unchanged: `flutter create`, the config/main/test templates, `pub add`, and `build_runner` all still run. Because `build_runner` runs, `components.g.dart` is emitted with an empty component list and the workspace compiles as-is.
- Updated the `init` command docs and added `InitArgs` parsing tests.

## Verification
End-to-end `widgetbook init --empty` against a fresh Flutter app produces `final components = <Component>[];`, generates zero story files, and `flutter analyze` on the generated workspace reports no issues.