### PR TITLE
docs: promote Testing to a top-level section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -221,14 +221,20 @@
         {
           "title": "Mock Widgets & Screens",
           "href": "/stories/mocking"
+        }
+      ]
+    },
+    {
+      "tab": "docs",
+      "group": "Testing",
+      "pages": [
+        {
+          "title": "Overview",
+          "href": "/testing/overview"
         },
         {
-          "group": "Testing",
+          "group": "Scenarios",
           "pages": [
-            {
-              "title": "Overview",
-              "href": "/testing/overview"
-            },
             {
               "title": "Default Scenarios",
               "href": "/testing/default-scenario"
@@ -240,20 +246,20 @@
             {
               "title": "Run Scenarios",
               "href": "/testing/run-scenarios"
-            },
-            {
-              "title": "Layout Constraining",
-              "href": "/testing/layout-constraining"
-            },
-            {
-              "title": "Accessibility Guidelines",
-              "href": "/testing/accessibility"
-            },
-            {
-              "title": "Visual Tests",
-              "href": "/testing/visual-tests"
             }
           ]
+        },
+        {
+          "title": "Layout Constraining",
+          "href": "/testing/layout-constraining"
+        },
+        {
+          "title": "Accessibility Guidelines",
+          "href": "/testing/accessibility"
+        },
+        {
+          "title": "Visual Tests",
+          "href": "/testing/visual-tests"
         }
       ]
     },

--- a/docs/testing/run-scenarios.mdx
+++ b/docs/testing/run-scenarios.mdx
@@ -2,7 +2,8 @@
 
 This page explains how scenarios are executed and which snapshot artifacts are created during tests.
 
-Widgetbook testing is built on top of Flutter's `flutter_test` package. Scenario execution runs in the same widget test environment you already use for regular Flutter tests.
+Widgetbook testing is built on top of Flutter's `flutter_test` package.
+Scenario execution runs in the same widget test environment you already use for regular Flutter tests.
 
 ## Setup
 
@@ -40,7 +41,8 @@ Both people and coding agents run the same `flutter test` command against the sa
 | Developer | Snapshots in `build/.widgetbook`, failures in the console |
 | Coding agent | The same failures, parsed as text: scenario name, assertion, overflow. Accessibility violations do not fail the run, so it reads those from the scenario metadata |
 
-Every failure is anchored to a named scenario, so it points at one widget state instead of a screen. That makes the scenario set a feedback loop an agent can close on its own, then hand you the snapshots to judge.
+Every failure is anchored to a named scenario, so it points at one widget state instead of a screen.
+That makes the scenario set a feedback loop an agent can close on its own, then hand you the snapshots to judge.
 
 See [Agentic Engineering](/agentic/overview) for the workflow, and [GenUI](/genui/testing#self-heal-with-flutter-test) for using it as the quality gate on a model's widget catalog.
 
@@ -61,16 +63,20 @@ For each scenario, the Widgetbook test runtime:
 - captures semantics data for accessibility inspection
 - evaluates accessibility guidelines and records any violations
 
-Because this flow uses `flutter_test`, your scenario `run` callback receives a `WidgetTester`. You can use familiar test APIs such as `tap`, `pump`, `pumpAndSettle`, and `expect` directly inside `run`.
+Because this flow uses `flutter_test`, your scenario `run` callback receives a `WidgetTester`.
+You can use familiar test APIs such as `tap`, `pump`, `pumpAndSettle`, and `expect` directly inside `run`.
 
 See [Creating Scenarios](/testing/create-scenario) for concrete `run` examples.
 
 ## Set Up and Tear Down Hooks
 
-`Config.scenarioConfig` accepts optional `setUp` and `tearDown` callbacks that run around every scenario. Both receive the active `WidgetTester` and the current `Scenario`, so they can pump frames, interact with the widget tree, or branch on scenario metadata.
+`Config.scenarioConfig` accepts optional `setUp` and `tearDown` callbacks that run around every scenario.
+Both receive the active `WidgetTester` and the current `Scenario`, so they can pump frames, interact with the widget tree, or branch on scenario metadata.
 
-- `setUp` runs after the scenario has been pumped but before its `run` callback executes. Use it to seed shared state, prime caches, or stub dependencies.
-- `tearDown` runs after the screenshot and semantics data have been written. Use it to reset state mutated during the scenario.
+- `setUp` runs after the scenario has been pumped but before its `run` callback executes.
+  Use it to seed shared state, prime caches, or stub dependencies.
+- `tearDown` runs after the screenshot and semantics data have been written.
+  Use it to reset state mutated during the scenario.
 
 ```dart
 import 'package:widgetbook/widgetbook.dart';
@@ -94,9 +100,11 @@ The hooks fire for every scenario across every component and story when run via 
 
 ## Wrapping Scenario Execution
 
-`Config.scenarioConfig` also accepts an optional `wrapper` callback that wraps the *entire* execution of every scenario: pumping the widget, `setUp`, the scenario's `run` callback, the snapshot capture, and `tearDown`. It receives the active `WidgetTester`, the current `Scenario`, and a `body` callback that performs all of the above; it must await `body` exactly once.
+`Config.scenarioConfig` also accepts an optional `wrapper` callback that wraps the *entire* execution of every scenario: pumping the widget, `setUp`, the scenario's `run` callback, the snapshot capture, and `tearDown`.
+It receives the active `WidgetTester`, the current `Scenario`, and a `body` callback that performs all of the above; it must await `body` exactly once.
 
-Unlike `setUp`, which runs after the scenario's widget has already been pumped, the `wrapper` is on the call stack *before* the first frame is built. This makes it the right place for `Zone`-scoped configuration that must be visible inside your widgets' `build` methods, such as faking time with [`package:clock`](https://pub.dev/packages/clock), overriding `HttpOverrides`, or setting `Intl.defaultLocale`.
+Unlike `setUp`, which runs after the scenario's widget has already been pumped, the `wrapper` is on the call stack *before* the first frame is built.
+This makes it the right place for `Zone`-scoped configuration that must be visible inside your widgets' `build` methods, such as faking time with [`package:clock`](https://pub.dev/packages/clock), overriding `HttpOverrides`, or setting `Intl.defaultLocale`.
 
 For example, to render every scenario at a fixed point in time (so widgets calling `clock.now()` produce deterministic snapshots):
 
@@ -115,12 +123,15 @@ final config = Config(
 );
 ```
 
-Note that wrapping `testWidgetbook(config)` itself in `withClock` does **not** work: the test framework executes each test body in its own `Zone`, which is not a child of the `Zone` that declared the tests. The `wrapper` hook exists precisely to re-apply your `Zone` setup inside each test body. For the same reason, addons cannot fake `clock.now()`, since they inject widgets into the tree, while `package:clock` reads from the call stack.
+Note that wrapping `testWidgetbook(config)` itself in `withClock` does **not** work: the test framework executes each test body in its own `Zone`, which is not a child of the `Zone` that declared the tests.
+The `wrapper` hook exists precisely to re-apply your `Zone` setup inside each test body.
+For the same reason, addons cannot fake `clock.now()`, since they inject widgets into the tree, while `package:clock` reads from the call stack.
 
 ## Excluding Stories and Scenarios from Testing
 
 Some stories cannot render under `flutter test`, for example widgets backed by
-a native plugin (video, PDF) or ones that must load a real network resource. You
+a native plugin (video, PDF) or ones that must load a real network resource.
+You
 can keep them **browsable in the Widgetbook app** while skipping them during
 testing by setting `excludeFromTests`.
 
@@ -153,7 +164,8 @@ still appears in the running Widgetbook app.
 <Info>
   Prefer mocking the missing dependency (see [Wrapping Scenario
   Execution](#wrapping-scenario-execution) for `HttpOverrides` and plugin fakes)
-  so you keep visual-regression coverage. Reach for `excludeFromTests` only when
+  so you keep visual-regression coverage.
+  Reach for `excludeFromTests` only when
   a scenario genuinely cannot render in a headless test.
 </Info>
 
@@ -168,10 +180,12 @@ Each scenario produces:
 - a PNG snapshot image
 - a JSON metadata file
 
-For example, a `Loading` scenario crossed with a `Dark Mode` definition is written as `build/.widgetbook/Button/Default/Loading • Dark Mode.png`. The metadata includes scenario details, image size, pixel ratio, semantics tree data, and accessibility guideline violations.
+For example, a `Loading` scenario crossed with a `Dark Mode` definition is written as `build/.widgetbook/Button/Default/Loading • Dark Mode.png`.
+The metadata includes scenario details, image size, pixel ratio, semantics tree data, and accessibility guideline violations.
 
 If text in these snapshots renders as solid black rectangles, a font family is not
-resolving in the test environment. See [Fonts](/sharing/fonts) for the cause and
+resolving in the test environment.
+See [Fonts](/sharing/fonts) for the cause and
 the fix.
 
 ## Accessibility Guideline Violations
@@ -180,6 +194,7 @@ For every scenario, `testWidgetbook` evaluates the guidelines of `Config.accessi
 
 See [Accessibility Guidelines](/testing/accessibility) for the default set, for configuring the evaluated guidelines, and for writing your own.
 
-> The `violations` field is new. Builds captured by older Widgetbook versions
+> The `violations` field is new.
+> Builds captured by older Widgetbook versions
 > omit it; consumers should treat a missing `violations` field as "not
 > evaluated" rather than "no violations".

--- a/docs/testing/run-scenarios.mdx
+++ b/docs/testing/run-scenarios.mdx
@@ -50,7 +50,7 @@ See [Agentic Engineering](/agentic/overview) for the workflow, and [GenUI](/genu
 are crossed with the global `ScenarioDefinition`s from your config according
 to each definition's `strategy` (see
 [How Global Scenario Definitions Are Applied](/testing/create-scenario#how-global-scenario-definitions-are-applied)).
-Crossed scenarios execute exactly like local ones — including their `run` callback.
+Crossed scenarios execute exactly like local ones, including their `run` callback.
 
 For each scenario, the Widgetbook test runtime:
 
@@ -94,9 +94,9 @@ The hooks fire for every scenario across every component and story when run via 
 
 ## Wrapping Scenario Execution
 
-`Config.scenarioConfig` also accepts an optional `wrapper` callback that wraps the *entire* execution of every scenario — pumping the widget, `setUp`, the scenario's `run` callback, the snapshot capture, and `tearDown`. It receives the active `WidgetTester`, the current `Scenario`, and a `body` callback that performs all of the above; it must await `body` exactly once.
+`Config.scenarioConfig` also accepts an optional `wrapper` callback that wraps the *entire* execution of every scenario: pumping the widget, `setUp`, the scenario's `run` callback, the snapshot capture, and `tearDown`. It receives the active `WidgetTester`, the current `Scenario`, and a `body` callback that performs all of the above; it must await `body` exactly once.
 
-Unlike `setUp`, which runs after the scenario's widget has already been pumped, the `wrapper` is on the call stack *before* the first frame is built. This makes it the right place for `Zone`-scoped configuration that must be visible inside your widgets' `build` methods — such as faking time with [`package:clock`](https://pub.dev/packages/clock), overriding `HttpOverrides`, or setting `Intl.defaultLocale`.
+Unlike `setUp`, which runs after the scenario's widget has already been pumped, the `wrapper` is on the call stack *before* the first frame is built. This makes it the right place for `Zone`-scoped configuration that must be visible inside your widgets' `build` methods, such as faking time with [`package:clock`](https://pub.dev/packages/clock), overriding `HttpOverrides`, or setting `Intl.defaultLocale`.
 
 For example, to render every scenario at a fixed point in time (so widgets calling `clock.now()` produce deterministic snapshots):
 
@@ -115,11 +115,11 @@ final config = Config(
 );
 ```
 
-Note that wrapping `testWidgetbook(config)` itself in `withClock` does **not** work: the test framework executes each test body in its own `Zone`, which is not a child of the `Zone` that declared the tests. The `wrapper` hook exists precisely to re-apply your `Zone` setup inside each test body. For the same reason, addons cannot fake `clock.now()` — they inject widgets into the tree, while `package:clock` reads from the call stack.
+Note that wrapping `testWidgetbook(config)` itself in `withClock` does **not** work: the test framework executes each test body in its own `Zone`, which is not a child of the `Zone` that declared the tests. The `wrapper` hook exists precisely to re-apply your `Zone` setup inside each test body. For the same reason, addons cannot fake `clock.now()`, since they inject widgets into the tree, while `package:clock` reads from the call stack.
 
 ## Excluding Stories and Scenarios from Testing
 
-Some stories cannot render under `flutter test` — for example widgets backed by
+Some stories cannot render under `flutter test`, for example widgets backed by
 a native plugin (video, PDF) or ones that must load a real network resource. You
 can keep them **browsable in the Widgetbook app** while skipping them during
 testing by setting `excludeFromTests`.

--- a/docs/testing/visual-tests.mdx
+++ b/docs/testing/visual-tests.mdx
@@ -18,7 +18,7 @@ Visual tests are valuable for a number of reasons:
 
 ### Challenges with Visual Tests for Flutter Developers
 
-While visual tests provide significant advantages, they also come with certain challenges—particularly for Flutter developers.
+While visual tests provide significant advantages, they also come with certain challenges, particularly for Flutter developers.
 
 1. **Platform-Specific Rendering**: Flutter is a cross-platform framework, meaning the same codebase is designed to run on multiple platforms (iOS, Android, web, desktop). Visual tests can become problematic when UI components render slightly differently on different platforms, leading to false positives where the tests fail even though the visual changes are minor or expected.
 

--- a/docs/testing/visual-tests.mdx
+++ b/docs/testing/visual-tests.mdx
@@ -1,49 +1,71 @@
 # What are Visual Tests?
 
-Visual tests, sometimes called golden tests in the Flutter ecosystem, are a specialized form of testing aimed at ensuring that visual components of an application do not inadvertently change during code modifications. A visual test captures a baseline image of the correct visual state of a UI at a certain point in time.
+Visual tests, sometimes called golden tests in the Flutter ecosystem, are a specialized form of testing aimed at ensuring that visual components of an application do not inadvertently change during code modifications.
+A visual test captures a baseline image of the correct visual state of a UI at a certain point in time.
 
-The basic premise is simple: you take a screenshot of a UI component (such as a widget in Flutter), and then any subsequent change to the UI is compared to this baseline image. If the rendered UI differs from the baseline, the test fails, signaling a potential unintended visual change. This makes visual tests an essential part of maintaining UI integrity as applications scale and undergo continuous updates.
+The basic premise is simple: you take a screenshot of a UI component (such as a widget in Flutter), and then any subsequent change to the UI is compared to this baseline image.
+If the rendered UI differs from the baseline, the test fails, signaling a potential unintended visual change.
+This makes visual tests an essential part of maintaining UI integrity as applications scale and undergo continuous updates.
 
 ### Why Are Visual Tests Useful?
 
 Visual tests are valuable for a number of reasons:
 
-1. **Detecting Visual Regressions Early**: By comparing UI screenshots after each change, visual tests catch unintentional changes in the visual output early in the development process. This is especially useful in scenarios where UI changes might go unnoticed during regular testing.
+1. **Detecting Visual Regressions Early**: By comparing UI screenshots after each change, visual tests catch unintentional changes in the visual output early in the development process.
+   This is especially useful in scenarios where UI changes might go unnoticed during regular testing.
 
-2. **Automated Visual Validation**: Instead of relying on manual visual inspection, visual tests automate the process of validating the UI. This saves time, minimizes human error, and ensures consistent results.
+2. **Automated Visual Validation**: Instead of relying on manual visual inspection, visual tests automate the process of validating the UI.
+   This saves time, minimizes human error, and ensures consistent results.
 
 3. **Maintaining Design Consistency**: For applications that need to follow strict design guidelines or branding requirements, visual tests help ensure that any changes don't compromise these standards.
 
-4. **Improved Collaboration**: Visual tests can serve as a shared visual standard across teams. Designers, developers, and QA teams can collaborate more effectively by using baseline images to track intended vs. unintended UI changes.
+4. **Improved Collaboration**: Visual tests can serve as a shared visual standard across teams.
+   Designers, developers, and QA teams can collaborate more effectively by using baseline images to track intended vs. unintended UI changes.
 
 ### Challenges with Visual Tests for Flutter Developers
 
 While visual tests provide significant advantages, they also come with certain challenges, particularly for Flutter developers.
 
-1. **Platform-Specific Rendering**: Flutter is a cross-platform framework, meaning the same codebase is designed to run on multiple platforms (iOS, Android, web, desktop). Visual tests can become problematic when UI components render slightly differently on different platforms, leading to false positives where the tests fail even though the visual changes are minor or expected.
+1. **Platform-Specific Rendering**: Flutter is a cross-platform framework, meaning the same codebase is designed to run on multiple platforms (iOS, Android, web, desktop).
+   Visual tests can become problematic when UI components render slightly differently on different platforms, leading to false positives where the tests fail even though the visual changes are minor or expected.
 
-2. **Environmental Variability**: The appearance of UI elements can depend on the environment in which the tests are run, such as the screen resolution, text scaling, or device-specific configurations. Flutter developers often encounter issues where the baseline images captured in one environment do not match those in another, even if the changes are not functionally significant.
+2. **Environmental Variability**: The appearance of UI elements can depend on the environment in which the tests are run, such as the screen resolution, text scaling, or device-specific configurations.
+   Flutter developers often encounter issues where the baseline images captured in one environment do not match those in another, even if the changes are not functionally significant.
 
-3. **Maintenance Overhead**: As an application grows, so does the number of visual tests. Maintaining and updating baseline images can become cumbersome, particularly when intentional UI changes are made. Developers have to manually verify that each visual change is expected and update the baselines accordingly, which can slow down the development process.
+3. **Maintenance Overhead**: As an application grows, so does the number of visual tests.
+   Maintaining and updating baseline images can become cumbersome, particularly when intentional UI changes are made.
+   Developers have to manually verify that each visual change is expected and update the baselines accordingly, which can slow down the development process.
 
-4. **Dynamic Content**: UI elements that involve dynamic content (such as API-driven images, data, or animations) make visual tests harder to implement. Flutter apps, often built with dynamic, real-time content, might trigger false positives in visual tests due to small, yet legitimate, differences in the rendering.
+4. **Dynamic Content**: UI elements that involve dynamic content (such as API-driven images, data, or animations) make visual tests harder to implement.
+   Flutter apps, often built with dynamic, real-time content, might trigger false positives in visual tests due to small, yet legitimate, differences in the rendering.
 
-5. **Writing Visual Tests**: To benefit from visual tests, developers need to write them. Especially for bigger applications where visual tests are most useful, this is time-consuming.
+5. **Writing Visual Tests**: To benefit from visual tests, developers need to write them.
+   Especially for bigger applications where visual tests are most useful, this is time-consuming.
 
 ### How Widgetbook Cloud Can Help
 
 To alleviate the challenges associated with visual tests for Flutter developers, **Widgetbook Cloud** offers a solution that enhances the workflow of testing, reviewing, and maintaining UI components.
 
-1. **Zero-Configuration Visual Testing**: Widgetbook users don't need to write visual tests. Every widget that is cataloged in Widgetbook will automatically be visually tested in every PR.
+1. **Zero-Configuration Visual Testing**: Widgetbook users don't need to write visual tests.
+   Every widget that is cataloged in Widgetbook will automatically be visually tested in every PR.
 
-1. **Cloud-Based Testing**: Widgetbook Cloud allows Flutter teams to run visual tests in a consistent, controlled environment. This eliminates platform-specific rendering discrepancies and environmental variability, as the tests are executed in a standard cloud environment where factors like screen resolution and device configurations are uniform.
+1. **Cloud-Based Testing**: Widgetbook Cloud allows Flutter teams to run visual tests in a consistent, controlled environment.
+   This eliminates platform-specific rendering discrepancies and environmental variability, as the tests are executed in a standard cloud environment where factors like screen resolution and device configurations are uniform.
 
-2. **Collaborative Review Process**: One of Widgetbook Cloud's standout features is its collaborative approach to reviewing UI changes. Developers, designers, and product managers can collectively inspect and approve visual changes in real time. By centralizing UI reviews in a shared platform, the burden of verifying and maintaining visual tests is distributed across the team, improving efficiency and accuracy.
+2. **Collaborative Review Process**: One of Widgetbook Cloud's standout features is its collaborative approach to reviewing UI changes.
+   Developers, designers, and product managers can collectively inspect and approve visual changes in real time.
+   By centralizing UI reviews in a shared platform, the burden of verifying and maintaining visual tests is distributed across the team, improving efficiency and accuracy.
 
-3. **Version Control for UI Components**: With Widgetbook Cloud, each UI component is versioned, which allows teams to track visual changes over time. This can reduce the maintenance overhead of baseline images because changes are automatically documented and traceable. If a component's appearance changes intentionally, the baseline can be easily updated in a controlled manner.
+3. **Version Control for UI Components**: With Widgetbook Cloud, each UI component is versioned, which allows teams to track visual changes over time.
+   This can reduce the maintenance overhead of baseline images because changes are automatically documented and traceable.
+   If a component's appearance changes intentionally, the baseline can be easily updated in a controlled manner.
 
-4. **Simplified Maintenance**: Instead of manually updating and managing baseline images, Widgetbook Cloud streamlines the process by allowing visual changes to be compared, reviewed, and approved in one place. This ensures that only the intended UI changes are accepted, reducing the risk of unintentional regressions while keeping maintenance efforts low.
+4. **Simplified Maintenance**: Instead of manually updating and managing baseline images, Widgetbook Cloud streamlines the process by allowing visual changes to be compared, reviewed, and approved in one place.
+   This ensures that only the intended UI changes are accepted, reducing the risk of unintentional regressions while keeping maintenance efforts low.
 
 ### Conclusion
 
-Visual tests are an essential part of maintaining UI consistency and detecting regressions in modern application development. However, they can be challenging to implement and maintain for Flutter developers due to platform variability, environmental factors, and dynamic content. Widgetbook Cloud automatically creates visual tests for Flutter teams and provides a comprehensive solution by offering a standardized, cloud-based platform for running and reviewing visual tests, improving collaboration, and simplifying the maintenance of baseline images. This ensures that Flutter teams can deliver visually consistent, high-quality user experiences with greater efficiency and confidence.
+Visual tests are an essential part of maintaining UI consistency and detecting regressions in modern application development.
+However, they can be challenging to implement and maintain for Flutter developers due to platform variability, environmental factors, and dynamic content.
+Widgetbook Cloud automatically creates visual tests for Flutter teams and provides a comprehensive solution by offering a standardized, cloud-based platform for running and reviewing visual tests, improving collaboration, and simplifying the maintenance of baseline images.
+This ensures that Flutter teams can deliver visually consistent, high-quality user experiences with greater efficiency and confidence.


### PR DESCRIPTION
Sixth of nine. **Stacked on #2006.** Sidebar change plus a small copy pass.

Testing was nested inside Stories — three levels deep — which undersold it. Scenarios are one of the main reasons teams adopt Widgetbook, not a Stories subtopic.

```
Stories                        Stories
├── Overview                   ├── Overview
├── Args ▸                     ├── Args ▸
├── Modes                      ├── Modes
├── Addons ▸           ->      ├── Addons ▸
├── Mock Widgets               └── Mock Widgets
└── Testing                    Testing
    ├── Overview               ├── Overview
    ├── Default Scenarios      ├── Scenarios ▸
    ├── Create Scenario        │   ├── Default Scenarios
    ├── Run Scenarios          │   ├── Create Scenario
    ├── Layout Constraining    │   └── Run Scenarios
    ├── Accessibility          ├── Layout Constraining
    └── Visual Tests           ├── Accessibility Guidelines
                               └── Visual Tests
```

The three scenario pages collapse into a `Scenarios` subgroup so the section opens on Overview instead of a wall of seven entries.

Also a small copy pass on `run-scenarios` and `visual-tests` (em dashes to commas, matching the rest of the docs).

## Verification

- 117 nav hrefs — all resolve
- 0 duplicates within a tab, 0 orphaned pages, 0 broken internal links