### PR TITLE
docs: rewrite the landing page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -19,8 +19,7 @@ While developing widgets or screens, you have probably faced one of the followin
 ## The Solution
 
 Widgetbook covers four jobs: build, test, document, share.
-Together they give a custom design system a place to live: every component visible, every state pinned, every change reviewed.
-See our guide on [building and maintaining high-quality Flutter UIs with a design system](https://www.widgetbook.io/blog/building-and-maintaining-high-quality-flutter-uis-with-a-design-system).
+Every component gets a page in the catalog, a screenshot per state, and a diff on every pull request.
 
 ### Build in Isolation
 
@@ -35,45 +34,40 @@ See [Core Concepts](/core-concepts) for how these fit together.
 
 ### Test
 
-[Scenarios](/testing/overview) freeze a story into a fixed state. `flutter test` captures a screenshot of each one.
+A [scenario](/testing/create-scenario) pins a story to a fixed state so it renders the same way every time.
 
-- One definition serves development, review, and automated testing.
-- Scenarios run on `flutter_test`, so a `run` callback can tap, pump frames, and assert.
-- [Accessibility guidelines](/testing/accessibility) are evaluated on every captured scenario, covering tap-target size, missing labels, and text contrast.
-- [Widgetbook Cloud](/sharing/publish-to-cloud) diffs those snapshots on every pull request, so [visual tests](/testing/visual-tests) need no separate suite.
+- Write that state once and reuse it while developing, while reviewing, and in [automated tests](/testing/run-scenarios).
+- `flutter test` renders every scenario and saves a screenshot.
+- [Accessibility guidelines](/testing/accessibility) check each screenshot for tap-target size, missing labels, and text contrast.
+- [Visual tests](/testing/visual-tests) in [Widgetbook Cloud](/sharing/publish-to-cloud) compare the screenshots against the previous build and show what changed in the pull request.
 
 ### Document
 
-[DocBlocks](/documentation/overview) generate component documentation from the code you already wrote: doc comments, the args table, and the story list. Blocks are [customizable](/documentation/customize) globally or per component.
+[DocBlocks](/documentation/overview) generate component documentation from the code you already wrote.
+Blocks are [customizable](/documentation/customize) globally or per component.
 
 ### Share
 
-Publish the catalog so the whole team can use it.
+Publish the catalog so the whole team has access without running Flutter code.
 
-- [Embed](/sharing/embedding) a single story in your own docs site.
+- [Embed a single story](/sharing/embedding) in your own docs site.
 - [Publish to Widgetbook Cloud](/sharing/publish-to-cloud) for a hosted build per commit and [reviews](/cloud/reviews) with sign-off from designers and QA.
 
 ### Serve as a GenUI Catalog
 
-In a generative UI app, the model composes screens at runtime from a fixed set of approved widgets. That catalog is a design system handed to a model, and its quality caps the quality of every generated screen.
+In a generative UI app, the model composes screens at runtime from a fixed set of approved widgets.
+Those screens are only as good as the widgets you hand the model.
 
-- A `CatalogItem` and a [Story](/stories/overview) describe the same widget: `dataSchema` maps to typed [args](/args/overview), `widgetBuilder` to the widget the story renders.
-- Generated screens cannot be snapshotted, but the catalog can. Covering each widget across its schema's range bounds every screen the model can produce.
-- Cached A2UI payloads replay as [scenarios](/testing/overview), turning real model output into permanent regression tests.
-- `flutter test` gives an agent a self-heal loop: every scenario is rendered, asserted, and checked against accessibility rules, so failures name the widget to fix.
+- A catalog entry and a [story](/stories/overview) describe the same widget, so one definition covers both.
+- Generated screens cannot be captured up front, but every widget the model picks from can.
+- Real model output replays as a [scenario](/testing/create-scenario) and becomes a regression test.
 
 See [GenUI](/genui/overview).
 
-New in v4: generated, type-safe declarations replace v3's annotations and knobs. See [What's new in v4](/whats-new-in-v4).
+New in v4: generated, type-safe declarations replace v3's annotations and knobs.
+See [What's new in v4](/whats-new-in-v4).
 
 ## Case Studies
-
-### 1KOMMA5°
-
-Cleantech company running 3 Flutter apps on a shared in-house design system.
-
-- **0 visual bugs shipped** since adopting Widgetbook Cloud.
-- **20% time saved** across designers and developers.
 
 <Card
   icon="bolt"
@@ -84,13 +78,6 @@ Cleantech company running 3 Flutter apps on a shared in-house design system.
   >
   > Anton Borries, Senior Software Engineer at 1KOMMA5º and Google Developer Expert for Flutter & Dart
 </Card>
-
-### Salto Systems
-
-Smart access and IoT company serving over 40,000 clients in more than 40 countries, with seven production Flutter apps.
-
-- **50% time saved** for developers.
-- Every UI change surfaced in the merge request.
 
 <Card
   icon="lock"
@@ -119,3 +106,10 @@ Smart access and IoT company serving over 40,000 clients in more than 40 countri
 **LeanCode** on a design system template shared with every new client.
 
 <YouTube id="rmQktvnyfPg" />
+
+## Next
+
+- [Install & Quick Start](/quick-start)
+- [Core Concepts](/core-concepts)
+- [Stories](/stories/overview)
+- [Testing](/testing/overview)

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,7 +1,7 @@
 # Why Widgetbook?
 
-Widgetbook is a sandbox for building **widgets and screens in isolation**. 
-It helps you develop and share hard-to-reach states and edge cases without needing to run your whole app. 
+Widgetbook is a sandbox for building and cataloging **widgets and screens in isolation**.
+It helps you develop and share hard-to-reach states and edge cases without running your whole app.
 Widgetbook is [open-source](https://github.com/widgetbook/widgetbook) and **free** to use.
 
 <YouTube id="sGRetvJ-zZI" />
@@ -10,58 +10,112 @@ Widgetbook is [open-source](https://github.com/widgetbook/widgetbook) and **free
 
 While developing widgets or screens, you have probably faced one of the following problems:
 
-- **Hard-to-reach states:** You need to test a widget in a specific state (e.g. error, loading, etc.) but it is hard to reach that state in your app.
-- **Time consuming:** You need to run your whole app to test a single widget or screen, and even spend more time to test in different configurations (e.g. dark mode, different locales, etc.).
-- **API/Datasource dependencies:** You need to mock data or APIs to test your screens, which is time-consuming and error-prone, and it is even not always possible to do that.
-- **Collaboration:** You need to share your widgets with your design team or other developers, but it is hard to do that without a proper documentation or cataloging system.
+- **Hard-to-reach states:** A widget needs to be checked in a specific state (error, loading, empty) that is hard to reach in the running app.
+- **Time consuming:** Testing a single widget means running the whole app, then running it again for every configuration such as dark mode or a different locale.
+- **API and datasource dependencies:** Screens need mocked data to render, which is slow to set up and sometimes not possible at all.
+- **Collaboration:** Sharing UI with designers, QA, and other developers has no obvious home without a catalog.
+- **Custom design systems are hard to maintain:** Components drift from the design over time, edge cases go undocumented, and nobody can tell what already exists, so the same button gets built twice.
 
-## The Solution: Widgetbook
+## The Solution
 
-With Widgetbook you can **build UI in isolation** without depending on any external data source or API. This allows you to:
+Widgetbook covers four jobs: build, test, document, share.
+Together they give a custom design system a place to live: every component visible, every state pinned, every change reviewed.
+See our guide on [building and maintaining high-quality Flutter UIs with a design system](https://www.widgetbook.io/blog/building-and-maintaining-high-quality-flutter-uis-with-a-design-system).
 
-- **Easily test your widgets** in different **states** (e.g. error, loading, etc.) via [Args](/args/overview), and **configurations** (e.g. dark mode, different locales, etc.) via [Addons](/addons/overview).
-- **Mock your data** so you can test your widgets without the need to run your whole app (learn more about [Mocking](/stories/mocking)).
-- **Catalog your widgets and screens** in a single place, so you can easily share them with all your team members (e.g. developers, designers, product managers, QA testers).
+### Build in Isolation
 
-<YouTube id="5cNUX7eDZWE" />
+Catalog every state of a widget without an API or a datasource behind it.
 
-## Customer Showcases
+- [Stories](/stories/overview) declare each state of a component.
+- [Args](/args/overview) are generated from your widget's constructor, so every property is a type-safe control in the UI.
+- [Modes](/addons/modes) and [Addons](/addons/overview) render the same story under a different theme, locale, viewport, or text scale.
+- [Mocking](/stories/mocking) injects fake dependencies so screens render standalone.
 
-### Salto Systems
+See [Core Concepts](/core-concepts) for how these fit together.
 
-Salto Systems is a company that specializes in smart locks and access control systems. They use Widgetbook to build their widgets in isolation, which allows them to speed up their development process.
+### Test
 
-<Card
-  icon="medium fa-brands"
-  title="How Salto prevents UI problems while saving 50% of their time"
-  href="https://medium.com/widgetbook/how-salto-prevents-ui-problems-while-saving-50-of-their-time-with-widgetbook-53194f79ee96"
->
-  > We build new features by starting with Widgetbook, allowing us to
-  immediately develop the UI in isolation and see how new components behave.
-  Building in isolation is especially helpful for larger components and screens
-  that handle various data states — like loading, loaded, or error. Before
-  Widgetbook, testing error states was time-consuming because they’re naturally
-  hard to reproduce; the data often comes from sources we can’t easily control.
-  But with Widgetbook’s isolation-first approach, we can inject mocked data and
-  test all component states. Once a component is ready, other developers can
-  easily explore its different variations. — Arthur Schenk, Mobile Team Lead at
-  Salto
-</Card>
+[Scenarios](/testing/overview) freeze a story into a fixed state. `flutter test` captures a screenshot of each one.
 
-### Lotum
+- One definition serves development, review, and automated testing.
+- Scenarios run on `flutter_test`, so a `run` callback can tap, pump frames, and assert.
+- [Accessibility guidelines](/testing/accessibility) are evaluated on every captured scenario, covering tap-target size, missing labels, and text contrast.
+- [Widgetbook Cloud](/sharing/publish-to-cloud) diffs those snapshots on every pull request, so [visual tests](/testing/visual-tests) need no separate suite.
 
-Lotum speeds up their app development by building their widgets in isolation with Widgetbook.
+### Document
 
-<YouTube id="0xV-OzfY2zg" />
+[DocBlocks](/documentation/overview) generate component documentation from the code you already wrote: doc comments, the args table, and the story list. Blocks are [customizable](/documentation/customize) globally or per component.
+
+### Share
+
+Publish the catalog so the whole team can use it.
+
+- [Embed](/sharing/embedding) a single story in your own docs site.
+- [Publish to Widgetbook Cloud](/sharing/publish-to-cloud) for a hosted build per commit and [reviews](/cloud/reviews) with sign-off from designers and QA.
+
+### Serve as a GenUI Catalog
+
+In a generative UI app, the model composes screens at runtime from a fixed set of approved widgets. That catalog is a design system handed to a model, and its quality caps the quality of every generated screen.
+
+- A `CatalogItem` and a [Story](/stories/overview) describe the same widget: `dataSchema` maps to typed [args](/args/overview), `widgetBuilder` to the widget the story renders.
+- Generated screens cannot be snapshotted, but the catalog can. Covering each widget across its schema's range bounds every screen the model can produce.
+- Cached A2UI payloads replay as [scenarios](/testing/overview), turning real model output into permanent regression tests.
+- `flutter test` gives an agent a self-heal loop: every scenario is rendered, asserted, and checked against accessibility rules, so failures name the widget to fix.
+
+See [GenUI](/genui/overview).
+
+New in v4: generated, type-safe declarations replace v3's annotations and knobs. See [What's new in v4](/whats-new-in-v4).
+
+## Case Studies
 
 ### 1KOMMA5°
 
-1KOMMA5° creates an in-house design system which is used across 6 different projects.
+Cleantech company running 3 Flutter apps on a shared in-house design system.
+
+- **0 visual bugs shipped** since adopting Widgetbook Cloud.
+- **20% time saved** across designers and developers.
+
+<Card
+  icon="bolt"
+  title="How 1KOMMA5º builds a custom design system and maintainable Flutter apps with Widgetbook"
+  href="https://www.widgetbook.io/blog/1komma5%C2%BA-custom-flutter-design-system-with-widgetbook"
+>
+  > Widgetbook provides us with a process to build and maintain our design system, prevent visual bugs, and align design and development.
+  >
+  > Anton Borries, Senior Software Engineer at 1KOMMA5º and Google Developer Expert for Flutter & Dart
+</Card>
+
+### Salto Systems
+
+Smart access and IoT company serving over 40,000 clients in more than 40 countries, with seven production Flutter apps.
+
+- **50% time saved** for developers.
+- Every UI change surfaced in the merge request.
+
+<Card
+  icon="lock"
+  title="How Salto prevents UI problems while saving 50% of their time with Widgetbook"
+  href="https://www.widgetbook.io/blog/salto-widgetbook-case"
+>
+  > Widgetbook saves us a lot of time and provides valuable insight into which changes are made with each merge request.
+  >
+  > Arthur Schenk, Mobile Team Lead at Salto
+</Card>
+
+## Videos
+
+**Building UI in isolation**
+
+<YouTube id="5cNUX7eDZWE" />
+
+**Lotum** speeds up app development by building widgets in isolation.
+
+<YouTube id="0xV-OzfY2zg" />
+
+**1KOMMA5°** on an in-house design system used across 3 apps.
 
 <YouTube id="4xWseFS5Z38" />
 
-### LeanCode
-
-LeanCode is a software agency which creates a design system template that they share with every new client for the project start.
+**LeanCode** on a design system template shared with every new client.
 
 <YouTube id="rmQktvnyfPg" />

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -39,7 +39,7 @@ A [scenario](/testing/create-scenario) pins a story to a fixed state so it rende
 - Write that state once and reuse it while developing, while reviewing, and in [automated tests](/testing/run-scenarios).
 - `flutter test` renders every scenario and saves a screenshot.
 - [Accessibility guidelines](/testing/accessibility) check each screenshot for tap-target size, missing labels, and text contrast.
-- [Visual tests](/testing/visual-tests) in [Widgetbook Cloud](/sharing/publish-to-cloud) compare the screenshots against the previous build and show what changed in the pull request.
+- [Visual tests](/testing/visual-tests) in [Widgetbook Cloud](/cloud) compare the screenshots against the previous build and show what changed in the pull request.
 
 ### Document
 
@@ -51,7 +51,7 @@ Blocks are [customizable](/documentation/customize) globally or per component.
 Publish the catalog so the whole team has access without running Flutter code.
 
 - [Embed a single story](/sharing/embedding) in your own docs site.
-- [Publish to Widgetbook Cloud](/sharing/publish-to-cloud) for a hosted build per commit and [reviews](/cloud/reviews) with sign-off from designers and QA.
+- [Publish to Widgetbook Cloud](/sharing/hosting) for a hosted build per commit and [reviews](/cloud/reviews) with sign-off from designers and QA.
 
 ### Serve as a GenUI Catalog
 

--- a/docs/stories/code-generation.mdx
+++ b/docs/stories/code-generation.mdx
@@ -17,7 +17,7 @@ const meta = Meta(Counter.new); // [!code highlight]
 
 The `part` directive is required since the generator writes all output into the corresponding `.stories.g.dart` file. `Meta` selects the constructor to inspect; the component widget is derived from the tear-off. Args are derived from that constructor's parameters, and the generator creates a type-safe `_Args` class, a `_Story` class with a default builder, and other generated declarations.
 
-`Meta` takes a single positional argument: a constructor tear-off such as `Counter.new` (the unnamed constructor) or `Counter.compact` (a named constructor). `Meta` variables must be declared as `const`. The name of the `meta` variable itself doesn't matter — the generator finds it by type.
+`Meta` takes a single positional argument: a constructor tear-off such as `Counter.new` (the unnamed constructor) or `Counter.compact` (a named constructor). `Meta` variables must be declared as `const`. The name of the `meta` variable itself doesn't matter, the generator finds it by type.
 
 ### Component Customization
 
@@ -42,7 +42,7 @@ final component = ComponentMeta(
 const meta = Meta(Counter.new);
 ```
 
-A `ComponentMeta` without parameters is redundant — omit it unless you need one of the customizations above.
+A `ComponentMeta` without parameters is redundant, so omit it unless you need one of the customizations above.
 
 ### Defining Stories
 
@@ -64,7 +64,7 @@ final $StartAtTen = _Story(
 
 ## Constructor Variants
 
-Widgets often have multiple constructors that represent distinct variants, like `MyButton()` and `MyButton.icon()`. A stories file can have any number of `Meta` variables — one per constructor, all targeting the same widget:
+Widgets often have multiple constructors that represent distinct variants, like `MyButton()` and `MyButton.icon()`. A stories file can have any number of `Meta` variables, one per constructor, all targeting the same widget:
 
 ```dart title="my_button.stories.dart"
 const meta = Meta(MyButton.new);
@@ -148,7 +148,7 @@ final defaults = _Defaults(
 );
 ```
 
-The generator matches a defaults variable to its variant by the variable's type, not its name — `_Defaults` applies to the unnamed constructor's stories, `_IconDefaults` to the `.icon` constructor's stories, and so on. Each variant can have at most one defaults variable.
+The generator matches a defaults variable to its variant by the variable's type, not its name. `_Defaults` applies to the unnamed constructor's stories, `_IconDefaults` to the `.icon` constructor's stories, and so on. Each variant can have at most one defaults variable.
 
 With defaults in place, stories only need to specify their args:
 

--- a/docs/stories/code-generation.mdx
+++ b/docs/stories/code-generation.mdx
@@ -1,6 +1,9 @@
 # Code Generation
 
-Widgetbook uses Dart's `build_runner` to generate the boilerplate needed for [Stories](/stories/overview), [Args](/args/overview), and [Scenarios](/testing/overview). At the core of this system is `Meta`, a declaration that selects a widget constructor to generate stories for. From a `Meta` declaration and a `part` directive, the generator produces type-safe args, story classes, and a component registry. This lets you focus on writing stories rather than wiring up boilerplate.
+Widgetbook uses Dart's `build_runner` to generate the boilerplate needed for [Stories](/stories/overview), [Args](/args/overview), and [Scenarios](/testing/overview).
+At the core of this system is `Meta`, a declaration that selects a widget constructor to generate stories for.
+From a `Meta` declaration and a `part` directive, the generator produces type-safe args, story classes, and a component registry.
+This lets you focus on writing stories rather than wiring up boilerplate.
 
 ## Usage
 
@@ -15,13 +18,16 @@ part 'counter.stories.g.dart'; // [!code highlight]
 const meta = Meta(Counter.new); // [!code highlight]
 ```
 
-The `part` directive is required since the generator writes all output into the corresponding `.stories.g.dart` file. `Meta` selects the constructor to inspect; the component widget is derived from the tear-off. Args are derived from that constructor's parameters, and the generator creates a type-safe `_Args` class, a `_Story` class with a default builder, and other generated declarations.
+The `part` directive is required since the generator writes all output into the corresponding `.stories.g.dart` file. `Meta` selects the constructor to inspect; the component widget is derived from the tear-off.
+Args are derived from that constructor's parameters, and the generator creates a type-safe `_Args` class, a `_Story` class with a default builder, and other generated declarations.
 
-`Meta` takes a single positional argument: a constructor tear-off such as `Counter.new` (the unnamed constructor) or `Counter.compact` (a named constructor). `Meta` variables must be declared as `const`. The name of the `meta` variable itself doesn't matter, the generator finds it by type.
+`Meta` takes a single positional argument: a constructor tear-off such as `Counter.new` (the unnamed constructor) or `Counter.compact` (a named constructor). `Meta` variables must be declared as `const`.
+The name of the `meta` variable itself doesn't matter, the generator finds it by type.
 
 ### Component Customization
 
-To customize the component as a whole, declare an optional `ComponentMeta` variable (at most one per stories file). All its parameters are optional:
+To customize the component as a whole, declare an optional `ComponentMeta` variable (at most one per stories file).
+All its parameters are optional:
 
 | Parameter | Type | Description |
 | --- | --- | --- |
@@ -46,7 +52,9 @@ A `ComponentMeta` without parameters is redundant, so omit it unless you need on
 
 ### Defining Stories
 
-Once the generator has run, you can define stories using the generated types. Each story variable must start with `$`. The variable name (without the `$`) becomes the story's display name in the Widgetbook UI:
+Once the generator has run, you can define stories using the generated types.
+Each story variable must start with `$`.
+The variable name (without the `$`) becomes the story's display name in the Widgetbook UI:
 
 ```dart title="counter.stories.dart"
 final $Default = _Story(
@@ -64,7 +72,8 @@ final $StartAtTen = _Story(
 
 ## Constructor Variants
 
-Widgets often have multiple constructors that represent distinct variants, like `MyButton()` and `MyButton.icon()`. A stories file can have any number of `Meta` variables, one per constructor, all targeting the same widget:
+Widgets often have multiple constructors that represent distinct variants, like `MyButton()` and `MyButton.icon()`.
+A stories file can have any number of `Meta` variables, one per constructor, all targeting the same widget:
 
 ```dart title="my_button.stories.dart"
 const meta = Meta(MyButton.new);
@@ -72,7 +81,8 @@ const meta = Meta(MyButton.new);
 const iconMeta = Meta(MyButton.icon); // [!code highlight]
 ```
 
-For each `Meta`, the generator emits a full set of types. Types for named constructors are prefixed with the PascalCase constructor name:
+For each `Meta`, the generator emits a full set of types.
+Types for named constructors are prefixed with the PascalCase constructor name:
 
 ```dart title="my_button.stories.dart"
 // Stories for MyButton(...)
@@ -86,11 +96,13 @@ final $IconLarge = _IconStory(
 );
 ```
 
-All stories appear in a flat list under the same component, with the story variable's name as the display name. Factory constructors work the same way as named constructors.
+All stories appear in a flat list under the same component, with the story variable's name as the display name.
+Factory constructors work the same way as named constructors.
 
 ## Custom Args
 
-For cases where you need a different args shape, provide `Meta.argsType` with a constructor tear-off of a plain Dart class. The generated args are then derived from that constructor's parameters instead of the widget's:
+For cases where you need a different args shape, provide `Meta.argsType` with a constructor tear-off of a plain Dart class.
+The generated args are then derived from that constructor's parameters instead of the widget's:
 
 Since the generator can no longer infer how to construct the widget from these custom args, you must provide a `builder`, either per story or via a shared `defaults` variable.
 
@@ -129,7 +141,8 @@ final $Primary = _Story(
 
 ### Defaults
 
-To avoid repeating the same `builder` and `setup` in every story, define a variable of the generated `_Defaults` type. The generated `_Story` class picks it up automatically:
+To avoid repeating the same `builder` and `setup` in every story, define a variable of the generated `_Defaults` type.
+The generated `_Story` class picks it up automatically:
 
 ```dart title="label_badge.stories.dart"
 final defaults = _Defaults(
@@ -148,7 +161,8 @@ final defaults = _Defaults(
 );
 ```
 
-The generator matches a defaults variable to its variant by the variable's type, not its name. `_Defaults` applies to the unnamed constructor's stories, `_IconDefaults` to the `.icon` constructor's stories, and so on. Each variant can have at most one defaults variable.
+The generator matches a defaults variable to its variant by the variable's type, not its name. `_Defaults` applies to the unnamed constructor's stories, `_IconDefaults` to the `.icon` constructor's stories, and so on.
+Each variant can have at most one defaults variable.
 
 With defaults in place, stories only need to specify their args:
 
@@ -173,7 +187,9 @@ Individual stories can still override `builder` or `setup` when needed.
 - The widget constructor has parameters that don't work well as args (callbacks, controllers, complex objects).
 - You want to expose a simplified or curated set of interactive controls.
 - Multiple widget parameters should be derived from a single arg value.
-- The widget depends on a provider and you want args to mirror the provider's properties instead of the widget's constructor. This lets you mock the provider in `setup` using the arg values. See the [Mocking guide](/stories/mocking) for more details.
+- The widget depends on a provider and you want args to mirror the provider's properties instead of the widget's constructor.
+  This lets you mock the provider in `setup` using the arg values.
+  See the [Mocking guide](/stories/mocking) for more details.
 
 ## Generated Output
 
@@ -184,7 +200,8 @@ Running the generator produces two kinds of output:
 
 ### Per-Story File
 
-For each `.stories.dart` file, a `.stories.g.dart` part file is generated containing one set of declarations per `Meta` variable. For named constructors, the PascalCase constructor name is inserted after the underscore (e.g. `_IconStory`) and after the widget name (e.g. `MyButtonIconStory`):
+For each `.stories.dart` file, a `.stories.g.dart` part file is generated containing one set of declarations per `Meta` variable.
+For named constructors, the PascalCase constructor name is inserted after the underscore (e.g. `_IconStory`) and after the widget name (e.g. `MyButtonIconStory`):
 
 | Declaration | Full Name | Description |
 | --- | --- | --- |
@@ -196,7 +213,8 @@ For each `.stories.dart` file, a `.stories.g.dart` part file is generated contai
 
 #### Syntactic Sugar
 
-The underscore-prefixed names (`_Story`, `_Args`, etc.) are private typedefs that point to the fully qualified generated classes. They exist so you don't have to repeat the widget name everywhere:
+The underscore-prefixed names (`_Story`, `_Args`, etc.) are private typedefs that point to the fully qualified generated classes.
+They exist so you don't have to repeat the widget name everywhere:
 
 ```dart
 // Without syntactic sugar, using the full generated names:
@@ -214,15 +232,18 @@ final $Primary = _Story(
 );
 ```
 
-Both forms are equivalent. The underscore aliases keep story files concise and consistent regardless of the widget name.
+Both forms are equivalent.
+The underscore aliases keep story files concise and consistent regardless of the widget name.
 
 #### The Args Class
 
-The generated `_Args` class wraps each constructor parameter in a typed `Arg<T>`. It provides three ways to interact with each parameter:
+The generated `_Args` class wraps each constructor parameter in a typed `Arg<T>`.
+It provides three ways to interact with each parameter:
 
 - **Arg fields** (e.g. `initialValueArg`): the full `Arg<T>` object, useful when you need to customize the arg's behavior.
 - **Value getters** (e.g. `initialValue`): convenience getters that return the resolved value directly.
-- **`.fixed()` constructor**: creates args with constant values that won't be interactive in the Widgetbook UI. Useful for [Scenarios](/testing/overview).
+- **`.fixed()` constructor**: creates args with constant values that won't be interactive in the Widgetbook UI.
+  Useful for [Scenarios](/testing/overview).
 
 ```dart
 // Interactive args with UI controls:
@@ -243,7 +264,8 @@ _Scenario(
 
 ### Component Registry
 
-A single `components.g.dart` file is generated at the library root. It collects every `{Widget}Component` variable into a list that Widgetbook uses to build the navigation tree:
+A single `components.g.dart` file is generated at the library root.
+It collects every `{Widget}Component` variable into a list that Widgetbook uses to build the navigation tree:
 
 ```dart title="components.g.dart"
 final components = <Component>[
@@ -265,19 +287,23 @@ dart run build_runner build
 
 ### Watch Mode
 
-For a smoother workflow, run the generator in **watch mode**. It re-generates automatically on every file save, so the generated types (`_Story`, `_Args`, etc.) stay up to date and your IDE autocompletion always works:
+For a smoother workflow, run the generator in **watch mode**.
+It re-generates automatically on every file save, so the generated types (`_Story`, `_Args`, etc.) stay up to date and your IDE autocompletion always works:
 
 ```bash
 dart run build_runner watch
 ```
 
 <Info>
-  Watch mode is strongly recommended during development. It removes the need to manually re-run the build command every time you add a story, change args, or modify your widget's constructor.
+  Watch mode is strongly recommended during development.
+  It removes the need to manually re-run the build command every time you add a story, change args, or modify your widget's constructor.
 </Info>
 
 ## Best Practices
 
 1. **Use watch mode during development.** Running `dart run build_runner watch` keeps generated code in sync with your source files automatically.
-2. **Set up `Meta` before writing stories.** Create the `meta` variable and `part` directive first, run the generator once, and then start writing stories. This ensures `_Story`, `_Args`, and other generated types are available for autocompletion in your IDE.
-3. **Prefer widget-derived args over custom args.** Without `argsType`, you get an auto-generated `builder`, so you don't need to manually map args to widget parameters. Only provide `argsType` when the widget's constructor doesn't fit your needs.
+2. **Set up `Meta` before writing stories.** Create the `meta` variable and `part` directive first, run the generator once, and then start writing stories.
+   This ensures `_Story`, `_Args`, and other generated types are available for autocompletion in your IDE.
+3. **Prefer widget-derived args over custom args.** Without `argsType`, you get an auto-generated `builder`, so you don't need to manually map args to widget parameters.
+   Only provide `argsType` when the widget's constructor doesn't fit your needs.
 4. **Prefix story variables with `$`.** The generator requires this prefix (e.g. `$Default`, `$Primary`) and strips the `$` to derive the display name shown in the Widgetbook UI.


### PR DESCRIPTION
Last of nine. **Stacked on #2009.** After this, the branch matches the finished restructure exactly.

"Why Widgetbook?" was a feature list. It now answers what Widgetbook is *for*, organized around the jobs it does — **build, test, document, share** — each linking into the section that covers it, plus a fifth on using the catalog as a **GenUI** widget set.

## Changes

- **Problem list** gains the design-system case: components drift from the design, edge cases go undocumented, and the same button gets built twice because nobody can tell what already exists.
- **Case studies** lead with outcomes (0 visual bugs shipped, 50% time saved) instead of company descriptions. The Salto quote is cut from ~10 lines to the sentence that carries it.
- **Videos** are collected into one section rather than interleaved between customer sections.

Also finishes the copy pass on `stories/code-generation`.

## Why it lands last

The rewrite links to `/genui/overview` (#2006), `/testing/accessibility` (#2005) and `/sharing/publish-to-cloud` (#2003). Landing it earlier would have shipped broken links to the live site.

## Verification

- 125 nav hrefs — all resolve
- 0 duplicates within a tab, 0 orphaned pages, 0 broken internal links
- 13 redirects — all targets exist, no source still present
- **The tree at this commit is byte-identical to the original restructure working tree** — the nine-PR split lost nothing and added nothing.

## One thing to check

The 1KOMMA5° section now says *"an in-house design system used across 3 apps"*; the previous copy said *"6 different projects"*. Intentional if the number changed, worth a look if not.