### PR TITLE
docs: remove the outdated product tour

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -459,10 +459,6 @@
         {
           "title": "Quickstart",
           "href": "/cloud/quickstart"
-        },
-        {
-          "title": "Product Tour",
-          "href": "https://app.arcade.software/share/KAUbnlpbFF26PJzIGrwG"
         }
       ]
     },

--- a/docs/cloud/index.mdx
+++ b/docs/cloud/index.mdx
@@ -53,10 +53,6 @@ Run the full workflow on a demo repository.
 <Card title="Set up your project" icon="folder-plus" href="/cloud/projects/create">
 Connect your own repository and upload the first build.
 </Card>
-
-<Card title="Product Tour" icon="play" href="https://app.arcade.software/share/KAUbnlpbFF26PJzIGrwG">
-Click through the product without signing up.
-</Card>
 </CardGroup>
 
 ## Case Studies


### PR DESCRIPTION
The Arcade product tour is outdated, so it is removed from the Cloud tab: the "Get Started" card on `/cloud` and the sidebar entry in `docs.json`.