### PR TITLE
docs: update the privacy policy sub-processor list

### DIFF
--- a/docs/cloud/account/privacy-policy.mdx
+++ b/docs/cloud/account/privacy-policy.mdx
@@ -138,8 +138,13 @@ Pseudonymized data may also be stored in cookies and may contain technical infor
 - **AWS:** For cloud data storage. [**Privacy Policy‍**](https://aws.amazon.com/privacy/)
 - **Sentry:** For error monitoring. [**Privacy Policy‍**](https://sentry.io/privacy/)
 - **Mixpanel:** For usage analytics. [**Privacy Policy‍**](https://mixpanel.com/legal/privacy-policy)
+- **Google Analytics:** For website traffic analysis. [**Privacy Policy**](https://policies.google.com/privacy)
 - **Cal.com:** For scheduling calls. [**Privacy Policy**](https://cal.com/privacy)
+- **Slack:** For notifications to connected workspaces. [**Privacy Policy**](https://slack.com/trust/privacy/privacy-policy)
 - **GitHub:** For code management. [**Privacy Policy‍**](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement)
+- **GitLab:** For pull request integration. [**Privacy Policy**](https://about.gitlab.com/privacy/)
+- **Bitbucket:** For pull request integration. [**Privacy Policy**](https://www.atlassian.com/legal/privacy-policy)
+- **Azure DevOps:** For pull request integration. [**Privacy Policy**](https://www.microsoft.com/en-us/privacy/privacystatement)
 - **Stripe:** For payment processing. [**Privacy Policy**](https://stripe.com/privacy)
 
 ---

--- a/docs/cloud/account/privacy-policy.mdx
+++ b/docs/cloud/account/privacy-policy.mdx
@@ -67,7 +67,7 @@ Widgetbook GmbH uses the collected data for the following purposes:
 
 When contacting us via email or contact form, your information will be stored for the purpose of responding to your inquiry.
 
-Personal data that you transmit to us through a contact request, an email, or direct business interaction may be processed and maintained by us using our Customer Relationship Management (CRM) system, namely HubSpot.
+Personal data that you transmit to us through a contact request, an email, or direct business interaction may be processed and maintained by us using our Customer Relationship Management (CRM) system.
 
 As a general rule, no data will be transferred to third parties unless permitted under applicable data protection law or if we are legally obligated to do so. You may withdraw your consent at any time with effect for the future. In case of withdrawal, your data will be deleted without delay unless statutory exceptions require continued processing. Otherwise, your data will be deleted once your inquiry has been addressed or the purpose of storage no longer applies and no other legal exceptions apply.
 
@@ -136,12 +136,9 @@ Pseudonymized data may also be stored in cookies and may contain technical infor
 - **Clerk:** For user management. [**Privacy Policy‍**](https://clerk.com/legal/privacy)
 - **Vercel:** For development and hosting. [**Privacy Policy‍**](https://vercel.com/legal/privacy-policy)
 - **AWS:** For cloud data storage. [**Privacy Policy‍**](https://aws.amazon.com/privacy/)
-- **Google Cloud Platform:** For cloud data storage. [**Privacy Policy‍**](https://cloud.google.com/privacy)
-- **Axiom:** For data analytics. [**Privacy Policy‍**](https://axiom.co/privacy)
 - **Sentry:** For error monitoring. [**Privacy Policy‍**](https://sentry.io/privacy/)
 - **Mixpanel:** For usage analytics. [**Privacy Policy‍**](https://mixpanel.com/legal/privacy-policy)
-- **Mouseflow:** For user behavior analytics. [**Privacy Policy‍**](https://mouseflow.com/privacy)
-- **HubSpot:** For CRM and marketing. [**Privacy Policy‍**](https://legal.hubspot.com/privacy-policy)
+- **Cal.com:** For scheduling calls. [**Privacy Policy**](https://cal.com/privacy)
 - **GitHub:** For code management. [**Privacy Policy‍**](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement)
 - **Stripe:** For payment processing. [**Privacy Policy**](https://stripe.com/privacy)
 


### PR DESCRIPTION
Updates the third-party provider list in section 9.3 of the privacy policy.

**Added**
- Cal.com, for scheduling calls.
- Google Analytics, for website traffic analysis.
- Slack, for notifications to connected workspaces.
- GitLab, Bitbucket, and Azure DevOps, for pull request integration. The list previously named GitHub as the only git provider.

**Removed**
- Google Cloud Platform
- Mouseflow
- Axiom
- HubSpot

**Also changed**

Section 5 previously named HubSpot as our CRM. It now refers to "our Customer Relationship Management (CRM) system" without naming a provider. If a CRM is still in use, it should be named here and listed in 9.3.
