### PR TITLE
feat: add on-device snapshotting via integration_test

### DIFF
--- a/examples/feature_preview/pubspec.lock
+++ b/examples/feature_preview/pubspec.lock
@@ -182,12 +182,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
   flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
     source: sdk
@@ -224,6 +234,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  integration_test:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   io:
     dependency: transitive
     description:
@@ -328,6 +343,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -344,6 +367,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -437,6 +468,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -573,6 +612,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   widgetbook:
     dependency: "direct main"
     description:

--- a/examples/full_example/pubspec.lock
+++ b/examples/full_example/pubspec.lock
@@ -182,12 +182,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
   flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
     source: sdk
@@ -224,6 +234,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  integration_test:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   io:
     dependency: transitive
     description:
@@ -328,6 +343,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -344,6 +367,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -437,6 +468,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -573,6 +612,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   widgetbook:
     dependency: "direct main"
     description:

--- a/examples/monorepo_example/widgetbook/pubspec.lock
+++ b/examples/monorepo_example/widgetbook/pubspec.lock
@@ -182,12 +182,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
   flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
     source: sdk
@@ -224,6 +234,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  integration_test:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   io:
     dependency: transitive
     description:
@@ -328,6 +343,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -344,6 +367,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -444,6 +475,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -580,6 +619,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   widgetbook:
     dependency: "direct main"
     description:

--- a/examples/screen_util_example/pubspec.lock
+++ b/examples/screen_util_example/pubspec.lock
@@ -182,6 +182,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_screenutil:
     dependency: "direct main"
     description:
@@ -196,6 +201,11 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
     source: sdk
@@ -232,6 +242,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  integration_test:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   io:
     dependency: transitive
     description:
@@ -336,6 +351,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -352,6 +375,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -445,6 +476,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -581,6 +620,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   widgetbook:
     dependency: "direct main"
     description:

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **FEAT**: Add on-device snapshotting. `testWidgetbookOnDevice` (`package:widgetbook/integration_test.dart`) and `widgetbookIntegrationDriver` (`package:widgetbook/integration_test_driver.dart`) capture scenarios on a real device or simulator via `integration_test`, so widgets backed by platform textures/views (e.g. `video_player`, `pdfrx`) render instead of appearing blank under `flutter test`. `testWidgetbook` (headless) remains the default; both accept a `where` filter to partition components between the headless and on-device runs.
+- **FEAT**: Add on-device snapshotting (`testWidgetbookOnDevice` + `widgetbookIntegrationDriver`) that captures scenarios on a device/simulator, so platform-backed widgets (e.g. `video_player`, `pdfrx`) render instead of appearing blank under `flutter test`. Both runners take a `where` filter to split components between them.
 
 ## 4.0.0-beta.11
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- **FEAT**: Add on-device snapshotting. `testWidgetbookOnDevice` (`package:widgetbook/integration_test.dart`) and `widgetbookIntegrationDriver` (`package:widgetbook/integration_test_driver.dart`) capture scenarios on a real device or simulator via `integration_test`, so widgets backed by platform textures/views (e.g. `video_player`, `pdfrx`) render instead of appearing blank under `flutter test`. Opt selected components in with the `where` filter; `testWidgetbook` (headless) remains the default.
+- **BREAKING**: Remove the incidental `testComponent`/`testStory`/`testScenario` helpers from `package:widgetbook/test.dart`; use `testWidgetbook`.
+
 ## 4.0.0-beta.11
 
 - **FIX**: Rebuild the workbench preview when switching between stories of the same component, instead of keeping the previously selected story's state. ([#1994](https://github.com/widgetbook/widgetbook/pull/1994))

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **FEAT**: Add on-device snapshotting. `testWidgetbookOnDevice` (`package:widgetbook/integration_test.dart`) and `widgetbookIntegrationDriver` (`package:widgetbook/integration_test_driver.dart`) capture scenarios on a real device or simulator via `integration_test`, so widgets backed by platform textures/views (e.g. `video_player`, `pdfrx`) render instead of appearing blank under `flutter test`. Opt selected components in with the `where` filter; `testWidgetbook` (headless) remains the default.
+- **FEAT**: Add on-device snapshotting. `testWidgetbookOnDevice` (`package:widgetbook/integration_test.dart`) and `widgetbookIntegrationDriver` (`package:widgetbook/integration_test_driver.dart`) capture scenarios on a real device or simulator via `integration_test`, so widgets backed by platform textures/views (e.g. `video_player`, `pdfrx`) render instead of appearing blank under `flutter test`. `testWidgetbook` (headless) remains the default; both accept a `where` filter to partition components between the headless and on-device runs.
 - **BREAKING**: Remove the incidental `testComponent`/`testStory`/`testScenario` helpers from `package:widgetbook/test.dart`; use `testWidgetbook`.
 
 ## 4.0.0-beta.11

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **FEAT**: Add on-device snapshotting (`testWidgetbookOnDevice` + `widgetbookIntegrationDriver`) that captures scenarios on a device/simulator, so platform-backed widgets (e.g. `video_player`, `pdfrx`) render instead of appearing blank under `flutter test`. Both runners take a `where` filter to split components between them.
+- **FEAT**: Add `testWidgetbookOnDevice` to snapshot scenarios on a device/simulator, so platform-backed widgets render instead of appearing blank. ([#2001](https://github.com/widgetbook/widgetbook/pull/2001))
 
 ## 4.0.0-beta.11
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## Unreleased
 
 - **FEAT**: Add on-device snapshotting. `testWidgetbookOnDevice` (`package:widgetbook/integration_test.dart`) and `widgetbookIntegrationDriver` (`package:widgetbook/integration_test_driver.dart`) capture scenarios on a real device or simulator via `integration_test`, so widgets backed by platform textures/views (e.g. `video_player`, `pdfrx`) render instead of appearing blank under `flutter test`. `testWidgetbook` (headless) remains the default; both accept a `where` filter to partition components between the headless and on-device runs.
-- **BREAKING**: Remove the incidental `testComponent`/`testStory`/`testScenario` helpers from `package:widgetbook/test.dart`; use `testWidgetbook`.
 
 ## 4.0.0-beta.11
 

--- a/packages/widgetbook/lib/integration_test.dart
+++ b/packages/widgetbook/lib/integration_test.dart
@@ -1,0 +1,10 @@
+/// On-device snapshotting for Widgetbook, built on `package:integration_test`.
+///
+/// Use `testWidgetbookOnDevice` as the entrypoint of an `integration_test`
+/// target to capture scenarios on a real device or simulator, where
+/// platform-backed widgets (e.g. `video_player`, `pdfrx`) render for real.
+/// Pair it with `widgetbookIntegrationDriver` from
+/// `package:widgetbook/integration_test_driver.dart` and run via `flutter drive`.
+library;
+
+export 'src/test/on_device_test.dart' show testWidgetbookOnDevice;

--- a/packages/widgetbook/lib/integration_test.dart
+++ b/packages/widgetbook/lib/integration_test.dart
@@ -1,10 +1,7 @@
-/// On-device snapshotting for Widgetbook, built on `package:integration_test`.
-///
-/// Use `testWidgetbookOnDevice` as the entrypoint of an `integration_test`
-/// target to capture scenarios on a real device or simulator, where
-/// platform-backed widgets (e.g. `video_player`, `pdfrx`) render for real.
-/// Pair it with `widgetbookIntegrationDriver` from
-/// `package:widgetbook/integration_test_driver.dart` and run via `flutter drive`.
+/// On-device snapshotting for Widgetbook. Use `testWidgetbookOnDevice` as an
+/// `integration_test` entrypoint (paired with `widgetbookIntegrationDriver`
+/// from `package:widgetbook/integration_test_driver.dart`) and run via
+/// `flutter drive`.
 library;
 
 export 'src/test/on_device_test.dart' show testWidgetbookOnDevice;

--- a/packages/widgetbook/lib/integration_test_driver.dart
+++ b/packages/widgetbook/lib/integration_test_driver.dart
@@ -1,8 +1,5 @@
-/// Host-side driver for `testWidgetbookOnDevice`.
-///
-/// Import this from a `test_driver/` script (run under `flutter drive`) to
-/// persist the on-device snapshots into `build/.widgetbook`. It imports no
-/// Flutter UI code, so it is safe in the `flutter drive` VM.
+/// Host-side driver for `testWidgetbookOnDevice`. Import from a `test_driver/`
+/// script run under `flutter drive` to persist snapshots into `build/.widgetbook`.
 library;
 
 export 'src/test/integration_test_driver.dart' show widgetbookIntegrationDriver;

--- a/packages/widgetbook/lib/integration_test_driver.dart
+++ b/packages/widgetbook/lib/integration_test_driver.dart
@@ -1,0 +1,8 @@
+/// Host-side driver for `testWidgetbookOnDevice`.
+///
+/// Import this from a `test_driver/` script (run under `flutter drive`) to
+/// persist the on-device snapshots into `build/.widgetbook`. It imports no
+/// Flutter UI code, so it is safe in the `flutter drive` VM.
+library;
+
+export 'src/test/integration_test_driver.dart' show widgetbookIntegrationDriver;

--- a/packages/widgetbook/lib/src/test/integration_test_driver.dart
+++ b/packages/widgetbook/lib/src/test/integration_test_driver.dart
@@ -23,7 +23,8 @@ Future<void> widgetbookIntegrationDriver() async {
       return true;
     },
     responseDataCallback: (data) async {
-      final store = (data?[widgetbookReportKey] as Map<String, dynamic>?) ??
+      final store =
+          (data?[widgetbookReportKey] as Map<String, dynamic>?) ??
           const <String, dynamic>{};
       const encoder = JsonEncoder.withIndent('  ');
 

--- a/packages/widgetbook/lib/src/test/integration_test_driver.dart
+++ b/packages/widgetbook/lib/src/test/integration_test_driver.dart
@@ -5,15 +5,10 @@ import 'package:integration_test/integration_test_driver_extended.dart';
 
 import 'report_key.dart';
 
-/// Host side of `testWidgetbookOnDevice`. Run it from `test_driver/` under
-/// `flutter drive`; it writes the two streams the device produces into
-/// `build/.widgetbook`, the layout the Widgetbook CLI reads:
-///   - screenshot bytes (via `onScreenshot`) to the PNG path the device chose;
-///   - per-scenario metadata (via `reportData`) to the sibling `.json` path,
-///     overwriting the PNG with cropped bytes when a viewport was applied.
-///
-/// This library imports no Flutter UI code, so it is safe to import from a
-/// driver script running in the `flutter drive` VM.
+/// Host side of `testWidgetbookOnDevice`. Run it from a `test_driver/` script
+/// under `flutter drive`; it writes the device's screenshots and metadata into
+/// `build/.widgetbook`, the layout the Widgetbook CLI reads. Imports no Flutter
+/// UI code, so it is safe in the `flutter drive` VM.
 Future<void> widgetbookIntegrationDriver() async {
   await integrationDriver(
     onScreenshot: (name, bytes, [args]) async {
@@ -31,8 +26,8 @@ Future<void> widgetbookIntegrationDriver() async {
       for (final entry in store.entries) {
         final value = entry.value as Map<String, dynamic>;
 
-        // A cropped (viewport) scenario ships its final PNG bytes here; they
-        // replace the full-screen bytes onScreenshot already wrote.
+        // Cropped scenarios ship final bytes here, replacing the full-screen
+        // PNG onScreenshot already wrote.
         final png = value['png'];
         if (png != null) {
           final imageFile = File(entry.key);

--- a/packages/widgetbook/lib/src/test/integration_test_driver.dart
+++ b/packages/widgetbook/lib/src/test/integration_test_driver.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:integration_test/integration_test_driver_extended.dart';
+
+import 'report_key.dart';
+
+/// Host side of `testWidgetbookOnDevice`. Run it from `test_driver/` under
+/// `flutter drive`; it writes the two streams the device produces into
+/// `build/.widgetbook`, the layout the Widgetbook CLI reads:
+///   - screenshot bytes (via `onScreenshot`) to the PNG path the device chose;
+///   - per-scenario metadata (via `reportData`) to the sibling `.json` path,
+///     overwriting the PNG with cropped bytes when a viewport was applied.
+///
+/// This library imports no Flutter UI code, so it is safe to import from a
+/// driver script running in the `flutter drive` VM.
+Future<void> widgetbookIntegrationDriver() async {
+  await integrationDriver(
+    onScreenshot: (name, bytes, [args]) async {
+      final file = File(name);
+      await file.parent.create(recursive: true);
+      await file.writeAsBytes(bytes);
+      return true;
+    },
+    responseDataCallback: (data) async {
+      final store = (data?[widgetbookReportKey] as Map<String, dynamic>?) ??
+          const <String, dynamic>{};
+      const encoder = JsonEncoder.withIndent('  ');
+
+      for (final entry in store.entries) {
+        final value = entry.value as Map<String, dynamic>;
+
+        // A cropped (viewport) scenario ships its final PNG bytes here; they
+        // replace the full-screen bytes onScreenshot already wrote.
+        final png = value['png'];
+        if (png != null) {
+          final imageFile = File(entry.key);
+          await imageFile.parent.create(recursive: true);
+          await imageFile.writeAsBytes((png as List).cast<int>());
+        }
+
+        final jsonPath = entry.key.replaceAll(RegExp(r'\.png$'), '.json');
+        final jsonFile = File(jsonPath);
+        await jsonFile.parent.create(recursive: true);
+        await jsonFile.writeAsString(encoder.convert(value['metadata']));
+      }
+    },
+  );
+}

--- a/packages/widgetbook/lib/src/test/on_device_test.dart
+++ b/packages/widgetbook/lib/src/test/on_device_test.dart
@@ -8,25 +8,15 @@ import 'package:integration_test/integration_test.dart';
 import '../../widgetbook.dart';
 import 'font_loader.dart';
 import 'report_key.dart';
-import 'scenario_metadata.dart';
 import 'snapshot_runner.dart';
 
-/// On-device counterpart of `testWidgetbook`.
+/// On-device counterpart of `testWidgetbook`, run via `flutter drive` on a real
+/// device or simulator so widgets backed by platform textures/views (e.g.
+/// `video_player`, `pdfrx`) render for real instead of appearing blank.
 ///
-/// Runs every scenario (optionally narrowed by [where]) under
-/// [IntegrationTestWidgetsFlutterBinding] on a real device or simulator, so
-/// widgets backed by platform textures/views (e.g. `video_player`, `pdfrx`)
-/// render for real and appear in the captured screenshot — unlike headless
-/// `testWidgetbook`, whose offscreen layer rasterization leaves them blank.
-///
-/// Because the device file system is remote from the host, results are handed
-/// back through the integration-test driver: screenshot bytes via
-/// `takeScreenshot`, and the per-scenario [ScenarioMetadata] via the binding's
-/// `reportData`. Pair it with `widgetbookIntegrationDriver` from
-/// `package:widgetbook/integration_test_driver.dart` and run via `flutter drive`.
-///
-/// Use [where] to opt only selected components into on-device capture while the
-/// rest stay on the faster headless path (mark those `excludeFromTests` there):
+/// Pair it with `widgetbookIntegrationDriver` from
+/// `package:widgetbook/integration_test_driver.dart`. Use [where] to route only
+/// selected components on-device while the rest stay on `testWidgetbook`:
 ///
 /// ```dart
 /// void main() => testWidgetbookOnDevice(
@@ -40,17 +30,13 @@ void testWidgetbookOnDevice(
 }) {
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  // Fonts must be loaded before tests run, but tests are declared
-  // synchronously — the integration-test runner begins before an async `main`
-  // resumes, so awaiting before declaring throws "Can't call group() once
-  // tests have begun running". Defer the load into setUpAll instead.
+  // Tests are declared synchronously (the runner starts before an async `main`
+  // resumes), so defer font loading into setUpAll rather than awaiting here.
   setUpAll(loadFonts);
 
   declareSnapshotTests(config, _IntegrationTestStrategy(binding), where: where);
 }
 
-/// On-device capture strategy: reads back the real composited surface via
-/// `takeScreenshot` and hands bytes + metadata to the host driver.
 class _IntegrationTestStrategy extends SnapshotStrategy {
   _IntegrationTestStrategy(this.binding);
 
@@ -67,8 +53,8 @@ class _IntegrationTestStrategy extends SnapshotStrategy {
   }) async {
     final pixelRatio = tester.view.devicePixelRatio;
 
-    // The screenshot name is the target PNG path; the driver writes the bytes
-    // there and derives the sibling `.json` path from it.
+    // Pass the target PNG path as the screenshot name so the driver knows where
+    // to write it.
     final imagePath = buildScenarioMetadata(
       scenario,
       CapturedSnapshot(
@@ -84,10 +70,8 @@ class _IntegrationTestStrategy extends SnapshotStrategy {
     final raw = await binding.takeScreenshot(imagePath);
     var bytes = Uint8List.fromList(raw);
 
-    // A `ViewportMode` on the scenario makes `ViewportAddon` size the use case
-    // to the viewport (centered) during build; crop the physical screenshot to
-    // it. Unlike the offscreen headless path, the viewport cannot exceed the
-    // device screen and renders at the device's own pixel ratio.
+    // A viewport is sized (centered) by ViewportAddon during build; crop the
+    // physical screenshot to it. It cannot exceed the device screen.
     final framed = viewport.maxWidth.isFinite && viewport.maxHeight.isFinite;
     if (framed) {
       final screen = tester.view.physicalSize;
@@ -118,9 +102,8 @@ class _IntegrationTestStrategy extends SnapshotStrategy {
     final store =
         (binding.reportData![widgetbookReportKey] ??= <String, dynamic>{})
             as Map<String, dynamic>;
-    // `takeScreenshot` already streamed the full-screen bytes to the driver's
-    // onScreenshot. When cropped, ship the cropped bytes so the driver
-    // overwrites the PNG to match the metadata.
+    // Ship the cropped bytes so the driver can replace the full-screen PNG that
+    // takeScreenshot already streamed to it.
     store[metadata.imageFile.path] = {
       'metadata': metadata.toJson(),
       if (framed) 'png': bytes,
@@ -128,7 +111,6 @@ class _IntegrationTestStrategy extends SnapshotStrategy {
   }
 }
 
-/// Crops [png] to the given physical-pixel rectangle and re-encodes it.
 Future<Uint8List> _cropPng(
   Uint8List png,
   double left,
@@ -157,8 +139,7 @@ Future<Uint8List> _cropPng(
   return data!.buffer.asUint8List();
 }
 
-/// Reads a big-endian uint32 from a PNG byte stream. Width/height live in the
-/// IHDR chunk at byte offsets 16 and 20 respectively.
+/// Reads a big-endian uint32 from a PNG's IHDR chunk (width at 16, height at 20).
 int _pngUint32(Uint8List b, int offset) =>
     (b[offset] << 24) |
     (b[offset + 1] << 16) |

--- a/packages/widgetbook/lib/src/test/on_device_test.dart
+++ b/packages/widgetbook/lib/src/test/on_device_test.dart
@@ -1,0 +1,166 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import '../../widgetbook.dart';
+import 'font_loader.dart';
+import 'report_key.dart';
+import 'scenario_metadata.dart';
+import 'snapshot_runner.dart';
+
+/// On-device counterpart of `testWidgetbook`.
+///
+/// Runs every scenario (optionally narrowed by [where]) under
+/// [IntegrationTestWidgetsFlutterBinding] on a real device or simulator, so
+/// widgets backed by platform textures/views (e.g. `video_player`, `pdfrx`)
+/// render for real and appear in the captured screenshot — unlike headless
+/// `testWidgetbook`, whose offscreen layer rasterization leaves them blank.
+///
+/// Because the device file system is remote from the host, results are handed
+/// back through the integration-test driver: screenshot bytes via
+/// `takeScreenshot`, and the per-scenario [ScenarioMetadata] via the binding's
+/// `reportData`. Pair it with `widgetbookIntegrationDriver` from
+/// `package:widgetbook/integration_test_driver.dart` and run via `flutter drive`.
+///
+/// Use [where] to opt only selected components into on-device capture while the
+/// rest stay on the faster headless path (mark those `excludeFromTests` there):
+///
+/// ```dart
+/// void main() => testWidgetbookOnDevice(
+///       config,
+///       where: (component) => component.name == 'VideoPlayer',
+///     );
+/// ```
+void testWidgetbookOnDevice(
+  Config config, {
+  bool Function(Component component)? where,
+}) {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  // Fonts must be loaded before tests run, but tests are declared
+  // synchronously — the integration-test runner begins before an async `main`
+  // resumes, so awaiting before declaring throws "Can't call group() once
+  // tests have begun running". Defer the load into setUpAll instead.
+  setUpAll(loadFonts);
+
+  declareSnapshotTests(config, _IntegrationTestStrategy(binding), where: where);
+}
+
+/// On-device capture strategy: reads back the real composited surface via
+/// `takeScreenshot` and hands bytes + metadata to the host driver.
+class _IntegrationTestStrategy extends SnapshotStrategy {
+  _IntegrationTestStrategy(this.binding);
+
+  final IntegrationTestWidgetsFlutterBinding binding;
+
+  @override
+  Future<void> captureAndPersist({
+    required WidgetTester tester,
+    required Scenario scenario,
+    required Key key,
+    required ViewportData viewport,
+    required Map<String, dynamic> semantics,
+    required List<Map<String, dynamic>> violations,
+  }) async {
+    final pixelRatio = tester.view.devicePixelRatio;
+
+    // The screenshot name is the target PNG path; the driver writes the bytes
+    // there and derives the sibling `.json` path from it.
+    final imagePath = buildScenarioMetadata(
+      scenario,
+      CapturedSnapshot(
+        bytes: Uint8List(0),
+        width: 0,
+        height: 0,
+        pixelRatio: pixelRatio,
+      ),
+      const {},
+      const [],
+    ).imageFile.path;
+
+    final raw = await binding.takeScreenshot(imagePath);
+    var bytes = Uint8List.fromList(raw);
+
+    // A `ViewportMode` on the scenario makes `ViewportAddon` size the use case
+    // to the viewport (centered) during build; crop the physical screenshot to
+    // it. Unlike the offscreen headless path, the viewport cannot exceed the
+    // device screen and renders at the device's own pixel ratio.
+    final framed = viewport.maxWidth.isFinite && viewport.maxHeight.isFinite;
+    if (framed) {
+      final screen = tester.view.physicalSize;
+      final w = viewport.maxWidth * pixelRatio;
+      final h = viewport.maxHeight * pixelRatio;
+      bytes = await _cropPng(
+        bytes,
+        (screen.width - w) / 2,
+        (screen.height - h) / 2,
+        w,
+        h,
+      );
+    }
+
+    final metadata = buildScenarioMetadata(
+      scenario,
+      CapturedSnapshot(
+        bytes: bytes,
+        width: _pngUint32(bytes, 16),
+        height: _pngUint32(bytes, 20),
+        pixelRatio: pixelRatio,
+      ),
+      semantics,
+      violations,
+    );
+
+    binding.reportData ??= <String, dynamic>{};
+    final store =
+        (binding.reportData![widgetbookReportKey] ??= <String, dynamic>{})
+            as Map<String, dynamic>;
+    // `takeScreenshot` already streamed the full-screen bytes to the driver's
+    // onScreenshot. When cropped, ship the cropped bytes so the driver
+    // overwrites the PNG to match the metadata.
+    store[metadata.imageFile.path] = {
+      'metadata': metadata.toJson(),
+      if (framed) 'png': bytes,
+    };
+  }
+}
+
+/// Crops [png] to the given physical-pixel rectangle and re-encodes it.
+Future<Uint8List> _cropPng(
+  Uint8List png,
+  double left,
+  double top,
+  double width,
+  double height,
+) async {
+  final codec = await ui.instantiateImageCodec(png);
+  final frame = await codec.getNextFrame();
+  final source = frame.image;
+
+  final w = width.round();
+  final h = height.round();
+  final recorder = ui.PictureRecorder();
+  ui.Canvas(recorder).drawImageRect(
+    source,
+    ui.Rect.fromLTWH(left, top, width, height),
+    ui.Rect.fromLTWH(0, 0, w.toDouble(), h.toDouble()),
+    ui.Paint(),
+  );
+  final cropped = await recorder.endRecording().toImage(w, h);
+  final data = await cropped.toByteData(format: ui.ImageByteFormat.png);
+
+  source.dispose();
+  cropped.dispose();
+  return data!.buffer.asUint8List();
+}
+
+/// Reads a big-endian uint32 from a PNG byte stream. Width/height live in the
+/// IHDR chunk at byte offsets 16 and 20 respectively.
+int _pngUint32(Uint8List b, int offset) =>
+    (b[offset] << 24) |
+    (b[offset + 1] << 16) |
+    (b[offset + 2] << 8) |
+    b[offset + 3];

--- a/packages/widgetbook/lib/src/test/report_key.dart
+++ b/packages/widgetbook/lib/src/test/report_key.dart
@@ -1,0 +1,8 @@
+/// The report key under which `testWidgetbookOnDevice` hands per-scenario
+/// snapshot metadata to `widgetbookIntegrationDriver` via the integration-test
+/// binding's `reportData`.
+///
+/// Kept in its own dependency-free file so the host-side driver can share it
+/// without importing any Flutter UI code (which is unavailable in the
+/// `flutter drive` VM).
+const widgetbookReportKey = 'widgetbook';

--- a/packages/widgetbook/lib/src/test/report_key.dart
+++ b/packages/widgetbook/lib/src/test/report_key.dart
@@ -1,8 +1,3 @@
-/// The report key under which `testWidgetbookOnDevice` hands per-scenario
-/// snapshot metadata to `widgetbookIntegrationDriver` via the integration-test
-/// binding's `reportData`.
-///
-/// Kept in its own dependency-free file so the host-side driver can share it
-/// without importing any Flutter UI code (which is unavailable in the
-/// `flutter drive` VM).
+/// Report-data key shared by `testWidgetbookOnDevice` and the driver. In its
+/// own dependency-free file so the host-side driver can import it safely.
 const widgetbookReportKey = 'widgetbook';

--- a/packages/widgetbook/lib/src/test/snapshot_runner.dart
+++ b/packages/widgetbook/lib/src/test/snapshot_runner.dart
@@ -8,7 +8,6 @@ import '../../widgetbook.dart';
 import 'scenario_metadata.dart';
 import 'semantics/semantics_tree_serializer.dart';
 
-/// A captured scenario image and the dimensions describing it.
 @internal
 class CapturedSnapshot {
   const CapturedSnapshot({
@@ -24,23 +23,15 @@ class CapturedSnapshot {
   final double pixelRatio;
 }
 
-/// The parts of snapshot capture that differ between the headless
-/// (`flutter test`) and on-device (`integration_test`) runners: how the
-/// viewport is applied, and how the built scenario is captured and persisted.
-///
-/// Everything else — the component/story/scenario walk, `Scenario.run`,
-/// accessibility evaluation, semantics, image-cache reset, `wrapper`, and
-/// `excludeFromTests` — is shared by [declareSnapshotTests].
+/// The capture behavior that differs between the headless (`flutter test`) and
+/// on-device (`integration_test`) runners. The scenario walk and everything
+/// around capture is shared by [declareSnapshotTests].
 @internal
 abstract class SnapshotStrategy {
   const SnapshotStrategy();
 
-  /// Applies [viewport] to the tester's view before the scenario is pumped.
   void applyViewport(WidgetTester tester, ViewportData viewport) {}
 
-  /// Captures the pumped scenario (keyed by [key]) and persists the resulting
-  /// image plus its [ScenarioMetadata]. Implementations build the metadata via
-  /// [buildScenarioMetadata] so both runners emit an identical shape.
   Future<void> captureAndPersist({
     required WidgetTester tester,
     required Scenario scenario,
@@ -51,8 +42,6 @@ abstract class SnapshotStrategy {
   });
 }
 
-/// Assembles [ScenarioMetadata] from a captured image. Shared so the headless
-/// and on-device runners produce byte-identical metadata.
 @internal
 ScenarioMetadata buildScenarioMetadata(
   Scenario scenario,
@@ -71,10 +60,8 @@ ScenarioMetadata buildScenarioMetadata(
   );
 }
 
-/// Declares a test group per component/story and a test case per scenario in
-/// [config], delegating capture and persistence to [strategy]. When [where] is
-/// given, only components it selects are included — the mechanism customers use
-/// to partition components between the headless and on-device runs.
+/// [where] restricts the run to matching components — how a project partitions
+/// components between the headless and on-device runs.
 @internal
 void declareSnapshotTests(
   Config config,
@@ -87,7 +74,6 @@ void declareSnapshotTests(
   }
 }
 
-/// Declares the test group for a single [component] using [strategy].
 @internal
 void declareComponentTests(
   Config config,
@@ -101,7 +87,6 @@ void declareComponentTests(
   });
 }
 
-/// Declares the test group for a single [story] using [strategy].
 @internal
 void declareStoryTests(
   Config config,
@@ -119,7 +104,6 @@ void declareStoryTests(
   );
 }
 
-/// Declares the test case for a single [scenario] using [strategy].
 @internal
 void declareScenarioTest(
   Config config,
@@ -175,17 +159,16 @@ void declareScenarioTest(
         await config.scenarioConfig.tearDown?.call(tester, scenario);
       }
 
-      // The wrapper must already be on the call stack when the widget is
-      // pumped, so that Zone values (e.g. package:clock's clock) are visible
-      // to the build methods of the scenario's widget tree.
+      // The wrapper must be on the call stack before pumping so its Zone values
+      // (e.g. package:clock) are visible to the scenario's build methods.
       final wrapper = config.scenarioConfig.wrapper;
       await (wrapper == null ? body() : wrapper(tester, scenario, body));
 
       semanticsHandle.dispose();
       addTearDown(tester.view.reset);
     },
-    // `null` (not `false`) so a non-excluded scenario inside an excluded story
-    // still inherits the story group's `skip`.
+    // `null` (not `false`) so a non-excluded scenario in an excluded story still
+    // inherits the group's `skip`.
     skip: scenario.excludeFromTests ? true : null,
   );
 }

--- a/packages/widgetbook/lib/src/test/snapshot_runner.dart
+++ b/packages/widgetbook/lib/src/test/snapshot_runner.dart
@@ -1,0 +1,170 @@
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta/meta.dart';
+
+import '../../widgetbook.dart';
+import 'scenario_metadata.dart';
+import 'semantics/semantics_tree_serializer.dart';
+
+/// A captured scenario image and the dimensions describing it.
+@internal
+class CapturedSnapshot {
+  const CapturedSnapshot({
+    required this.bytes,
+    required this.width,
+    required this.height,
+    required this.pixelRatio,
+  });
+
+  final Uint8List bytes;
+  final int width;
+  final int height;
+  final double pixelRatio;
+}
+
+/// The parts of snapshot capture that differ between the headless
+/// (`flutter test`) and on-device (`integration_test`) runners: how the
+/// viewport is applied, and how the built scenario is captured and persisted.
+///
+/// Everything else — the component/story/scenario walk, `Scenario.run`,
+/// accessibility evaluation, semantics, image-cache reset, `wrapper`, and
+/// `excludeFromTests` — is shared by [declareSnapshotTests].
+@internal
+abstract class SnapshotStrategy {
+  const SnapshotStrategy();
+
+  /// Applies [viewport] to the tester's view before the scenario is pumped.
+  void applyViewport(WidgetTester tester, ViewportData viewport) {}
+
+  /// Captures the pumped scenario (keyed by [key]) and persists the resulting
+  /// image plus its [ScenarioMetadata]. Implementations build the metadata via
+  /// [buildScenarioMetadata] so both runners emit an identical shape.
+  Future<void> captureAndPersist({
+    required WidgetTester tester,
+    required Scenario scenario,
+    required Key key,
+    required ViewportData viewport,
+    required Map<String, dynamic> semantics,
+    required List<Map<String, dynamic>> violations,
+  });
+}
+
+/// Assembles [ScenarioMetadata] from a captured image. Shared so the headless
+/// and on-device runners produce byte-identical metadata.
+@internal
+ScenarioMetadata buildScenarioMetadata(
+  Scenario scenario,
+  CapturedSnapshot capture,
+  Map<String, dynamic> semantics,
+  List<Map<String, dynamic>> violations,
+) {
+  return ScenarioMetadata(
+    scenario: scenario,
+    imageBytes: capture.bytes,
+    imageWidth: capture.width,
+    imageHeight: capture.height,
+    pixelRatio: capture.pixelRatio,
+    semanticsData: semantics,
+    violations: violations,
+  );
+}
+
+/// Declares a test group per component/story and a test case per scenario in
+/// [config], delegating capture and persistence to [strategy]. When [where] is
+/// given, only components it selects are included — the mechanism customers use
+/// to opt specific components into on-device snapshotting.
+@internal
+void declareSnapshotTests(
+  Config config,
+  SnapshotStrategy strategy, {
+  bool Function(Component component)? where,
+}) {
+  for (final component in config.components) {
+    if (where != null && !where(component)) continue;
+
+    group(component.name, () {
+      for (final story in component.stories) {
+        group(
+          story.name,
+          () {
+            for (final scenario in story.allScenarios(config)) {
+              _testScenario(config, scenario, strategy);
+            }
+          },
+          skip: story.excludeFromTests ? 'Excluded from snapshots' : null,
+        );
+      }
+    });
+  }
+}
+
+void _testScenario(
+  Config config,
+  Scenario scenario,
+  SnapshotStrategy strategy,
+) {
+  final targetViewport = scenario.viewport ?? Viewports.none;
+
+  testWidgets(
+    scenario.name,
+    (tester) async {
+      // Reset the shared image cache so it doesn't leak between scenarios.
+      addTearDown(() {
+        final imageCache = PaintingBinding.instance.imageCache;
+        imageCache.clear();
+        imageCache.clearLiveImages();
+      });
+
+      strategy.applyViewport(tester, targetViewport);
+
+      final semanticsHandle = tester.binding.ensureSemantics();
+
+      Future<void> body() async {
+        final key = UniqueKey();
+        await tester.pumpWidget(
+          Builder(
+            key: key,
+            builder: (context) => scenario.buildWithConfig(context, config),
+          ),
+        );
+
+        await config.scenarioConfig.setUp?.call(tester, scenario);
+        await scenario.execute(tester);
+
+        final violations = (await evaluateGuidelines(
+          tester,
+          config.accessibilityConfig.guidelines,
+        )).map((violation) => violation.toJson()).toList();
+
+        final semantics = SemanticsTreeSerializer.toJson(
+          tester.getSemantics(find.byKey(key)),
+        );
+
+        await strategy.captureAndPersist(
+          tester: tester,
+          scenario: scenario,
+          key: key,
+          viewport: targetViewport,
+          semantics: semantics,
+          violations: violations,
+        );
+
+        await config.scenarioConfig.tearDown?.call(tester, scenario);
+      }
+
+      // The wrapper must already be on the call stack when the widget is
+      // pumped, so that Zone values (e.g. package:clock's clock) are visible
+      // to the build methods of the scenario's widget tree.
+      final wrapper = config.scenarioConfig.wrapper;
+      await (wrapper == null ? body() : wrapper(tester, scenario, body));
+
+      semanticsHandle.dispose();
+      addTearDown(tester.view.reset);
+    },
+    // `null` (not `false`) so a non-excluded scenario inside an excluded story
+    // still inherits the story group's `skip`.
+    skip: scenario.excludeFromTests ? true : null,
+  );
+}

--- a/packages/widgetbook/lib/src/test/snapshot_runner.dart
+++ b/packages/widgetbook/lib/src/test/snapshot_runner.dart
@@ -74,7 +74,7 @@ ScenarioMetadata buildScenarioMetadata(
 /// Declares a test group per component/story and a test case per scenario in
 /// [config], delegating capture and persistence to [strategy]. When [where] is
 /// given, only components it selects are included — the mechanism customers use
-/// to opt specific components into on-device snapshotting.
+/// to partition components between the headless and on-device runs.
 @internal
 void declareSnapshotTests(
   Config config,
@@ -83,24 +83,45 @@ void declareSnapshotTests(
 }) {
   for (final component in config.components) {
     if (where != null && !where(component)) continue;
-
-    group(component.name, () {
-      for (final story in component.stories) {
-        group(
-          story.name,
-          () {
-            for (final scenario in story.allScenarios(config)) {
-              _testScenario(config, scenario, strategy);
-            }
-          },
-          skip: story.excludeFromTests ? 'Excluded from snapshots' : null,
-        );
-      }
-    });
+    declareComponentTests(config, component, strategy);
   }
 }
 
-void _testScenario(
+/// Declares the test group for a single [component] using [strategy].
+@internal
+void declareComponentTests(
+  Config config,
+  Component component,
+  SnapshotStrategy strategy,
+) {
+  group(component.name, () {
+    for (final story in component.stories) {
+      declareStoryTests(config, story, strategy);
+    }
+  });
+}
+
+/// Declares the test group for a single [story] using [strategy].
+@internal
+void declareStoryTests(
+  Config config,
+  Story story,
+  SnapshotStrategy strategy,
+) {
+  group(
+    story.name,
+    () {
+      for (final scenario in story.allScenarios(config)) {
+        declareScenarioTest(config, scenario, strategy);
+      }
+    },
+    skip: story.excludeFromTests ? 'Excluded from snapshots' : null,
+  );
+}
+
+/// Declares the test case for a single [scenario] using [strategy].
+@internal
+void declareScenarioTest(
   Config config,
   Scenario scenario,
   SnapshotStrategy strategy,

--- a/packages/widgetbook/lib/src/test/test.dart
+++ b/packages/widgetbook/lib/src/test/test.dart
@@ -13,16 +13,21 @@ import 'snapshot_runner.dart';
 const outputDir = 'build/.widgetbook';
 
 /// Generates a snapshot for every scenario in [config] headlessly under
-/// `flutter test`.
+/// `flutter test`, optionally narrowed to the components matching [where].
 ///
 /// Widgets backed by platform textures/views (e.g. `video_player`, `pdfrx`)
 /// render blank here because there is no real engine or GPU — only the Flutter
 /// layer tree is rasterized. For those, use `testWidgetbookOnDevice` from
 /// `package:widgetbook/integration_test.dart`, which runs on a device/simulator.
-Future<void> testWidgetbook(Config config) async {
+/// The two share the same `where` filter, so a project can partition its
+/// components between the fast headless run and the on-device run.
+Future<void> testWidgetbook(
+  Config config, {
+  bool Function(Component component)? where,
+}) async {
   TestWidgetsFlutterBinding.ensureInitialized();
   await loadFonts();
-  declareSnapshotTests(config, const _LayerStrategy());
+  declareSnapshotTests(config, const _LayerStrategy(), where: where);
 }
 
 /// Headless capture strategy: rasterizes the Flutter layer tree offscreen via

--- a/packages/widgetbook/lib/src/test/test.dart
+++ b/packages/widgetbook/lib/src/test/test.dart
@@ -30,6 +30,18 @@ Future<void> testWidgetbook(
   declareSnapshotTests(config, const _LayerStrategy(), where: where);
 }
 
+/// Declares the headless snapshot tests for a single [component].
+void testComponent(Config config, Component component) =>
+    declareComponentTests(config, component, const _LayerStrategy());
+
+/// Declares the headless snapshot tests for a single [story].
+void testStory(Config config, Story story) =>
+    declareStoryTests(config, story, const _LayerStrategy());
+
+/// Declares the headless snapshot test for a single [scenario].
+void testScenario(Config config, Scenario scenario) =>
+    declareScenarioTest(config, scenario, const _LayerStrategy());
+
 /// Headless capture strategy: rasterizes the Flutter layer tree offscreen via
 /// [captureImage] and writes the results straight to disk.
 class _LayerStrategy extends SnapshotStrategy {

--- a/packages/widgetbook/lib/src/test/test.dart
+++ b/packages/widgetbook/lib/src/test/test.dart
@@ -15,12 +15,8 @@ const outputDir = 'build/.widgetbook';
 /// Generates a snapshot for every scenario in [config] headlessly under
 /// `flutter test`, optionally narrowed to the components matching [where].
 ///
-/// Widgets backed by platform textures/views (e.g. `video_player`, `pdfrx`)
-/// render blank here because there is no real engine or GPU — only the Flutter
-/// layer tree is rasterized. For those, use `testWidgetbookOnDevice` from
-/// `package:widgetbook/integration_test.dart`, which runs on a device/simulator.
-/// The two share the same `where` filter, so a project can partition its
-/// components between the fast headless run and the on-device run.
+/// Platform-backed widgets (e.g. `video_player`, `pdfrx`) render blank here;
+/// capture those with `testWidgetbookOnDevice` (they share the `where` filter).
 Future<void> testWidgetbook(
   Config config, {
   bool Function(Component component)? where,
@@ -30,20 +26,16 @@ Future<void> testWidgetbook(
   declareSnapshotTests(config, const _LayerStrategy(), where: where);
 }
 
-/// Declares the headless snapshot tests for a single [component].
 void testComponent(Config config, Component component) =>
     declareComponentTests(config, component, const _LayerStrategy());
 
-/// Declares the headless snapshot tests for a single [story].
 void testStory(Config config, Story story) =>
     declareStoryTests(config, story, const _LayerStrategy());
 
-/// Declares the headless snapshot test for a single [scenario].
 void testScenario(Config config, Scenario scenario) =>
     declareScenarioTest(config, scenario, const _LayerStrategy());
 
-/// Headless capture strategy: rasterizes the Flutter layer tree offscreen via
-/// [captureImage] and writes the results straight to disk.
+/// Headless capture: rasterizes the layer tree offscreen and writes to disk.
 class _LayerStrategy extends SnapshotStrategy {
   const _LayerStrategy();
 
@@ -65,8 +57,7 @@ class _LayerStrategy extends SnapshotStrategy {
     final element = tester.element(find.byKey(key));
     final imageFuture = captureImage(element, 1);
 
-    // Run on a real event loop as async operations cannot be run inside
-    // testWidgets directly.
+    // Async image encoding + file I/O can't run inside testWidgets directly.
     await TestWidgetsFlutterBinding.instance.runAsync(() async {
       final image = await imageFuture;
       final byteData = await image.toByteData(format: ImageByteFormat.png);

--- a/packages/widgetbook/lib/src/test/test.dart
+++ b/packages/widgetbook/lib/src/test/test.dart
@@ -7,149 +7,81 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../../widgetbook.dart';
 import 'font_loader.dart';
-import 'scenario_metadata.dart';
-import 'semantics/semantics_tree_serializer.dart';
+import 'snapshot_runner.dart';
 
 /// The default location is already an ignored path by default.
 const outputDir = 'build/.widgetbook';
 
+/// Generates a snapshot for every scenario in [config] headlessly under
+/// `flutter test`.
+///
+/// Widgets backed by platform textures/views (e.g. `video_player`, `pdfrx`)
+/// render blank here because there is no real engine or GPU — only the Flutter
+/// layer tree is rasterized. For those, use `testWidgetbookOnDevice` from
+/// `package:widgetbook/integration_test.dart`, which runs on a device/simulator.
 Future<void> testWidgetbook(Config config) async {
   TestWidgetsFlutterBinding.ensureInitialized();
   await loadFonts();
+  declareSnapshotTests(config, const _LayerStrategy());
+}
 
-  for (final component in config.components) {
-    testComponent(config, component);
+/// Headless capture strategy: rasterizes the Flutter layer tree offscreen via
+/// [captureImage] and writes the results straight to disk.
+class _LayerStrategy extends SnapshotStrategy {
+  const _LayerStrategy();
+
+  @override
+  void applyViewport(WidgetTester tester, ViewportData viewport) {
+    tester.view.physicalConstraints = viewport.viewConstraints;
+    tester.view.devicePixelRatio = viewport.pixelRatio;
+  }
+
+  @override
+  Future<void> captureAndPersist({
+    required WidgetTester tester,
+    required Scenario scenario,
+    required Key key,
+    required ViewportData viewport,
+    required Map<String, dynamic> semantics,
+    required List<Map<String, dynamic>> violations,
+  }) async {
+    final element = tester.element(find.byKey(key));
+    final imageFuture = captureImage(element, 1);
+
+    // Run on a real event loop as async operations cannot be run inside
+    // testWidgets directly.
+    await TestWidgetsFlutterBinding.instance.runAsync(() async {
+      final image = await imageFuture;
+      final byteData = await image.toByteData(format: ImageByteFormat.png);
+      final bytes = byteData!.buffer.asUint8List();
+
+      final metadata = buildScenarioMetadata(
+        scenario,
+        CapturedSnapshot(
+          bytes: bytes,
+          width: image.width,
+          height: image.height,
+          pixelRatio: viewport.pixelRatio,
+        ),
+        semantics,
+        violations,
+      );
+
+      await metadata.directory.create(recursive: true);
+      await Future.wait([
+        metadata.imageFile.writeAsBytes(bytes, flush: true),
+        metadata.jsonFile.writeAsString(
+          const JsonEncoder.withIndent('  ').convert(metadata),
+          flush: true,
+        ),
+      ]);
+
+      image.dispose();
+    });
   }
 }
 
-void testComponent(
-  Config config,
-  Component component,
-) {
-  group('${component.name}', () {
-    for (final story in component.stories) {
-      testStory(config, story);
-    }
-  });
-}
-
-void testStory(
-  Config config,
-  Story story,
-) {
-  group(
-    story.name,
-    () {
-      final scenarios = story.allScenarios(config);
-      for (final scenario in scenarios) {
-        testScenario(config, scenario);
-      }
-    },
-    skip: story.excludeFromTests ? 'Excluded from snapshots' : null,
-  );
-}
-
-void testScenario(
-  Config config,
-  Scenario scenario,
-) {
-  final defaultViewport = Viewports.none;
-  final targetViewport = scenario.viewport ?? defaultViewport;
-
-  testWidgets(
-    scenario.name,
-    (tester) async {
-      // Reset the shared image cache so it doesn't leak between scenarios.
-      addTearDown(() {
-        final imageCache = PaintingBinding.instance.imageCache;
-        imageCache.clear();
-        imageCache.clearLiveImages();
-      });
-
-      tester.view.physicalConstraints = targetViewport.viewConstraints;
-      tester.view.devicePixelRatio = targetViewport.pixelRatio;
-
-      final semanticsHandle = tester.binding.ensureSemantics();
-
-      Future<void> body() async {
-        final key = UniqueKey();
-        await tester.pumpWidget(
-          Builder(
-            key: key,
-            builder: (context) => scenario.buildWithConfig(context, config),
-          ),
-        );
-
-        await config.scenarioConfig.setUp?.call(tester, scenario);
-
-        await scenario.execute(tester);
-
-        final violations = (await evaluateGuidelines(
-          tester,
-          config.accessibilityConfig.guidelines,
-        )).map((violation) => violation.toJson()).toList();
-
-        final element = tester.element(find.byKey(key));
-        final imageFuture = captureImage(element, 1);
-
-        final semanticsNode = tester.getSemantics(find.byKey(key));
-
-        // Run on separate isolate as async operations cannot be run inside
-        // testWidgets directly.
-        final binding = TestWidgetsFlutterBinding.instance;
-        await binding.runAsync(() async {
-          final image = await imageFuture;
-          final byteData = await image.toByteData(format: ImageByteFormat.png);
-          final imageBytes = byteData!.buffer.asUint8List();
-
-          final jsonEncoder = const JsonEncoder.withIndent('  ');
-
-          final semanticsData = SemanticsTreeSerializer.toJson(
-            semanticsNode,
-          );
-
-          final metadata = ScenarioMetadata(
-            scenario: scenario,
-            imageBytes: imageBytes,
-            imageWidth: image.width,
-            imageHeight: image.height,
-            pixelRatio: targetViewport.pixelRatio,
-            semanticsData: semanticsData,
-            violations: violations,
-          );
-
-          await metadata.directory.create(recursive: true);
-
-          await Future.wait([
-            metadata.imageFile.writeAsBytes(imageBytes, flush: true),
-            metadata.jsonFile.writeAsString(
-              jsonEncoder.convert(metadata),
-              flush: true,
-            ),
-          ]);
-
-          image.dispose();
-        });
-
-        await config.scenarioConfig.tearDown?.call(tester, scenario);
-      }
-
-      // The wrapper must already be on the call stack when the widget is
-      // pumped, so that Zone values (e.g. package:clock's clock) are visible
-      // to the build methods of the scenario's widget tree.
-      final wrapper = config.scenarioConfig.wrapper;
-      await (wrapper == null ? body() : wrapper(tester, scenario, body));
-
-      semanticsHandle.dispose();
-      addTearDown(tester.view.reset);
-    },
-    // `null` (not `false`) so a non-excluded scenario inside an excluded story
-    // still inherits the story group's `skip`.
-    skip: scenario.excludeFromTests ? true : null,
-  );
-}
-
-/// Same as [captureImage] from `flutter_test` but has [pixelRatio] parameter.
+/// Same as `captureImage` from `flutter_test` but has [pixelRatio] parameter.
 Future<Image> captureImage(
   Element element,
   double pixelRatio,

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -28,9 +28,9 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
+  glob: ^2.0.2
   integration_test:
     sdk: flutter
-  glob: ^2.0.2
   meta: ^1.8.0
   nested: ^1.0.0
   path: ^1.8.0

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -28,6 +28,8 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   glob: ^2.0.2
   meta: ^1.8.0
   nested: ^1.0.0

--- a/sandbox/pubspec.lock
+++ b/sandbox/pubspec.lock
@@ -182,12 +182,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
   flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
     source: sdk
@@ -224,6 +234,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  integration_test:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   io:
     dependency: transitive
     description:
@@ -328,6 +343,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -344,6 +367,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -437,6 +468,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -573,6 +612,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   widgetbook:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## What

Adds **on-device snapshotting** to `widgetbook`, alongside the existing headless `testWidgetbook`.

- `testWidgetbookOnDevice(config, {where})` — `package:widgetbook/integration_test.dart`
- `widgetbookIntegrationDriver()` — `package:widgetbook/integration_test_driver.dart`

## Why

`testWidgetbook` runs under `TestWidgetsFlutterBinding` and captures via `OffsetLayer.toImage`, which only rasterizes the Flutter layer tree. Widgets backed by platform textures/views — e.g. `video_player`, `pdfrx` — have no engine/GPU there and render **blank**. Running the same scenarios under `IntegrationTestWidgetsFlutterBinding` on a device/simulator renders them for real, and `takeScreenshot` reads back the actual composited surface.

Headless stays the **default**. On-device is opt-in, and `where` lets a project run most components headlessly (fast) and route only the platform-backed ones on-device:

```dart
// integration_test/widgetbook_test.dart
void main() => testWidgetbookOnDevice(
      config,
      where: (component) => component.name == 'VideoPlayer',
    );

// test_driver/integration_test.dart
void main() => widgetbookIntegrationDriver();
```

```sh
flutter drive \
  --driver test_driver/integration_test.dart \
  --target integration_test/widgetbook_test.dart \
  -d <device-or-simulator>
```

Both write the same `build/.widgetbook/<Component>/<Story>/<Scenario>.{png,json}` cache the CLI already uploads — no cloud-side changes.

## Design

The per-scenario pipeline — `Scenario.run`, semantics, accessibility (`evaluateGuidelines`), image-cache reset, `wrapper`, `excludeFromTests`, and `ScenarioMetadata` assembly — is shared via an internal `SnapshotStrategy`, so the two runners can't drift. Only the three things that genuinely differ vary per strategy:

| | Headless (`testWidgetbook`) | On-device (`testWidgetbookOnDevice`) |
|---|---|---|
| Binding | `TestWidgetsFlutterBinding` | `IntegrationTestWidgetsFlutterBinding` |
| Capture | `OffsetLayer.toImage` (widget bounds) | `takeScreenshot` + viewport crop |
| Persist | write files | round-trip via driver `reportData` |

The driver library imports no Flutter UI code, so it is safe in the `flutter drive` VM. `integration_test` is added to `widgetbook`'s dependencies (it was already a `flutter_test` consumer; widgetbook is a tooling dependency, so the transitive `flutter_driver` doesn't reach production apps).

## Notes / scope

- **Draft.** No example app is included in this repo; a runnable demo lives separately. On-device rendering is inherently exercised on a device/simulator, so it isn't covered by in-repo `flutter test`. Headless behavior is covered by the existing `test/test/` suite (still green after the refactor).
- **BREAKING (minor):** removes the incidental `testComponent`/`testStory`/`testScenario` exports from `test.dart`; use `testWidgetbook`.
- Structural differences from headless: on-device captures the physical surface at the device's pixel ratio; a viewport (via `ViewportMode`/`ViewportAddon`) is cropped from the screenshot and cannot exceed the device screen.
- `pana`'s `analyzer <13` finding is pre-existing on `v4`, unrelated to this change.
