### PR TITLE
docs: update the Cloud demo video

### DIFF
--- a/docs/cloud/index.mdx
+++ b/docs/cloud/index.mdx
@@ -5,7 +5,7 @@ Widgetbook Cloud hosts a [build](/cloud/builds/overview) for every commit and tu
 Widgetbook itself stays [open source](https://github.com/widgetbook/widgetbook) and free.
 Cloud is optional.
 
-<YouTube id="l3tj9VvkjLs" />
+<YouTube id="sjuPdgtYi0w" />
 
 <Image theme="light" src="/assets/cloud/review.light.png" />
 <Image theme="dark" src="/assets/cloud/review.dark.png" />


### PR DESCRIPTION
Replaces the demo video embedded at the top of the Cloud landing page with the current one (`sjuPdgtYi0w`).

Note: `packages/widgetbook/README.md` still links the previous video and is untouched here.