### PR TITLE
docs: add Agentic Engineering and GenUI sections

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -349,6 +349,38 @@
     },
     {
       "tab": "docs",
+      "group": "Agentic Engineering",
+      "pages": [
+        {
+          "title": "Overview",
+          "href": "/agentic/overview"
+        },
+        {
+          "title": "Best Practices",
+          "href": "/agentic/best-practices"
+        }
+      ]
+    },
+    {
+      "tab": "docs",
+      "group": "GenUI",
+      "pages": [
+        {
+          "title": "Overview",
+          "href": "/genui/overview"
+        },
+        {
+          "title": "Build Your Catalog",
+          "href": "/genui/catalog"
+        },
+        {
+          "title": "Test the Catalog",
+          "href": "/genui/testing"
+        }
+      ]
+    },
+    {
+      "tab": "docs",
       "group": "Releases",
       "pages": [
         {

--- a/docs/agentic/best-practices.mdx
+++ b/docs/agentic/best-practices.mdx
@@ -1,14 +1,16 @@
 # Best Practices
 
 <Warning>
-  Early guidance. These are conventions that hold up in practice, not a stable API contract.
+  Early guidance.
+  These are conventions that hold up in practice, not a stable API contract.
 </Warning>
 
 How to get useful results when an agent writes stories in your project.
 
 ## Run the Generator in Watch Mode
 
-`_Story`, `_Args`, and `_Scenario` only exist after code generation. An agent writing against missing types produces code that does not compile, then guesses at fixes.
+`_Story`, `_Args`, and `_Scenario` only exist after code generation.
+An agent writing against missing types produces code that does not compile, then guesses at fixes.
 
 ```bash
 dart run build_runner watch
@@ -18,9 +20,11 @@ See [Code Generation](/stories/code-generation).
 
 ## Give the Agent Examples First
 
-Write three to five stories by hand covering your real patterns: a widget with a callback, one with an enum, one screen with a mocked dependency. Point the agent at them.
+Write three to five stories by hand covering your real patterns: a widget with a callback, one with an enum, one screen with a mocked dependency.
+Point the agent at them.
 
-Generic instructions produce generic stories. Your own files carry the conventions no prompt can state.
+Generic instructions produce generic stories.
+Your own files carry the conventions no prompt can state.
 
 This is the same workflow the [v4 Migration Guide](/v4-migration) uses.
 
@@ -28,7 +32,8 @@ This is the same workflow the [v4 Migration Guide](/v4-migration) uses.
 
 Agents get these wrong without being told:
 
-- Story variables start with `$`. The name minus `$` becomes the display name.
+- Story variables start with `$`.
+  The name minus `$` becomes the display name.
 - Every stories file needs a `part 'name.stories.g.dart';` directive.
 - `Meta` variables must be `const`. `ComponentMeta` with a `docsBuilder` must be `final`.
 - Constructor parameters without a usable default must be passed in `args`.
@@ -36,9 +41,11 @@ Agents get these wrong without being told:
 
 ## Prefer Widget-Derived Args
 
-Without `Meta.argsType`, the generator writes the `builder` for you. Custom args require a hand-written `builder` mapping args to the widget, which is more surface for an agent to get wrong.
+Without `Meta.argsType`, the generator writes the `builder` for you.
+Custom args require a hand-written `builder` mapping args to the widget, which is more surface for an agent to get wrong.
 
-Use custom args only when the constructor genuinely does not fit. See [When to Use Custom Args](/stories/code-generation#when-to-use-custom-args).
+Use custom args only when the constructor genuinely does not fit.
+See [When to Use Custom Args](/stories/code-generation#when-to-use-custom-args).
 
 ## Let Scenarios Do the Verification
 
@@ -48,4 +55,5 @@ This turns "the agent says it works" into an artifact you can look at.
 
 ## Review the Story Set, Not Just the Code
 
-Agents produce plausible stories for states that do not exist and skip the states that break. Check coverage against the widget's actual API: every enum value, every nullable path, empty and overflow content.
+Agents produce plausible stories for states that do not exist and skip the states that break.
+Check coverage against the widget's actual API: every enum value, every nullable path, empty and overflow content.

--- a/docs/agentic/best-practices.mdx
+++ b/docs/agentic/best-practices.mdx
@@ -1,0 +1,51 @@
+# Best Practices
+
+<Warning>
+  Early guidance. These are conventions that hold up in practice, not a stable API contract.
+</Warning>
+
+How to get useful results when an agent writes stories in your project.
+
+## Run the Generator in Watch Mode
+
+`_Story`, `_Args`, and `_Scenario` only exist after code generation. An agent writing against missing types produces code that does not compile, then guesses at fixes.
+
+```bash
+dart run build_runner watch
+```
+
+See [Code Generation](/stories/code-generation).
+
+## Give the Agent Examples First
+
+Write three to five stories by hand covering your real patterns: a widget with a callback, one with an enum, one screen with a mocked dependency. Point the agent at them.
+
+Generic instructions produce generic stories. Your own files carry the conventions no prompt can state.
+
+This is the same workflow the [v4 Migration Guide](/v4-migration) uses.
+
+## State the Constraints the Generator Enforces
+
+Agents get these wrong without being told:
+
+- Story variables start with `$`. The name minus `$` becomes the display name.
+- Every stories file needs a `part 'name.stories.g.dart';` directive.
+- `Meta` variables must be `const`. `ComponentMeta` with a `docsBuilder` must be `final`.
+- Constructor parameters without a usable default must be passed in `args`.
+- Callbacks belong in `Arg.fixed(...)`, not an arg control.
+
+## Prefer Widget-Derived Args
+
+Without `Meta.argsType`, the generator writes the `builder` for you. Custom args require a hand-written `builder` mapping args to the widget, which is more surface for an agent to get wrong.
+
+Use custom args only when the constructor genuinely does not fit. See [When to Use Custom Args](/stories/code-generation#when-to-use-custom-args).
+
+## Let Scenarios Do the Verification
+
+Ask for a [Scenario](/testing/overview) alongside each story. `flutter test` then captures a screenshot per state into `build/.widgetbook`.
+
+This turns "the agent says it works" into an artifact you can look at.
+
+## Review the Story Set, Not Just the Code
+
+Agents produce plausible stories for states that do not exist and skip the states that break. Check coverage against the widget's actual API: every enum value, every nullable path, empty and overflow content.

--- a/docs/agentic/overview.mdx
+++ b/docs/agentic/overview.mdx
@@ -47,7 +47,7 @@ That is a separate step the agent runs, not part of `flutter test`, and it catch
 Agents own coverage.
 Humans own judgment.
 
-- [Widgetbook Cloud](/sharing/publish-to-cloud) shows a visual diff per scenario across every mode, so themes, locales, and viewports are all covered.
+- [Widgetbook Cloud](/cloud) shows a visual diff per scenario across every mode, so themes, locales, and viewports are all covered.
 - [Accessibility regressions](/cloud/accessibility/regressions) compare the semantics tree against the base build.
 - Reviewers approve at the scenario level instead of reading a line diff.
 

--- a/docs/agentic/overview.mdx
+++ b/docs/agentic/overview.mdx
@@ -1,38 +1,51 @@
 # Agentic Engineering
 
-Coding agents write Flutter UI quickly. Quality is the bottleneck, not speed.
+Coding agents write Flutter UI quickly.
+Quality is the bottleneck, not speed.
 
-The agent has no idea what your design system looks like at the rendering level, so it guesses. Three failures follow:
+The agent has no idea what your design system looks like at the rendering level, so it guesses.
+Three failures follow:
 
-- **Design and code drift apart.** The agent reaches for `ElevatedButton` instead of your `AppButton`, hardcodes `Color(0xFFFF0000)` instead of resolving `theme.colorScheme.error`, or drops a `SizedBox(height: 16)` where `AppSpacing.medium` belongs. The screen looks roughly right and ships roughly wrong.
-- **Visual bugs slip through.** UI review is visual review. Catching a regression by hand means running the app and navigating to every state, theme, breakpoint, and locale.
-- **Accessibility violations.** A reject button at 32x32 is below the minimum touch target. An icon button with no label is invisible to a screen reader. The screen can look identical while these properties change.
+- **Design and code drift apart.** The agent reaches for `ElevatedButton` instead of your `AppButton`, hardcodes `Color(0xFFFF0000)` instead of resolving `theme.colorScheme.error`, or drops a `SizedBox(height: 16)` where `AppSpacing.medium` belongs.
+  The screen looks roughly right and ships roughly wrong.
+- **Visual bugs slip through.** UI review is visual review.
+  Catching a regression by hand means running the app and navigating to every state, theme, breakpoint, and locale.
+- **Accessibility violations.** A reject button at 32x32 is below the minimum touch target.
+  An icon button with no label is invisible to a screen reader.
+  The screen can look identical while these properties change.
 
-Our guide on [agentic UI engineering for Flutter](https://www.widgetbook.io/blog/agentic-ui-engineering-for-flutter) lays out a workflow in three phases. The summary below covers the parts Widgetbook supports today.
+Our guide on [agentic UI engineering for Flutter](https://www.widgetbook.io/blog/agentic-ui-engineering-for-flutter) lays out a workflow in three phases.
+The summary below covers the parts Widgetbook supports today.
 
 ## Prevent
 
-Give the agent the rules before it generates anything. Fixing drift afterwards costs more than preventing it.
+Give the agent the rules before it generates anything.
+Fixing drift afterwards costs more than preventing it.
 
 - Write down your design system rules, naming conventions, and component catalog as a plain text file the agent reads.
-- Point the agent at your existing `.stories.dart` files. They show valid components, valid args, and the states each component supports.
+- Point the agent at your existing `.stories.dart` files.
+  They show valid components, valid args, and the states each component supports.
 - Enforce design system usage with custom lint rules, so violations surface as analyzer warnings.
 
 ## Self-Correct
 
 Give the agent a feedback loop it can read without a human in the middle.
 
-`flutter test` runs three checks, in this order:
+`flutter test` gives the agent two things to read:
 
 1. **Scenario and interaction tests.** [Scenarios](/testing/overview) assert real behavior, so a failure is a concrete error rather than a guess.
-2. **Figma diff.** The [Figma MCP server](https://developers.figma.com/docs/figma-mcp-server/) lets the agent check its render against the design itself. This catches a hardcoded value that looks correct but bypasses your tokens.
-3. **Accessibility rules.** [Accessibility guidelines](/testing/accessibility) are evaluated on every captured scenario and written into the scenario metadata, including which element broke which rule.
+2. **Accessibility results.** [Accessibility guidelines](/testing/accessibility) are evaluated on every captured scenario and written into the scenario metadata, including which element broke which rule.
+   They do not fail the run, so the agent reads them from the metadata file rather than the console.
 
-The agent reads those failures and iterates on its own.
+The agent reads both and iterates on its own.
+
+Alongside that loop, the [Figma MCP server](https://developers.figma.com/docs/figma-mcp-server/) lets the agent check its render against the design itself.
+That is a separate step the agent runs, not part of `flutter test`, and it catches a hardcoded value that looks correct but bypasses your tokens.
 
 ## Review
 
-Agents own coverage. Humans own judgment.
+Agents own coverage.
+Humans own judgment.
 
 - [Widgetbook Cloud](/sharing/publish-to-cloud) shows a visual diff per scenario across every mode, so themes, locales, and viewports are all covered.
 - [Accessibility regressions](/cloud/accessibility/regressions) compare the semantics tree against the base build.

--- a/docs/agentic/overview.mdx
+++ b/docs/agentic/overview.mdx
@@ -1,0 +1,45 @@
+# Agentic Engineering
+
+Coding agents write Flutter UI quickly. Quality is the bottleneck, not speed.
+
+The agent has no idea what your design system looks like at the rendering level, so it guesses. Three failures follow:
+
+- **Design and code drift apart.** The agent reaches for `ElevatedButton` instead of your `AppButton`, hardcodes `Color(0xFFFF0000)` instead of resolving `theme.colorScheme.error`, or drops a `SizedBox(height: 16)` where `AppSpacing.medium` belongs. The screen looks roughly right and ships roughly wrong.
+- **Visual bugs slip through.** UI review is visual review. Catching a regression by hand means running the app and navigating to every state, theme, breakpoint, and locale.
+- **Accessibility violations.** A reject button at 32x32 is below the minimum touch target. An icon button with no label is invisible to a screen reader. The screen can look identical while these properties change.
+
+Our guide on [agentic UI engineering for Flutter](https://www.widgetbook.io/blog/agentic-ui-engineering-for-flutter) lays out a workflow in three phases. The summary below covers the parts Widgetbook supports today.
+
+## Prevent
+
+Give the agent the rules before it generates anything. Fixing drift afterwards costs more than preventing it.
+
+- Write down your design system rules, naming conventions, and component catalog as a plain text file the agent reads.
+- Point the agent at your existing `.stories.dart` files. They show valid components, valid args, and the states each component supports.
+- Enforce design system usage with custom lint rules, so violations surface as analyzer warnings.
+
+## Self-Correct
+
+Give the agent a feedback loop it can read without a human in the middle.
+
+`flutter test` runs three checks, in this order:
+
+1. **Scenario and interaction tests.** [Scenarios](/testing/overview) assert real behavior, so a failure is a concrete error rather than a guess.
+2. **Figma diff.** The [Figma MCP server](https://developers.figma.com/docs/figma-mcp-server/) lets the agent check its render against the design itself. This catches a hardcoded value that looks correct but bypasses your tokens.
+3. **Accessibility rules.** [Accessibility guidelines](/testing/accessibility) are evaluated on every captured scenario and written into the scenario metadata, including which element broke which rule.
+
+The agent reads those failures and iterates on its own.
+
+## Review
+
+Agents own coverage. Humans own judgment.
+
+- [Widgetbook Cloud](/sharing/publish-to-cloud) shows a visual diff per scenario across every mode, so themes, locales, and viewports are all covered.
+- [Accessibility regressions](/cloud/accessibility/regressions) compare the semantics tree against the base build.
+- Reviewers approve at the scenario level instead of reading a line diff.
+
+## Next
+
+- [Best Practices](/agentic/best-practices) for getting usable stories out of an agent.
+- [GenUI](/genui/overview) for the other direction, where a model composes UI from your widgets at runtime.
+- [Agentic UI engineering for Flutter](https://www.widgetbook.io/blog/agentic-ui-engineering-for-flutter) for the full workflow.

--- a/docs/genui/catalog.mdx
+++ b/docs/genui/catalog.mdx
@@ -1,0 +1,188 @@
+# Build Your Catalog with Stories
+
+A catalog item binds model data to a widget. A story binds args to the same widget. Structure the widget so both can reach it.
+
+## Split the Widget from the Binding
+
+Write the catalog widget as a plain presentational widget. No `DataModel`, no schema.
+
+```dart title="design_system/lib/option_tiles.dart"
+class OptionTiles extends StatelessWidget {
+  const OptionTiles({
+    super.key,
+    required this.question,
+    required this.options,
+    required this.selectedId,
+    required this.onSelected,
+  });
+
+  final String question;
+  final List<TileOption> options;
+  final String? selectedId;
+  final ValueChanged<String> onSelected;
+
+  // ...
+}
+```
+
+Keep GenUI awareness in the `CatalogItem`:
+
+```dart title="app/lib/genui/option_tiles_item.dart"
+final optionTiles = CatalogItem(
+  name: 'OptionTiles',
+  dataSchema: _optionTilesSchema,
+  widgetBuilder: (context) {
+    final data = _OptionTilesData.fromMap(context.data! as Map<String, Object?>);
+
+    return BoundString(
+      dataContext: context.dataContext,
+      value: data.selection,
+      builder: (builderContext, selectedId) => OptionTiles(
+        question: data.question,
+        options: data.options,
+        selectedId: selectedId,
+        onSelected: (id) => context.dataContext.update(
+          DataPath(data.selectionPath),
+          id,
+        ),
+      ),
+    );
+  },
+);
+```
+
+Selections write to the local `DataModel`. Tapping a tile does not call the model again.
+
+## Hold State in a Host Widget
+
+`OptionTiles` is controlled: it renders `selectedId` and reports taps through `onSelected`. The `DataModel` holds that state in the app. Nothing holds it in a story, so taps would do nothing.
+
+Add a stateful host:
+
+```dart title="widgetbook/lib/option_tiles_host.dart"
+class OptionTilesHost extends StatefulWidget {
+  const OptionTilesHost({
+    super.key,
+    required this.question,
+    required this.options,
+    this.initialSelectionId,
+  });
+
+  final String question;
+  final List<TileOption> options;
+  final String? initialSelectionId;
+
+  @override
+  State<OptionTilesHost> createState() => _OptionTilesHostState();
+}
+
+class _OptionTilesHostState extends State<OptionTilesHost> {
+  late String? _selectedId = widget.initialSelectionId;
+
+  @override
+  Widget build(BuildContext context) {
+    return OptionTiles(
+      question: widget.question,
+      options: widget.options,
+      selectedId: _selectedId,
+      onSelected: (id) => setState(() => _selectedId = id),
+    );
+  }
+}
+```
+
+The host stands in for the `DataModel`, making selection testable in a [scenario](/testing/create-scenario#create-interaction-scenarios).
+
+Widgetbook rebuilds a story with a new key when an arg changes, so editing `initialSelectionId` resets the host. See [Stateful Widgets and Arg Updates](/args/overview#stateful-widgets-and-arg-updates).
+
+## Write the Story
+
+`Meta` points at the host, so args come from its constructor:
+
+```dart title="widgetbook/lib/option_tiles.stories.dart"
+import 'package:design_system/option_tiles.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import 'option_tiles_host.dart';
+
+part 'option_tiles.stories.g.dart';
+
+const meta = Meta(OptionTilesHost.new);
+
+const _seasons = [
+  TileOption(id: 'spring', label: 'Spring'),
+  TileOption(id: 'summer', label: 'Summer'),
+  TileOption(id: 'autumn', label: 'Autumn'),
+  TileOption(id: 'winter', label: 'Winter'),
+];
+
+final $Default = _Story(
+  args: _Args(
+    question: StringArg('Which season?'),
+    options: Arg.fixed(_seasons),
+    initialSelectionId: NullableStringArg(null),
+  ),
+);
+```
+
+`options` is not a primitive, so the generator produces `Arg<List<TileOption>>` and you supply it with `Arg.fixed`. For an editable control, write a [custom arg](/args/custom).
+
+### Callbacks Are Not Args
+
+`onSelected` never appears in the story. Functions are not model-authored data, so they are neither args nor schema properties.
+
+When the model should influence behavior, it emits data and the app maps it. A `variant` enum or `showsClearAction` boolean is model-authored. The callback it triggers is yours. See [Best Practices](/agentic/best-practices).
+
+## Derive the Schema from the Story
+
+No generator required. A `.stories.dart` file is a typed spec of the widget: every parameter, allowed enum value, default, and the states worth a scenario. Hand it to a coding agent and ask for the `dataSchema`.
+
+| Widgetbook | `json_schema_builder` |
+| --- | --- |
+| `StringArg` | `S.string()` |
+| `IntArg` / `DoubleArg` | `S.integer()` / `S.number()` |
+| `BoolArg` | `S.boolean()` |
+| `EnumArg<T>(values: T.values)` | `S.string(enumValues: [...])` |
+| `Arg.fixed(List<T>)` | `S.list(items: S.object(...))` |
+| Non-nullable arg | Listed in `required` |
+| `NullableStringArg` and friends | Omitted from `required` |
+| `Arg.fixed(callback)` | Nothing. App-owned |
+
+For the story above:
+
+```dart title="app/lib/genui/option_tiles_item.dart"
+final _optionTilesSchema = S.object(
+  description: 'A compact tile selector for a single choice along one axis.',
+  properties: {
+    'question': S.string(description: 'The question shown above the tiles.'),
+    'options': S.list(
+      description: 'Between two and six choices.',
+      items: S.object(
+        properties: {
+          'id': S.string(description: 'Stable identifier for the choice.'),
+          'label': S.string(description: 'Short display label, 1-3 words.'),
+        },
+        required: ['id', 'label'],
+      ),
+    ),
+    'selection': A2uiSchemas.stringReference(
+      description: 'Path under /scene/* where the selection is stored.',
+    ),
+  },
+  required: ['question', 'options', 'selection'],
+);
+```
+
+Two things an agent cannot infer from types:
+
+- **Descriptions are prompt text.** The model reads them to decide when to use the widget and what to put in it. `'Short display label, 1-3 words'` prevents overflow that no type signature could.
+- **Design constraints.** If the layout breaks past six tiles, the schema must say so. The Dart signature accepts any list length. Your design does not.
+
+<Warning>
+  Regeneration is the only thing keeping schema and widget aligned. Add a constructor parameter and no test fails, the model simply never emits it. Regenerate whenever a catalog widget's API changes.
+</Warning>
+
+## Next
+
+- [Test the Catalog](/genui/testing)
+- [Code Generation](/stories/code-generation)

--- a/docs/genui/catalog.mdx
+++ b/docs/genui/catalog.mdx
@@ -1,10 +1,13 @@
 # Build Your Catalog with Stories
 
-A catalog item binds model data to a widget. A story binds args to the same widget. Structure the widget so both can reach it.
+A catalog item binds model data to a widget.
+A story binds args to the same widget.
+Structure the widget so both can reach it.
 
 ## Split the Widget from the Binding
 
-Write the catalog widget as a plain presentational widget. No `DataModel`, no schema.
+Write the catalog widget as a plain presentational widget.
+No `DataModel`, no schema.
 
 ```dart title="design_system/lib/option_tiles.dart"
 class OptionTiles extends StatelessWidget {
@@ -32,7 +35,7 @@ final optionTiles = CatalogItem(
   name: 'OptionTiles',
   dataSchema: _optionTilesSchema,
   widgetBuilder: (context) {
-    final data = _OptionTilesData.fromMap(context.data! as Map<String, Object?>);
+    final data = _OptionTilesData.fromMap(context.data as Map<String, Object?>);
 
     return BoundString(
       dataContext: context.dataContext,
@@ -51,11 +54,13 @@ final optionTiles = CatalogItem(
 );
 ```
 
-Selections write to the local `DataModel`. Tapping a tile does not call the model again.
+Selections write to the local `DataModel`.
+Tapping a tile does not call the model again.
 
 ## Hold State in a Host Widget
 
-`OptionTiles` is controlled: it renders `selectedId` and reports taps through `onSelected`. The `DataModel` holds that state in the app. Nothing holds it in a story, so taps would do nothing.
+`OptionTiles` is controlled: it renders `selectedId` and reports taps through `onSelected`.
+The `DataModel` holds that state in the app. Nothing holds it in a story, so taps would do nothing.
 
 Add a stateful host:
 
@@ -93,7 +98,8 @@ class _OptionTilesHostState extends State<OptionTilesHost> {
 
 The host stands in for the `DataModel`, making selection testable in a [scenario](/testing/create-scenario#create-interaction-scenarios).
 
-Widgetbook rebuilds a story with a new key when an arg changes, so editing `initialSelectionId` resets the host. See [Stateful Widgets and Arg Updates](/args/overview#stateful-widgets-and-arg-updates).
+Widgetbook rebuilds a story with a new key when an arg changes, so editing `initialSelectionId` resets the host.
+See [Stateful Widgets and Arg Updates](/args/overview#stateful-widgets-and-arg-updates).
 
 ## Write the Story
 
@@ -125,24 +131,31 @@ final $Default = _Story(
 );
 ```
 
-`options` is not a primitive, so the generator produces `Arg<List<TileOption>>` and you supply it with `Arg.fixed`. For an editable control, write a [custom arg](/args/custom).
+`options` is not a primitive, so the generator produces `Arg<List<TileOption>>` and you supply it with `Arg.fixed`.
+For an editable control, write a [custom arg](/args/custom).
 
 ### Callbacks Are Not Args
 
-`onSelected` never appears in the story. Functions are not model-authored data, so they are neither args nor schema properties.
+`onSelected` never appears in the story.
+Functions are not model-authored data, so they are neither args nor schema properties.
 
-When the model should influence behavior, it emits data and the app maps it. A `variant` enum or `showsClearAction` boolean is model-authored. The callback it triggers is yours. See [Best Practices](/agentic/best-practices).
+When the model should influence behavior, it emits data and the app maps it.
+A `variant` enum or `showsClearAction` boolean is model-authored.
+The callback it triggers is yours.
+See [Best Practices](/agentic/best-practices).
 
 ## Derive the Schema from the Story
 
-No generator required. A `.stories.dart` file is a typed spec of the widget: every parameter, allowed enum value, default, and the states worth a scenario. Hand it to a coding agent and ask for the `dataSchema`.
+No generator required.
+A `.stories.dart` file is a typed spec of the widget: every parameter, allowed enum value, default, and the states worth a scenario.
+Hand it to a coding agent and ask for the `dataSchema`.
 
 | Widgetbook | `json_schema_builder` |
 | --- | --- |
 | `StringArg` | `S.string()` |
 | `IntArg` / `DoubleArg` | `S.integer()` / `S.number()` |
 | `BoolArg` | `S.boolean()` |
-| `EnumArg<T>(values: T.values)` | `S.string(enumValues: [...])` |
+| `EnumArg<T>(T.someValue, values: T.values)` | `S.string(enumValues: [...])` |
 | `Arg.fixed(List<T>)` | `S.list(items: S.object(...))` |
 | Non-nullable arg | Listed in `required` |
 | `NullableStringArg` and friends | Omitted from `required` |
@@ -176,10 +189,14 @@ final _optionTilesSchema = S.object(
 Two things an agent cannot infer from types:
 
 - **Descriptions are prompt text.** The model reads them to decide when to use the widget and what to put in it. `'Short display label, 1-3 words'` prevents overflow that no type signature could.
-- **Design constraints.** If the layout breaks past six tiles, the schema must say so. The Dart signature accepts any list length. Your design does not.
+- **Design constraints.** If the layout breaks past six tiles, the schema must say so.
+  The Dart signature accepts any list length.
+  Your design does not.
 
 <Warning>
-  Regeneration is the only thing keeping schema and widget aligned. Add a constructor parameter and no test fails, the model simply never emits it. Regenerate whenever a catalog widget's API changes.
+  Regeneration is the only thing keeping schema and widget aligned.
+  Add a constructor parameter and no test fails, the model simply never emits it.
+  Regenerate whenever a catalog widget's API changes.
 </Warning>
 
 ## Next

--- a/docs/genui/overview.mdx
+++ b/docs/genui/overview.mdx
@@ -1,0 +1,59 @@
+# GenUI
+
+In a generative UI app, the model emits a description of an interface assembled from a fixed set of approved widgets. That set is the **catalog**, and it is the model's entire vocabulary.
+
+Catalog quality caps generated UI quality. A catalog is a design system handed to a model.
+
+## Mapping
+
+A `CatalogItem` in the [Flutter GenUI SDK](https://github.com/flutter/genui) and a Widgetbook [Story](/stories/overview) describe the same widget from two directions.
+
+| Flutter GenUI SDK | Widgetbook |
+| --- | --- |
+| `CatalogItem.name` | Component in the navigation tree |
+| `dataSchema` | Typed [args](/args/overview) |
+| `widgetBuilder` | The widget the story renders |
+
+<Info>
+  Widgetbook has no GenUI-specific API. This section uses the same stories, args, scenarios, and modes as the rest of the docs.
+</Info>
+
+## Self-Healing Components
+
+Model-composed screens have no design review step. The catalog is the only place quality is enforced, so enforce it in a loop the agent can run without you.
+
+1. The agent writes the catalog widget, its [stories](/stories/overview), and a [scenario](/testing/overview) per schema edge.
+2. `flutter test` renders every scenario, runs assertions, evaluates [accessibility guidelines](/testing/accessibility), and writes a snapshot per scenario.
+3. Failures are concrete: which scenario, which assertion, which accessibility rule, which element.
+4. The agent reads the failures and fixes the widget.
+
+Repeat until green. The agent owns coverage across the schema's range, you own judgment on the result. See [Agentic Engineering](/agentic/overview).
+
+## Two Layers of Coverage
+
+Generated screens are not testable in the general case. The model composes them at runtime, so there is no fixed output to snapshot. Two layers cover it instead.
+
+| Layer | What it tests | Why it works |
+| --- | --- | --- |
+| [Catalog widgets](/genui/testing#scenarios-at-the-schemas-edges) | Every widget across its schema's range | The catalog is closed and each widget is deterministic given its data |
+| [Cached surfaces](/genui/testing#test-cached-a2ui-surfaces) | Real compositions the model produced | An A2UI payload is JSON, so a captured one replays identically |
+
+The first bounds what the model can emit. The second checks what it actually did.
+
+## Catalog Rules
+
+Catalog widgets are stricter than ordinary design system widgets, because a model picks them without judgment.
+
+- **Small and composable.** One layout primitive plus a few answer components, not one widget with fifteen optional parameters.
+- **Theme-aware.** No hardcoded colors or spacing. The model supplies data, never styling.
+- **Data in, data out.** Report selections into the surface's `DataModel`. Do not navigate, call an API, or own app state.
+- **Complete at every input.** The model will emit the longest label and largest list the schema permits.
+
+Behavior stays app-owned. The schema describes model-authored data; what happens on user action is yours.
+
+## Next
+
+- [Build Your Catalog](/genui/catalog)
+- [Test the Catalog](/genui/testing)
+- [Using Widgetbook as your GenUI catalog](https://www.widgetbook.io/blog/genui-catalog)
+- [From structured outputs to A2UI surfaces](https://medium.com/flutter-community/from-structured-outputs-to-a2ui-surfaces-migrating-to-flutter-genui-sdk-4f09aeacee80)

--- a/docs/genui/overview.mdx
+++ b/docs/genui/overview.mdx
@@ -1,8 +1,10 @@
 # GenUI
 
-In a generative UI app, the model emits a description of an interface assembled from a fixed set of approved widgets. That set is the **catalog**, and it is the model's entire vocabulary.
+In a generative UI app, the model emits a description of an interface assembled from a fixed set of approved widgets.
+That set is the **catalog**, and it is the model's entire vocabulary.
 
-Catalog quality caps generated UI quality. A catalog is a design system handed to a model.
+Catalog quality caps generated UI quality.
+A catalog is a design system handed to a model.
 
 ## Mapping
 
@@ -15,41 +17,51 @@ A `CatalogItem` in the [Flutter GenUI SDK](https://github.com/flutter/genui) and
 | `widgetBuilder` | The widget the story renders |
 
 <Info>
-  Widgetbook has no GenUI-specific API. This section uses the same stories, args, scenarios, and modes as the rest of the docs.
+  Widgetbook has no GenUI-specific API.
+  This section uses the same stories, args, scenarios, and modes as the rest of the docs.
 </Info>
 
 ## Self-Healing Components
 
-Model-composed screens have no design review step. The catalog is the only place quality is enforced, so enforce it in a loop the agent can run without you.
+Model-composed screens have no design review step.
+The catalog is the only place quality is enforced, so enforce it in a loop the agent can run without you.
 
 1. The agent writes the catalog widget, its [stories](/stories/overview), and a [scenario](/testing/overview) per schema edge.
 2. `flutter test` renders every scenario, runs assertions, evaluates [accessibility guidelines](/testing/accessibility), and writes a snapshot per scenario.
 3. Failures are concrete: which scenario, which assertion, which accessibility rule, which element.
 4. The agent reads the failures and fixes the widget.
 
-Repeat until green. The agent owns coverage across the schema's range, you own judgment on the result. See [Agentic Engineering](/agentic/overview).
+Repeat until green.
+The agent owns coverage across the schema's range, you own judgment on the result.
+See [Agentic Engineering](/agentic/overview).
 
 ## Two Layers of Coverage
 
-Generated screens are not testable in the general case. The model composes them at runtime, so there is no fixed output to snapshot. Two layers cover it instead.
+Generated screens are not testable in the general case.
+The model composes them at runtime, so there is no fixed output to snapshot.
+Two layers cover it instead.
 
 | Layer | What it tests | Why it works |
 | --- | --- | --- |
 | [Catalog widgets](/genui/testing#scenarios-at-the-schemas-edges) | Every widget across its schema's range | The catalog is closed and each widget is deterministic given its data |
 | [Cached surfaces](/genui/testing#test-cached-a2ui-surfaces) | Real compositions the model produced | An A2UI payload is JSON, so a captured one replays identically |
 
-The first bounds what the model can emit. The second checks what it actually did.
+The first bounds what the model can emit.
+The second checks what it actually did.
 
 ## Catalog Rules
 
 Catalog widgets are stricter than ordinary design system widgets, because a model picks them without judgment.
 
 - **Small and composable.** One layout primitive plus a few answer components, not one widget with fifteen optional parameters.
-- **Theme-aware.** No hardcoded colors or spacing. The model supplies data, never styling.
-- **Data in, data out.** Report selections into the surface's `DataModel`. Do not navigate, call an API, or own app state.
+- **Theme-aware.** No hardcoded colors or spacing.
+  The model supplies data, never styling.
+- **Data in, data out.** Report selections into the surface's `DataModel`.
+  Do not navigate, call an API, or own app state.
 - **Complete at every input.** The model will emit the longest label and largest list the schema permits.
 
-Behavior stays app-owned. The schema describes model-authored data; what happens on user action is yours.
+Behavior stays app-owned.
+The schema describes model-authored data; what happens on user action is yours.
 
 ## Next
 

--- a/docs/genui/testing.mdx
+++ b/docs/genui/testing.mdx
@@ -1,12 +1,15 @@
 # Test the Catalog, Not the Screen
 
-The same prompt produces a different screen on every run. There is no fixed output to snapshot and no meaningful diff between two runs.
+The same prompt produces a different screen on every run.
+There is no fixed output to snapshot and no meaningful diff between two runs.
 
-Test the parts instead. The catalog is closed, each widget is deterministic given its data, and the schema states which data is possible.
+Test the parts instead.
+The catalog is closed, each widget is deterministic given its data, and the schema states which data is possible.
 
 ## Self-Heal with `flutter test`
 
-Model-composed screens skip design review. The catalog is the only quality gate, so run it as a loop the agent closes on its own.
+Model-composed screens skip design review.
+The catalog is the only quality gate, so run it as a loop the agent closes on its own.
 
 ```bash
 flutter test
@@ -18,11 +21,17 @@ One command renders every scenario, runs its assertions, evaluates [accessibilit
 | --- | --- |
 | Assertion | Which scenario, which expectation, actual value |
 | Overflow | Which scenario overflowed and by how much |
-| Accessibility | Which element broke which rule |
 
-Each failure names a scenario, and each scenario names a schema edge. The agent fixes the widget, reruns, and repeats until green. No human in the loop until the snapshots are worth looking at.
+Each failure names a scenario, and each scenario names a schema edge.
+The agent fixes the widget, reruns, and repeats until green.
+No human in the loop until the snapshots are worth looking at.
 
-Ask for the scenarios in the same prompt as the widget. A catalog widget without scenarios has nothing to self-heal against. See [Agentic Engineering](/agentic/overview).
+Accessibility violations never fail the run.
+They are written into `build/.widgetbook/<Component>/<Story>/<Scenario>.json`, so the agent reads them from the metadata rather than the exit code.
+
+Ask for the scenarios in the same prompt as the widget.
+A catalog widget without scenarios has nothing to self-heal against.
+See [Agentic Engineering](/agentic/overview).
 
 ## Scenarios at the Schema's Edges
 
@@ -79,12 +88,14 @@ Checklist per property:
 | Optional | Present and absent |
 
 <Info>
-  A scenario you cannot write sensibly is a signal about the schema. If `Empty options` renders broken, require at least one option in the schema instead of covering the breakage in a test.
+  A scenario you cannot write sensibly is a signal about the schema.
+  If `Empty options` renders broken, require at least one option in the schema instead of covering the breakage in a test.
 </Info>
 
 ## Test the Binding
 
-A widget that renders correctly but never reports its selection leaves the `DataModel` empty and the app unable to advance. The [host widget](/genui/catalog#hold-state-in-a-host-widget) makes that path testable:
+A widget that renders correctly but never reports its selection leaves the `DataModel` empty and the app unable to advance.
+The [host widget](/genui/catalog#hold-state-in-a-host-widget) makes that path testable:
 
 ```dart title="widgetbook/lib/option_tiles.stories.dart"
 _Scenario(
@@ -105,7 +116,7 @@ _Scenario(
 ## Test Cached A2UI Surfaces
 
 <Card
-  icon="medium"
+  icon="medium fa-brands"
   title="From Structured Outputs to A2UI Surfaces: Migrating to Flutter GenUI SDK"
   href="https://medium.com/flutter-community/from-structured-outputs-to-a2ui-surfaces-migrating-to-flutter-genui-sdk-4f09aeacee80"
 >
@@ -113,9 +124,12 @@ _Scenario(
 The workflow below is his, and the article is the reference implementation for everything it replays.
 </Card>
 
-Catalog coverage bounds what the model can emit. It does not tell you whether a real composition holds up: the model may stack four widgets in a `Column` that overflows, or pick a framing meter where tiles were intended.
+Catalog coverage bounds what the model can emit.
+It does not tell you whether a real composition holds up: the model may stack four widgets in a `Column` that overflows, or pick a framing meter where tiles were intended.
 
-An A2UI surface is JSON. Once captured it is deterministic, so it replays identically every run. Cagatay caches the surfaces his app produced, brings them back into Widgetbook to test them there, and uploads the reviewed set again.
+An A2UI surface is JSON.
+Once captured it is deterministic, so it replays identically every run.
+Cagatay caches the surfaces his app produced, brings them back into Widgetbook to test them there, and uploads the reviewed set again.
 
 Round trip:
 
@@ -131,11 +145,11 @@ Replay through a host that takes a payload:
 class CachedSurface extends StatelessWidget {
   const CachedSurface({super.key, required this.payload});
 
-  final A2uiPayload payload;
+  final A2uiMessage payload;
 
   @override
   Widget build(BuildContext context) {
-    // Render the payload through the app's catalog.
+    // ...
   }
 }
 ```
@@ -159,15 +173,18 @@ final $Surfaces = _Story(
 );
 ```
 
-Every payload the model produced in production becomes a permanent regression test. Change a catalog widget and you see which real screens moved.
+Every payload the model produced in production becomes a permanent regression test.
+Change a catalog widget and you see which real screens moved.
 
 <Info>
-  Capture payloads that broke as well as payloads that worked. A composition that overflowed once is the highest-value fixture you have.
+  Capture payloads that broke as well as payloads that worked.
+  A composition that overflowed once is the highest-value fixture you have.
 </Info>
 
 ## Cover Locale and Text Scale
 
-The model authors strings at runtime, so labels cannot be reviewed ahead of time the way a localization file can. A model asked for Finnish produces Finnish of whatever length it likes.
+The model authors strings at runtime, so labels cannot be reviewed ahead of time the way a localization file can.
+A model asked for Finnish produces Finnish of whatever length it likes.
 
 Cross every catalog scenario with a [global scenario definition](/testing/create-scenario#define-global-scenario-definitions) instead of duplicating cases:
 
@@ -191,7 +208,8 @@ Same applies to [locale](/addons/locale-addon) and [viewport](/addons/viewport-a
 
 [Publish the build](/sharing/publish-to-cloud) and Widgetbook Cloud diffs every snapshot against the base branch.
 
-This catches changes that quietly narrow what the model can safely emit: a padding tweak that overflows six tiles, a font change that clips the longest label. The widget still compiles and the schema still permits the input.
+This catches changes that quietly narrow what the model can safely emit: a padding tweak that overflows six tiles, a font change that clips the longest label.
+The widget still compiles and the schema still permits the input.
 
 [Accessibility regressions](/cloud/accessibility/regressions) compare the semantics tree against the base build.
 

--- a/docs/genui/testing.mdx
+++ b/docs/genui/testing.mdx
@@ -105,11 +105,12 @@ _Scenario(
 ## Test Cached A2UI Surfaces
 
 <Card
-  icon="medium fa-brands"
+  icon="medium"
   title="From Structured Outputs to A2UI Surfaces: Migrating to Flutter GenUI SDK"
   href="https://medium.com/flutter-community/from-structured-outputs-to-a2ui-surfaces-migrating-to-flutter-genui-sdk-4f09aeacee80"
 >
-  Cagatay Ulusoy builds the *Finnish It* language-learning app on the Flutter GenUI SDK: catalogs, surfaces, `DataModel` binding, and the streaming transport. The workflow below is his, and the article is the reference implementation for everything it replays.
+[Cagatay Ulusoy](https://x.com/ulusoyapps) builds the *Finnish It* language-learning app on the Flutter GenUI SDK: catalogs, surfaces, `DataModel` binding, and the streaming transport.
+The workflow below is his, and the article is the reference implementation for everything it replays.
 </Card>
 
 Catalog coverage bounds what the model can emit. It does not tell you whether a real composition holds up: the model may stack four widgets in a `Column` that overflows, or pick a framing meter where tiles were intended.

--- a/docs/genui/testing.mdx
+++ b/docs/genui/testing.mdx
@@ -1,0 +1,200 @@
+# Test the Catalog, Not the Screen
+
+The same prompt produces a different screen on every run. There is no fixed output to snapshot and no meaningful diff between two runs.
+
+Test the parts instead. The catalog is closed, each widget is deterministic given its data, and the schema states which data is possible.
+
+## Self-Heal with `flutter test`
+
+Model-composed screens skip design review. The catalog is the only quality gate, so run it as a loop the agent closes on its own.
+
+```bash
+flutter test
+```
+
+One command renders every scenario, runs its assertions, evaluates [accessibility guidelines](/testing/accessibility), and writes a snapshot per scenario into `build/.widgetbook`.
+
+| Failure | What the agent reads |
+| --- | --- |
+| Assertion | Which scenario, which expectation, actual value |
+| Overflow | Which scenario overflowed and by how much |
+| Accessibility | Which element broke which rule |
+
+Each failure names a scenario, and each scenario names a schema edge. The agent fixes the widget, reruns, and repeats until green. No human in the loop until the snapshots are worth looking at.
+
+Ask for the scenarios in the same prompt as the widget. A catalog widget without scenarios has nothing to self-heal against. See [Agentic Engineering](/agentic/overview).
+
+## Scenarios at the Schema's Edges
+
+Read each schema property and write scenarios for its extremes.
+
+```dart title="widgetbook/lib/option_tiles.stories.dart"
+final $Default = _Story(
+  args: _Args(
+    question: StringArg('Which season?'),
+    options: Arg.fixed(_seasons),
+    initialSelectionId: NullableStringArg(null),
+  ),
+  scenarios: [
+    _Scenario(
+      name: 'Two options',
+      args: _Args.fixed(
+        question: 'Indoors or outdoors?',
+        options: _twoOptions,
+      ),
+    ),
+    _Scenario(
+      name: 'Maximum options',
+      args: _Args.fixed(
+        question: 'Which season?',
+        options: _sixOptions,
+      ),
+    ),
+    _Scenario(
+      name: 'Long localized label',
+      args: _Args.fixed(
+        question: 'Missä vuodenaikana kuva on otettu?',
+        options: _longFinnishLabels,
+      ),
+    ),
+    _Scenario(
+      name: 'Preselected',
+      args: _Args.fixed(
+        question: 'Which season?',
+        options: _seasons,
+        initialSelectionId: 'winter',
+      ),
+    ),
+  ],
+);
+```
+
+Checklist per property:
+
+| Property type | Scenarios |
+| --- | --- |
+| String | Longest the description allows, in your longest-running locale |
+| List | Smallest and largest count the schema permits |
+| Enum | Every value |
+| Optional | Present and absent |
+
+<Info>
+  A scenario you cannot write sensibly is a signal about the schema. If `Empty options` renders broken, require at least one option in the schema instead of covering the breakage in a test.
+</Info>
+
+## Test the Binding
+
+A widget that renders correctly but never reports its selection leaves the `DataModel` empty and the app unable to advance. The [host widget](/genui/catalog#hold-state-in-a-host-widget) makes that path testable:
+
+```dart title="widgetbook/lib/option_tiles.stories.dart"
+_Scenario(
+  name: 'Selects a tile',
+  args: _Args.fixed(
+    question: 'Which season?',
+    options: _seasons,
+  ),
+  run: (tester, args) async {
+    await tester.tap(find.text('Winter'));
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('Winter, selected'), findsOneWidget);
+  },
+),
+```
+
+## Test Cached A2UI Surfaces
+
+<Card
+  icon="medium fa-brands"
+  title="From Structured Outputs to A2UI Surfaces: Migrating to Flutter GenUI SDK"
+  href="https://medium.com/flutter-community/from-structured-outputs-to-a2ui-surfaces-migrating-to-flutter-genui-sdk-4f09aeacee80"
+>
+  Cagatay Ulusoy builds the *Finnish It* language-learning app on the Flutter GenUI SDK: catalogs, surfaces, `DataModel` binding, and the streaming transport. The workflow below is his, and the article is the reference implementation for everything it replays.
+</Card>
+
+Catalog coverage bounds what the model can emit. It does not tell you whether a real composition holds up: the model may stack four widgets in a `Column` that overflows, or pick a framing meter where tiles were intended.
+
+An A2UI surface is JSON. Once captured it is deterministic, so it replays identically every run. Cagatay caches the surfaces his app produced, brings them back into Widgetbook to test them there, and uploads the reviewed set again.
+
+Round trip:
+
+1. Persist the A2UI payloads the app receives, for example in Firestore.
+2. Pull the cached payloads into your Widgetbook project.
+3. Replay each one through the same catalog the app uses.
+4. `flutter test` snapshots each surface, so real compositions get the same [self-heal loop](/genui/testing#self-heal-with-flutter-test) and Cloud diff as catalog widgets.
+5. Upload the reviewed payload set back to Firestore, so the app and the test suite share one source.
+
+Replay through a host that takes a payload:
+
+```dart title="widgetbook/lib/cached_surface.dart"
+class CachedSurface extends StatelessWidget {
+  const CachedSurface({super.key, required this.payload});
+
+  final A2uiPayload payload;
+
+  @override
+  Widget build(BuildContext context) {
+    // Render the payload through the app's catalog.
+  }
+}
+```
+
+One scenario per cached payload:
+
+```dart title="widgetbook/lib/cached_surface.stories.dart"
+const meta = Meta(CachedSurface.new);
+
+final $Surfaces = _Story(
+  args: _Args(
+    payload: Arg.fixed(cachedSurfaces.first),
+  ),
+  scenarios: [
+    for (final payload in cachedSurfaces)
+      _Scenario(
+        name: payload.id,
+        args: _Args.fixed(payload: payload),
+      ),
+  ],
+);
+```
+
+Every payload the model produced in production becomes a permanent regression test. Change a catalog widget and you see which real screens moved.
+
+<Info>
+  Capture payloads that broke as well as payloads that worked. A composition that overflowed once is the highest-value fixture you have.
+</Info>
+
+## Cover Locale and Text Scale
+
+The model authors strings at runtime, so labels cannot be reviewed ahead of time the way a localization file can. A model asked for Finnish produces Finnish of whatever length it likes.
+
+Cross every catalog scenario with a [global scenario definition](/testing/create-scenario#define-global-scenario-definitions) instead of duplicating cases:
+
+```dart title="widgetbook/lib/widgetbook.config.dart"
+final config = Config(
+  // ...
+  scenarioConfig: ScenarioConfig(
+    definitions: [
+      ScenarioDefinition(
+        name: 'Large Text',
+        modes: [TextScaleMode(2.0)],
+      ),
+    ],
+  ),
+);
+```
+
+Same applies to [locale](/addons/locale-addon) and [viewport](/addons/viewport-addon).
+
+## Catch Regressions in CI
+
+[Publish the build](/sharing/publish-to-cloud) and Widgetbook Cloud diffs every snapshot against the base branch.
+
+This catches changes that quietly narrow what the model can safely emit: a padding tweak that overflows six tiles, a font change that clips the longest label. The widget still compiles and the schema still permits the input.
+
+[Accessibility regressions](/cloud/accessibility/regressions) compare the semantics tree against the base build.
+
+## Next
+
+- [Testing Overview](/testing/overview)
+- [Agentic Engineering](/agentic/overview)

--- a/docs/genui/testing.mdx
+++ b/docs/genui/testing.mdx
@@ -206,7 +206,7 @@ Same applies to [locale](/addons/locale-addon) and [viewport](/addons/viewport-a
 
 ## Catch Regressions in CI
 
-[Publish the build](/sharing/publish-to-cloud) and Widgetbook Cloud diffs every snapshot against the base branch.
+[Publish the build](/sharing/hosting) and Widgetbook Cloud diffs every snapshot against the base branch.
 
 This catches changes that quietly narrow what the model can safely emit: a padding tweak that overflows six tiles, a font change that clips the longest label.
 The widget still compiles and the schema still permits the input.

--- a/docs/genui/testing.mdx
+++ b/docs/genui/testing.mdx
@@ -116,7 +116,7 @@ _Scenario(
 ## Test Cached A2UI Surfaces
 
 <Card
-  icon="medium fa-brands"
+  icon="newspaper"
   title="From Structured Outputs to A2UI Surfaces: Migrating to Flutter GenUI SDK"
   href="https://medium.com/flutter-community/from-structured-outputs-to-a2ui-surfaces-migrating-to-flutter-genui-sdk-4f09aeacee80"
 >

--- a/docs/testing/overview.mdx
+++ b/docs/testing/overview.mdx
@@ -18,6 +18,17 @@ Scenarios unify this by letting you model a state once and reuse it for:
 
 This reduces duplicate setup and keeps implementation and validation aligned.
 
+## Run by Humans and Agents
+
+Scenarios run through `flutter test`, and the same command serves both audiences.
+
+- **Developers** run it locally before pushing and inspect the snapshots in `build/.widgetbook`.
+- **Coding agents** run it as a self-correction loop. Every failure names the scenario, the assertion, and any accessibility violation, so an agent can fix the widget and rerun without a human in the middle.
+
+Nothing in the setup differs. Writing scenarios alongside a widget turns "the agent says it works" into a snapshot you can look at.
+
+See [Agentic Engineering](/agentic/overview) for the workflow.
+
 ## Better Control for Screenshot-Based Testing
 
 Scenarios improve control over screenshot testing in Widgetbook Cloud. Developers can define interactions before capture by using the scenario `run` method.

--- a/docs/testing/overview.mdx
+++ b/docs/testing/overview.mdx
@@ -18,16 +18,8 @@ Scenarios unify this by letting you model a state once and reuse it for:
 
 This reduces duplicate setup and keeps implementation and validation aligned.
 
-## Run by Humans and Agents
-
-Scenarios run through `flutter test`, and the same command serves both audiences.
-
-- **Developers** run it locally before pushing and inspect the snapshots in `build/.widgetbook`.
-- **Coding agents** run it as a self-correction loop. Every failure names the scenario, the assertion, and any accessibility violation, so an agent can fix the widget and rerun without a human in the middle.
-
-Nothing in the setup differs. Writing scenarios alongside a widget turns "the agent says it works" into a snapshot you can look at.
-
-See [Agentic Engineering](/agentic/overview) for the workflow.
+Developers and coding agents run the same scenarios through the same command.
+See [Who Runs Scenarios](/testing/run-scenarios#who-runs-scenarios).
 
 ## Better Control for Screenshot-Based Testing
 

--- a/docs/testing/overview.mdx
+++ b/docs/testing/overview.mdx
@@ -1,14 +1,18 @@
 # Overview
 
-Scenarios connect development and testing in one workflow. They let teams reuse the same setup for [Stories](/stories/overview), [Args](/args/overview), and automated validation while keeping behavior reproducible.
+Scenarios connect development and testing in one workflow.
+They let teams reuse the same setup for [Stories](/stories/overview), [Args](/args/overview), and automated validation while keeping behavior reproducible.
 
-A `Scenario` defines a fixed, testable state of a widget for visual and automated testing. It combines inputs like Args, and optional interactions into one reproducible setup.
+A `Scenario` defines a fixed, testable state of a widget for visual and automated testing.
+It combines inputs like Args, and optional interactions into one reproducible setup.
 
-Under the hood, Widgetbook uses Flutter's `flutter_test` runtime to execute scenarios. This keeps the workflow familiar and lets teams reuse existing widget-testing knowledge.
+Under the hood, Widgetbook uses Flutter's `flutter_test` runtime to execute scenarios.
+This keeps the workflow familiar and lets teams reuse existing widget-testing knowledge.
 
 ## One Setup for Catalogs and Tests
 
-Teams often use Widgetbook to build components and use widget or golden tests to catch regressions. Across these workflows, the key step is the same: define a component state with fixed parameters so the widget renders in a predictable way.
+Teams often use Widgetbook to build components and use widget or golden tests to catch regressions.
+Across these workflows, the key step is the same: define a component state with fixed parameters so the widget renders in a predictable way.
 
 Scenarios unify this by letting you model a state once and reuse it for:
 
@@ -23,7 +27,8 @@ See [Who Runs Scenarios](/testing/run-scenarios#who-runs-scenarios).
 
 ## Better Control for Screenshot-Based Testing
 
-Scenarios improve control over screenshot testing in Widgetbook Cloud. Developers can define interactions before capture by using the scenario `run` method.
+Scenarios improve control over screenshot testing in Widgetbook Cloud.
+Developers can define interactions before capture by using the scenario `run` method.
 
 The `run` method exposes a `WidgetTester`, so developers can use standard `flutter_test` APIs for interactions and assertions.
 
@@ -34,6 +39,7 @@ Screenshots are always captured after the `run` method has completed.
 
 ## Transparent and Reproducible in the UI
 
-Each scenario is visible in the UI for detailed inspection and debugging. To keep scenarios deterministic, [Modes](/addons/modes) and [Args](/args/overview) are locked to fixed test inputs.
+Each scenario is visible in the UI for detailed inspection and debugging.
+To keep scenarios deterministic, [Modes](/addons/modes) and [Args](/args/overview) are locked to fixed test inputs.
 
 This makes scenario behavior stable across local development, collaboration, and cloud-based test execution.

--- a/docs/testing/run-scenarios.mdx
+++ b/docs/testing/run-scenarios.mdx
@@ -38,7 +38,7 @@ Both people and coding agents run the same `flutter test` command against the sa
 | Runner | Reads |
 | --- | --- |
 | Developer | Snapshots in `build/.widgetbook`, failures in the console |
-| Coding agent | The same failures, parsed as text: scenario name, assertion, overflow, accessibility violation |
+| Coding agent | The same failures, parsed as text: scenario name, assertion, overflow. Accessibility violations do not fail the run, so it reads those from the scenario metadata |
 
 Every failure is anchored to a named scenario, so it points at one widget state instead of a screen. That makes the scenario set a feedback loop an agent can close on its own, then hand you the snapshots to judge.
 

--- a/docs/testing/run-scenarios.mdx
+++ b/docs/testing/run-scenarios.mdx
@@ -31,6 +31,19 @@ Widgetbook testing is built on top of Flutter's `flutter_test` package. Scenario
   </Step>
 </Steps>
 
+## Who Runs Scenarios
+
+Both people and coding agents run the same `flutter test` command against the same setup.
+
+| Runner | Reads |
+| --- | --- |
+| Developer | Snapshots in `build/.widgetbook`, failures in the console |
+| Coding agent | The same failures, parsed as text: scenario name, assertion, overflow, accessibility violation |
+
+Every failure is anchored to a named scenario, so it points at one widget state instead of a screen. That makes the scenario set a feedback loop an agent can close on its own, then hand you the snapshots to judge.
+
+See [Agentic Engineering](/agentic/overview) for the workflow, and [GenUI](/genui/testing#self-heal-with-flutter-test) for using it as the quality gate on a model's widget catalog.
+
 ## What Happens During Execution
 
 `testWidgetbook` first expands the scenarios of every story: local scenarios


### PR DESCRIPTION
Fifth of nine. **Stacked on #2005.** Two new sections, for two audiences the docs didn't address.

## Agentic Engineering

For teams whose Flutter UI is written by a coding agent. Framed as **prevent → self-correct → review**, with Widgetbook's role in each:

- **Prevent** — stories as the example set the agent reads before generating
- **Self-correct** — `flutter test` as a loop the agent closes on its own: scenario failures, Figma diffs, accessibility rules
- **Review** — judging the story set, not just the diff

`Best Practices` covers the concrete habits: generator watch mode, priming with existing stories, preferring widget-derived args, letting scenarios do the verification.

## GenUI

For teams where a model composes screens at runtime from an approved widget set. The observation is that a `CatalogItem` and a Story describe the same widget — `dataSchema` maps to typed args, `widgetBuilder` to what the story renders — so one definition serves both.

- **Build Your Catalog** — splitting the widget from its binding, holding state in a host widget, deriving the schema from the story
- **Test the Catalog** — you can't snapshot a generated screen, but you *can* snapshot the catalog, which bounds every screen the model can produce. Covers schema-edge scenarios, binding tests, and replaying cached A2UI payloads as permanent regression tests.

## Also in here

The Testing cross-references, since `flutter test` is what closes the loop in both workflows: a "Run by Humans and Agents" section in `testing/overview`, and "Who Runs Scenarios" in `run-scenarios`.

## Verification

- 117 nav hrefs — all resolve
- 0 duplicates within a tab, 0 orphaned pages, 0 broken internal links
- `#self-heal-with-flutter-test` anchor confirmed against the heading in `genui/testing.mdx`