### PR TITLE
feat: add --allow-existing flag to cloud build push

### DIFF
--- a/docs/cli/commands/cloud-build-push.mdx
+++ b/docs/cli/commands/cloud-build-push.mdx
@@ -20,6 +20,7 @@ The CLI accepts the following arguments.
 | `--commit`     | ➖        | HEAD commit of current branch | The SHA hash of the commit for which the Widgetbook is uploaded. |
 | `--repository` | ➖        | Repository top-level name     | The name of the repository for which the Widgetbook is uploaded. |
 | `--actor`      | ➖        | Git config `user.name`        | The username of the actor which triggered the build.             |
+| `--allow-existing` | ➖    | `false`                       | Exit successfully instead of failing when a build for this commit already exists on Widgetbook Cloud. Useful when a CI workflow re-uploads a pull request's base build. |
 
 _\* These defaults are used when the CLI is used locally.
 If the CLI is used in a CI/CD environment, the defaults have different respective values._

--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FEAT**: Add `--allow-existing` to `cloud build push`, which exits successfully instead of failing when a build for the commit already exists. ([#1986](https://github.com/widgetbook/widgetbook/pull/1986))
+
 ## 4.0.0-beta.11
 
 - **FEAT**: Add `cloud review skip`, which resolves the Widgetbook Review check on pull requests that upload no build. ([#1995](https://github.com/widgetbook/widgetbook/pull/1995))

--- a/packages/widgetbook_cli/lib/src/api/cloud_exception.dart
+++ b/packages/widgetbook_cli/lib/src/api/cloud_exception.dart
@@ -5,12 +5,16 @@ import 'package:mason_logger/mason_logger.dart';
 import '../core/core.dart';
 
 class CloudException extends CliException {
-  CloudException(String message)
+  CloudException(String message, {this.statusCode})
     : super(
         'Something went wrong while communicating with the Widgetbook Cloud:\n'
         '$message\n',
         ExitCode.software.code,
       );
+
+  /// HTTP status code of the failed response, or `null` when the server did
+  /// not respond (e.g. timeout, connection or handshake errors).
+  final int? statusCode;
 
   static CloudException parse(Object exception, StackTrace stackTrace) {
     if (exception is! DioException) {
@@ -27,6 +31,7 @@ class CloudException extends CliException {
       );
     }
 
+    final statusCode = response.statusCode;
     final body = response.data;
 
     // If the body is JSON, then the server has responded,
@@ -41,20 +46,22 @@ class CloudException extends CliException {
         // (e.g. ['Field is required', 'Field must be unique']).
         return CloudException(
           message.mapIndexed((i, msg) => '${i + 1}. $msg').join('\n'),
+          statusCode: statusCode,
         );
       } else if (message is String) {
         // Other 4xx errors' message is as a single string.
         // (e.g. 'Could not find API key').
-        return CloudException(message);
+        return CloudException(message, statusCode: statusCode);
       } else {
         // Message is non-string, use the full body instead.
-        return CloudException('$body');
+        return CloudException('$body', statusCode: statusCode);
       }
     }
 
     // Body can be HTML or string at this point.
     return CloudException(
       '${exception.message}\n${body ?? ''}',
+      statusCode: statusCode,
     );
   }
 }

--- a/packages/widgetbook_cli/lib/src/commands/build_push.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push.dart
@@ -10,6 +10,7 @@ import 'package:pool/pool.dart';
 import 'package:process/process.dart';
 
 import '../api/api.dart';
+import '../api/cloud_exception.dart';
 import '../cache/cache.dart';
 import '../core/core.dart';
 import '../storage/storage.dart';
@@ -77,6 +78,13 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
       ..addOption(
         'actor',
         help: 'Author of the commit',
+      )
+      ..addFlag(
+        'allow-existing',
+        help:
+            'Exit successfully instead of failing when a build for this '
+            'commit already exists on Widgetbook Cloud.',
+        negatable: false,
       )
       ..addOption(
         'api-url',
@@ -157,6 +165,7 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
     }
 
     final noTurbo = results['no-turbo'] as bool;
+    final allowExisting = results['allow-existing'] as bool;
 
     return BuildPushArgs(
       apiKey: apiKey,
@@ -168,6 +177,7 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
       actor: actor,
       repository: repoName,
       noTurbo: noTurbo,
+      allowExisting: allowExisting,
     );
   }
 
@@ -248,22 +258,39 @@ class BuildPushCommand extends CliCommand<BuildPushArgs> {
     final stories = storiesByNavPath.values.toList();
 
     final createProgress = logger.progress('Creating build');
-    final createResponse = await cloudClient.createBuild(
-      versions,
-      CreateBuildRequest(
-        apiKey: args.apiKey,
-        versionControlProvider: args.vendor,
-        repository: args.repository,
-        actor: args.actor,
-        branch: args.branch,
-        sha: args.commit,
-        mergedResultSha: args.mergedResultCommit,
-        stories: stories,
-        expectedSnapshotCount: cache.scenarios.length,
-        size: dirSize + cache.totalSnapshotSize,
-        hash: hash,
-      ),
-    );
+
+    final CreateBuildResponse createResponse;
+    try {
+      createResponse = await cloudClient.createBuild(
+        versions,
+        CreateBuildRequest(
+          apiKey: args.apiKey,
+          versionControlProvider: args.vendor,
+          repository: args.repository,
+          actor: args.actor,
+          branch: args.branch,
+          sha: args.commit,
+          mergedResultSha: args.mergedResultCommit,
+          stories: stories,
+          expectedSnapshotCount: cache.scenarios.length,
+          size: dirSize + cache.totalSnapshotSize,
+          hash: hash,
+        ),
+      );
+    } on CloudException catch (e) {
+      // A 409 means a build for this commit already exists. When
+      // `--allow-existing` is set (e.g. when a CI workflow re-uploads the base
+      // build of a pull request), treat that as success instead of failing.
+      if (args.allowExisting && e.statusCode == 409) {
+        createProgress.complete(
+          'Build already exists for commit ${args.commit}, skipping upload',
+        );
+
+        return 0;
+      }
+
+      rethrow;
+    }
 
     if (createResponse.isTurbo) {
       final turboResponse = createResponse.asTurbo;

--- a/packages/widgetbook_cli/lib/src/commands/build_push_args.dart
+++ b/packages/widgetbook_cli/lib/src/commands/build_push_args.dart
@@ -10,6 +10,7 @@ class BuildPushArgs {
     required this.actor,
     required this.repository,
     required this.noTurbo,
+    required this.allowExisting,
   });
 
   final String apiKey;
@@ -21,4 +22,8 @@ class BuildPushArgs {
   final String actor;
   final String repository;
   final bool noTurbo;
+
+  /// Whether to exit successfully instead of failing when a build for this
+  /// commit already exists on Widgetbook Cloud.
+  final bool allowExisting;
 }

--- a/packages/widgetbook_cli/test/src/commands/build_push_flow_test.dart
+++ b/packages/widgetbook_cli/test/src/commands/build_push_flow_test.dart
@@ -2,6 +2,7 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
+import 'package:widgetbook_cli/src/api/cloud_exception.dart';
 import 'package:widgetbook_cli/widgetbook_cli.dart';
 
 import '../../helper/mocks.dart';
@@ -94,6 +95,7 @@ void main() {
       actor: 'jens',
       repository: 'widgetbook/app',
       noTurbo: true,
+      allowExisting: false,
     );
 
     setUp(() {
@@ -268,6 +270,49 @@ void main() {
 
       verify(() => cloudClient.submitBuild(any())).called(1);
     });
+
+    test(
+      'allow-existing tolerates a 409 on create and skips the upload',
+      () async {
+        when(() => cloudClient.createBuild(any(), any())).thenThrow(
+          CloudException('Build already exists', statusCode: 409),
+        );
+
+        final exitCode = await command.runWith(
+          context,
+          const BuildPushArgs(
+            apiKey: 'api-key',
+            path: '/project',
+            branch: 'main',
+            commit: 'sha-1',
+            mergedResultCommit: null,
+            vendor: 'github',
+            actor: 'jens',
+            repository: 'widgetbook/app',
+            noTurbo: true,
+            allowExisting: true,
+          ),
+        );
+
+        expect(exitCode, equals(0));
+        verifyNever(
+          () => cloudClient.appendSnapshots(any(), any<String>(), any()),
+        );
+        verifyNever(() => storageClient.uploadObjects(any(), any(), any()));
+        verifyNever(() => cloudClient.submitBuild(any()));
+      },
+    );
+
+    test('without allow-existing a 409 on create is rethrown', () async {
+      when(() => cloudClient.createBuild(any(), any())).thenThrow(
+        CloudException('Build already exists', statusCode: 409),
+      );
+
+      await expectLater(
+        command.runWith(context, makeArgs()),
+        throwsA(isA<CloudException>()),
+      );
+    });
   });
 
   group('$BuildPushCommand runWith (turbo flow)', () {
@@ -350,6 +395,7 @@ void main() {
           actor: 'jens',
           repository: 'widgetbook/app',
           noTurbo: true,
+          allowExisting: false,
         ),
       );
 

--- a/packages/widgetbook_cli/test/src/commands/build_push_test.dart
+++ b/packages/widgetbook_cli/test/src/commands/build_push_test.dart
@@ -72,6 +72,7 @@ void main() {
         when(() => results['path']).thenReturn('default path');
         when(() => results['api-key']).thenReturn('default key');
         when(() => results['no-turbo']).thenReturn(true);
+        when(() => results['allow-existing']).thenReturn(false);
 
         // Default Context
         when(() => context.name).thenReturn('default');


### PR DESCRIPTION
Adds an `--allow-existing` flag to `widgetbook cloud build push`.

## Why
When a build for the pushed commit already exists, Widgetbook Cloud responds with `409 Conflict` and the CLI fails. That is a problem for CI workflows that upload a pull request's **base** build on every run: once the base build exists, the re-upload 409s and turns the pipeline red.

## What
- `--allow-existing` (default `false`): on a `409` from build creation, the CLI logs that the build already exists and exits `0` instead of failing. Any other error still fails as before.
- `CloudException` now carries the HTTP `statusCode` so the command can distinguish a 409 from other failures.
- Added tests for both the tolerated-409 and the still-failing (flag off) paths, and documented the flag.

## Notes
This is opt-in and only affects the build-creation step; the flag has no effect when the build does not already exist.