### PR TITLE
docs: replace the v4 beta sign-up form with an email link

### DIFF
--- a/docs/whats-new-in-v4.mdx
+++ b/docs/whats-new-in-v4.mdx
@@ -202,5 +202,5 @@ We're passing those savings directly on to our customers.
 
 Right now, we do not know exactly how much cost savings we will have.
 We're working closely together with Beta Users to find that out.
-[Sign up for the Widgetbook Cloud v4 Beta Program](https://ic7614zmz3s.typeform.com/to/qsBbdJf4) to get 2,5x more snapshot usage for free immediately as well as individual support calls to shape v4 and the new pricing together with us.
+Email us at [contact@widgetbook.io](mailto:contact@widgetbook.io) to get 2,5x more snapshot usage for free immediately as well as individual support calls to shape v4 and the new pricing together with us.
 We will announce the final pricing plans before general availability.


### PR DESCRIPTION
The Widgetbook Cloud v4 Beta Program sign-up form is no longer in use. The link in `docs/whats-new-in-v4.mdx` now points to contact@widgetbook.io instead, keeping the same offer text.

This was the last Typeform link in the docs.