### PR TITLE
fix: register dependency package fonts under their bare family name in tests

### DIFF
--- a/packages/widgetbook/lib/src/test/font_loader.dart
+++ b/packages/widgetbook/lib/src/test/font_loader.dart
@@ -1,6 +1,13 @@
+/// @docImport 'package:flutter/painting.dart';
+library;
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'font_manifest.dart';
+
+/// Prefix Flutter gives to font families declared by a dependency package.
+const _packagePrefix = 'packages/';
 
 /// Loads all fonts included in pubspec.yaml or dependencies.
 ///
@@ -9,24 +16,78 @@ import 'font_manifest.dart';
 /// their own copies of them.
 ///
 /// Widgetbook supplies Roboto because it is free to use.
+///
+/// Fonts declared by a dependency package are registered by Flutter under a
+/// `packages/<package>/<family>` name, and only resolve for a [TextStyle] that
+/// passes a matching `package` argument. A [TextStyle] naming the bare family
+/// instead falls back to the test font, which paints every glyph as a filled
+/// rectangle. To keep snapshots legible, each package family is also registered
+/// under its bare name, unless that name is already claimed by the root package
+/// or by another dependency.
 Future<void> loadFonts() async {
   final fontManifest = await rootBundle.loadStructuredData(
     'FontManifest.json',
     (json) async => FontManifest.fromJson(json),
   );
 
-  for (final family in fontManifest.families) {
-    final fontLoader = FontLoader(
-      // Localize font names from this package,
-      // so that any font included here (e.g. Roboto) works.
-      family.name.replaceAll('packages/widgetbook/', ''),
-    );
+  final aliases = bareFamilyAliases(
+    fontManifest.families.map((family) => family.name),
+  );
 
-    for (final font in family.fonts) {
-      final fontBytes = rootBundle.load(font.asset);
-      fontLoader.addFont(fontBytes);
+  for (final family in fontManifest.families) {
+    final names = {
+      family.name,
+      if (aliases[family.name] case final alias?) alias,
+    };
+
+    for (final name in names) {
+      final fontLoader = FontLoader(name);
+
+      for (final font in family.fonts) {
+        final fontBytes = rootBundle.load(font.asset);
+        fontLoader.addFont(fontBytes);
+      }
+
+      await fontLoader.load();
+    }
+  }
+}
+
+/// Maps each package-scoped family name onto the bare family name it may
+/// safely also be registered under.
+///
+/// A bare name is only safe when nothing else already resolves under it,
+/// otherwise the alias would silently shadow a different typeface.
+@visibleForTesting
+Map<String, String> bareFamilyAliases(Iterable<String> familyNames) {
+  final names = familyNames.toList();
+  final rootNames = names
+      .where((name) => !name.startsWith(_packagePrefix))
+      .toSet();
+
+  final claimants = <String, List<String>>{};
+  for (final name in names) {
+    if (!name.startsWith(_packagePrefix)) continue;
+
+    final bare = name.split('/').skip(2).join('/');
+    if (bare.isEmpty || rootNames.contains(bare)) continue;
+
+    claimants.putIfAbsent(bare, () => []).add(name);
+  }
+
+  final aliases = <String, String>{};
+  claimants.forEach((bare, contenders) {
+    if (contenders.length > 1) {
+      debugPrint(
+        'Widgetbook: font family "$bare" is declared by multiple packages '
+        '(${contenders.join(', ')}). Snapshots will only render it for a '
+        'TextStyle that passes the matching `package` argument.',
+      );
+      return;
     }
 
-    await fontLoader.load();
-  }
+    aliases[contenders.single] = bare;
+  });
+
+  return aliases;
 }

--- a/packages/widgetbook/test/test/font_loader_test.dart
+++ b/packages/widgetbook/test/test/font_loader_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/src/test/font_loader.dart';
+
+void main() {
+  group('bareFamilyAliases', () {
+    test('aliases a dependency package font to its bare family name', () {
+      // Regression test for widgetbook#1991: a font declared by a dependency
+      // package and referenced without a `package:` argument fell back to the
+      // test font, rendering every glyph as a filled black rectangle.
+      final aliases = bareFamilyAliases([
+        'MaterialIcons',
+        'packages/assets/My Custom Font',
+      ]);
+
+      expect(aliases, {'packages/assets/My Custom Font': 'My Custom Font'});
+    });
+
+    test('leaves root package families untouched', () {
+      final aliases = bareFamilyAliases(['MaterialIcons', 'Inter']);
+
+      expect(aliases, isEmpty);
+    });
+
+    test('does not shadow a family already declared by the root package', () {
+      final aliases = bareFamilyAliases([
+        'Inter',
+        'packages/design_system/Inter',
+      ]);
+
+      expect(aliases, isEmpty);
+    });
+
+    test('does not alias a family declared by more than one package', () {
+      final aliases = bareFamilyAliases([
+        'packages/design_system/Inter',
+        'packages/legacy_theme/Inter',
+      ]);
+
+      expect(aliases, isEmpty);
+    });
+
+    test('keeps aliasing the Roboto that widgetbook supplies', () {
+      final aliases = bareFamilyAliases(['packages/widgetbook/Roboto']);
+
+      expect(aliases, {'packages/widgetbook/Roboto': 'Roboto'});
+    });
+  });
+}


### PR DESCRIPTION
Closes #1991.

## Problem

Flutter registers a font family declared by a **dependency package** as
`packages/<package>/<family>`. A `TextStyle` that names the bare family does not
resolve against that name.

Under `flutter_test` an unresolved family falls back to the stand-in test font,
whose glyphs are all filled boxes — so scenario snapshots in `build/.widgetbook`
come out as black rectangles instead of text.

The same reference falls back to a real system font when the app runs, which
looks plausible, so the misconfiguration is only ever visible in snapshots. This
also affects the common layout where fonts are declared in the app package and a
separate `widgetbook/` workspace depends on it: the bare family that works when
the app is the root package stops resolving once the app is a dependency.

## Change

`loadFonts` now registers each package-scoped family under its bare name in
addition to the prefixed one, so both spellings resolve in tests.

The alias is skipped when the bare name is already claimed by the root package
or by a second dependency, since registering it would silently shadow a
different typeface; the multi-package case logs instead.

## Verification

Reproduced against `4.0.0-beta.10` in a project with a font in a dependency
package referenced without `package:` — snapshot was solid bars (5 unique
colours). With this change the same scenario renders real glyphs (174 unique
colours).

Unaffected, and confirmed unchanged: root-package fonts, correctly prefixed
package fonts, families with spaces in the name, and the widgetbook-supplied
Roboto.
