### PR TITLE
deps(cli): bump `analyzer` to 14.x

### DIFF
--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - **FEAT**: Add `--allow-existing` to `cloud build push`, which exits successfully instead of failing when a build for the commit already exists. ([#1986](https://github.com/widgetbook/widgetbook/pull/1986))
+- **REFACTOR**: Bump `analyzer` to 14.x.
 
 ## 4.0.0-beta.11
 

--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - **FEAT**: Add `--allow-existing` to `cloud build push`, which exits successfully instead of failing when a build for the commit already exists. ([#1986](https://github.com/widgetbook/widgetbook/pull/1986))
-- **REFACTOR**: Bump `analyzer` to 14.x.
+- **REFACTOR**: Bump `analyzer` to 14.x. ([#1998](https://github.com/widgetbook/widgetbook/pull/1998))
 
 ## 4.0.0-beta.11
 

--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
   sdk: ">=3.11.0 <4.0.0"
 
 dependencies:
-  analyzer: ^13.0.0
+  analyzer: ^14.0.0
   args: ^2.6.0
   ci: ^0.1.0
   collection: ^1.18.0


### PR DESCRIPTION
The `_ / pana` CI job fails for `widgetbook_cli` because its `analyzer: ^13.0.0` constraint excludes the latest stable analyzer (14.1.0). pana scores 140/150 on "All of the package dependencies are supported in the latest version", and CI runs it with `--exit-code-threshold 0`, so any lost point fails the job.

Bumps the constraint to `^14.0.0`.

No source changes were needed. Analyzer 14.0.0's breaking changes are the removal of `FormalParameterElement.isInitializingFormal`, `.isSuperFormal`, `.formalParameters`, `.typeParameters`, and of `PackageConfigFileBuilder`. The only apparent match in this package is `widget_info_collector.dart:64`, but that is `ConstructorElement.formalParameters`, which is unaffected.

Verified locally against analyzer 14.1.0: `dart analyze` clean, all 54 tests pass, and `pana . --no-warning --exit-code-threshold 0 --no-dartdoc` now scores **150/150** (exit 0).

Note: `packages/widgetbook` has a separate, still-open pana failure — it pins `analyzer: ">=8.0.0 <13.0.0"`, which excludes stable 13.x. That is out of scope here and needs its own change.