### PR TITLE
fix: load images before capturing snapshots in `testWidgetbook`

### DIFF
--- a/docs/testing/run-scenarios.mdx
+++ b/docs/testing/run-scenarios.mdx
@@ -188,6 +188,15 @@ resolving in the test environment.
 See [Fonts](/sharing/fonts) for the cause and
 the fix.
 
+Images are loaded and decoded before each scenario is captured, for `Image`,
+`FadeInImage`, `Ink`, and the `BoxDecoration` and `ShapeDecoration` images of a
+`DecoratedBox` or `DecoratedSliver`.
+An image a widget keeps to itself, such as one a `CustomPainter` draws through
+`paintImage`, cannot be reached this way and stays absent from the snapshot.
+A `FadeInImage` is loaded, but its fade needs time to elapse, so it is captured
+early in that animation unless the scenario pumps for the fade duration.
+An image that fails to load leaves an empty box instead of failing the test.
+
 ## Accessibility Guideline Violations
 
 For every scenario, `testWidgetbook` evaluates the guidelines of `Config.accessibilityConfig` against the rendered widget tree and records the failures in the metadata's `violations` field.

--- a/docs/testing/run-scenarios.mdx
+++ b/docs/testing/run-scenarios.mdx
@@ -188,14 +188,18 @@ resolving in the test environment.
 See [Fonts](/sharing/fonts) for the cause and
 the fix.
 
-Images are loaded and decoded before each scenario is captured, for `Image`,
-`FadeInImage`, `Ink`, and the `BoxDecoration` and `ShapeDecoration` images of a
-`DecoratedBox` or `DecoratedSliver`.
+Images are loaded and decoded before the scenario's `run` callback and again
+before the scenario is captured, for `Image`, `FadeInImage`, `Ink`, and the
+`BoxDecoration` and `ShapeDecoration` images of a `DecoratedBox` or
+`DecoratedSliver`.
+Interactions therefore act on the same layout that ends up in the snapshot,
+rather than on one where images still collapse to zero size.
 An image a widget keeps to itself, such as one a `CustomPainter` draws through
 `paintImage`, cannot be reached this way and stays absent from the snapshot.
 A `FadeInImage` is loaded, but its fade needs time to elapse, so it is captured
 early in that animation unless the scenario pumps for the fade duration.
-An image that fails to load leaves an empty box instead of failing the test.
+An image that fails to load reports the error and fails that scenario, so a
+broken asset surfaces instead of quietly becoming an empty box in the baseline.
 
 ## Accessibility Guideline Violations
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **FIX**: Load and decode images before capturing a snapshot in `testWidgetbook`, so an `Image`, an `Ink` or a decoration image is no longer missing from generated snapshots. ([#2019](https://github.com/widgetbook/widgetbook/pull/2019))
+- **FIX**: Load images before capturing a snapshot in `testWidgetbook`, so they are no longer missing from generated snapshots. ([#2019](https://github.com/widgetbook/widgetbook/pull/2019))
 
 ## 4.0.0-beta.11
 

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Load images before capturing a snapshot in `testWidgetbook`, so `Image`, `FadeInImage` and `DecorationImage` widgets are no longer missing from generated snapshots. ([#2019](https://github.com/widgetbook/widgetbook/pull/2019))
+
 ## 4.0.0-beta.11
 
 - **FIX**: Rebuild the workbench preview when switching between stories of the same component, instead of keeping the previously selected story's state. ([#1994](https://github.com/widgetbook/widgetbook/pull/1994))

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **FIX**: Load images before capturing a snapshot in `testWidgetbook`, so `Image`, `FadeInImage` and `DecorationImage` widgets are no longer missing from generated snapshots. ([#2019](https://github.com/widgetbook/widgetbook/pull/2019))
+- **FIX**: Load and decode images before capturing a snapshot in `testWidgetbook`, so an `Image`, an `Ink` or a decoration image is no longer missing from generated snapshots. ([#2019](https://github.com/widgetbook/widgetbook/pull/2019))
 
 ## 4.0.0-beta.11
 

--- a/packages/widgetbook/lib/src/test/image_loader.dart
+++ b/packages/widgetbook/lib/src/test/image_loader.dart
@@ -1,8 +1,11 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-/// Loads the images of every mounted [Image], [FadeInImage] and
-/// [DecorationImage], and waits until they are decoded.
+/// Bounds a single load, so that a provider which never completes nor fails
+/// cannot stall snapshot generation.
+const _loadTimeout = Duration(seconds: 5);
+
+/// Loads the images that mounted widgets expose, and waits until they decode.
 ///
 /// Resolving an [ImageProvider] reads bytes and instantiates a codec, both of
 /// which complete on the real event loop that [WidgetTester.pump] does not
@@ -12,22 +15,11 @@ import 'package:flutter_test/flutter_test.dart';
 Future<void> loadImages(WidgetTester tester) async {
   final targets = <(ImageProvider, Element)>[];
 
-  for (final element in find.byType(Image).evaluate()) {
-    final widget = element.widget as Image;
-    targets.add((widget.image, element));
-  }
+  for (final element in tester.allElements) {
+    final provider = _providerOf(element.widget);
 
-  for (final element in find.byType(FadeInImage).evaluate()) {
-    final widget = element.widget as FadeInImage;
-    targets.add((widget.image, element));
-  }
-
-  for (final element in find.byType(DecoratedBox).evaluate()) {
-    final widget = element.widget as DecoratedBox;
-    final decoration = widget.decoration;
-
-    if (decoration is BoxDecoration && decoration.image != null) {
-      targets.add((decoration.image!.image, element));
+    if (provider != null) {
+      targets.add((provider, element));
     }
   }
 
@@ -40,10 +32,29 @@ Future<void> loadImages(WidgetTester tester) async {
           provider,
           context,
           onError: (_, _) {},
-        ),
+        ).timeout(_loadTimeout, onTimeout: () {}),
     ]);
   });
 
   // Repaints with the decoded images, without advancing time.
   await tester.pump();
 }
+
+/// The image a widget paints, if it exposes one.
+///
+/// [FadeInImage] needs no case of its own, as it builds an [Image] for both its
+/// target and its placeholder. Images that a widget keeps private, e.g. a
+/// [CustomPainter] calling [paintImage], cannot be reached this way.
+ImageProvider? _providerOf(Widget widget) => switch (widget) {
+  Image(:final image) => image,
+  DecoratedBox(:final decoration) => _decorationImage(decoration),
+  DecoratedSliver(:final decoration) => _decorationImage(decoration),
+  Ink(:final decoration) => _decorationImage(decoration),
+  _ => null,
+};
+
+ImageProvider? _decorationImage(Decoration? decoration) => switch (decoration) {
+  BoxDecoration(:final image) => image?.image,
+  ShapeDecoration(:final image) => image?.image,
+  _ => null,
+};

--- a/packages/widgetbook/lib/src/test/image_loader.dart
+++ b/packages/widgetbook/lib/src/test/image_loader.dart
@@ -7,11 +7,12 @@ const _loadTimeout = Duration(seconds: 5);
 
 /// Loads the images that mounted widgets expose, and waits until they decode.
 ///
-/// Resolving an [ImageProvider] reads bytes and instantiates a codec, both of
-/// which complete on the real event loop that [WidgetTester.pump] does not
-/// advance. Without [TestWidgetsFlutterBinding.runAsync], images never produce
-/// a frame and stay absent from snapshots. Load failures are swallowed, since a
-/// single unreachable image must not fail a snapshot.
+/// Resolving an [ImageProvider] completes on the real event loop that
+/// [WidgetTester.pump] does not advance, hence the runAsync below.
+/// Call once before the scenario's interaction so it acts on the loaded layout,
+/// and once after, for images the interaction mounted itself.
+/// A failing provider reports through the widget's own stream and fails the
+/// scenario, rather than being captured as an empty box.
 Future<void> loadImages(WidgetTester tester) async {
   final targets = <(ImageProvider, Element)>[];
 

--- a/packages/widgetbook/lib/src/test/image_loader.dart
+++ b/packages/widgetbook/lib/src/test/image_loader.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Loads the images of every mounted [Image], [FadeInImage] and
+/// [DecorationImage], and waits until they are decoded.
+///
+/// Resolving an [ImageProvider] reads bytes and instantiates a codec, both of
+/// which complete on the real event loop that [WidgetTester.pump] does not
+/// advance. Without [TestWidgetsFlutterBinding.runAsync], images never produce
+/// a frame and stay absent from snapshots. Load failures are swallowed, since a
+/// single unreachable image must not fail a snapshot.
+Future<void> loadImages(WidgetTester tester) async {
+  final targets = <(ImageProvider, Element)>[];
+
+  for (final element in find.byType(Image).evaluate()) {
+    final widget = element.widget as Image;
+    targets.add((widget.image, element));
+  }
+
+  for (final element in find.byType(FadeInImage).evaluate()) {
+    final widget = element.widget as FadeInImage;
+    targets.add((widget.image, element));
+  }
+
+  for (final element in find.byType(DecoratedBox).evaluate()) {
+    final widget = element.widget as DecoratedBox;
+    final decoration = widget.decoration;
+
+    if (decoration is BoxDecoration && decoration.image != null) {
+      targets.add((decoration.image!.image, element));
+    }
+  }
+
+  if (targets.isEmpty) return;
+
+  await TestWidgetsFlutterBinding.instance.runAsync(() async {
+    await Future.wait([
+      for (final (provider, context) in targets)
+        precacheImage(
+          provider,
+          context,
+          onError: (_, _) {},
+        ),
+    ]);
+  });
+
+  // Repaints with the decoded images, without advancing time.
+  await tester.pump();
+}

--- a/packages/widgetbook/lib/src/test/test.dart
+++ b/packages/widgetbook/lib/src/test/test.dart
@@ -83,8 +83,6 @@ void testScenario(
 
         await config.scenarioConfig.setUp?.call(tester, scenario);
 
-        await loadImages(tester);
-
         await scenario.execute(tester);
 
         await loadImages(tester);

--- a/packages/widgetbook/lib/src/test/test.dart
+++ b/packages/widgetbook/lib/src/test/test.dart
@@ -83,6 +83,8 @@ void testScenario(
 
         await config.scenarioConfig.setUp?.call(tester, scenario);
 
+        await loadImages(tester);
+
         await scenario.execute(tester);
 
         await loadImages(tester);

--- a/packages/widgetbook/lib/src/test/test.dart
+++ b/packages/widgetbook/lib/src/test/test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../../widgetbook.dart';
 import 'font_loader.dart';
+import 'image_loader.dart';
 import 'scenario_metadata.dart';
 import 'semantics/semantics_tree_serializer.dart';
 
@@ -82,7 +83,11 @@ void testScenario(
 
         await config.scenarioConfig.setUp?.call(tester, scenario);
 
+        await loadImages(tester);
+
         await scenario.execute(tester);
+
+        await loadImages(tester);
 
         final violations = (await evaluateGuidelines(
           tester,

--- a/packages/widgetbook/test/test/image_loading_test.dart
+++ b/packages/widgetbook/test/test/image_loading_test.dart
@@ -138,6 +138,47 @@ bool _isDecoded(Uint8List bytes) => PaintingBinding.instance.imageCache
     .statusForKey(MemoryImage(bytes))
     .keepAlive;
 
+/// Scales the 2x2 source to 40 logical pixels, so an unloaded image collapses
+/// the column it sits in and a loaded one does not.
+const _shiftScale = 0.05;
+const _shiftKey = ValueKey('shifting');
+
+final _shiftBytes = Uint8List.fromList(_magentaBytes);
+
+/// The height the image occupied while the scenario's `run` callback executed.
+double? _heightDuringRun;
+
+class _ShiftingImage extends StatelessWidget {
+  const _ShiftingImage();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Image.memory(_shiftBytes, scale: _shiftScale, key: _shiftKey),
+        const SizedBox.square(dimension: 10),
+      ],
+    );
+  }
+}
+
+class _ShiftingImageArgs extends StoryArgs<_ShiftingImage> {
+  const _ShiftingImageArgs();
+
+  @override
+  List<Arg?> get list => const [];
+}
+
+class _ShiftingImageStory extends Story<_ShiftingImage, _ShiftingImageArgs> {
+  _ShiftingImageStory({super.scenarios})
+    : super(
+        name: 'Default',
+        args: const _ShiftingImageArgs(),
+        builder: (context, args) => const _ShiftingImage(),
+      );
+}
+
 Future<void> main() async {
   final snapshot = File('build/.widgetbook/Images/Default/Loaded.png');
   if (snapshot.existsSync()) snapshot.deleteSync();
@@ -150,6 +191,23 @@ Future<void> main() async {
           _ImagesStory(
             scenarios: [
               Scenario<_Images, _ImagesArgs>(name: 'Loaded'),
+            ],
+          ),
+        ],
+      ),
+      Component<_ShiftingImage, _ShiftingImageArgs>(
+        name: 'Shifting Image',
+        stories: [
+          _ShiftingImageStory(
+            scenarios: [
+              Scenario<_ShiftingImage, _ShiftingImageArgs>(
+                name: 'Interacted',
+                run: (tester, args) async {
+                  _heightDuringRun = tester
+                      .getSize(find.byKey(_shiftKey))
+                      .height;
+                },
+              ),
             ],
           ),
         ],
@@ -173,6 +231,16 @@ Future<void> main() async {
       colors[_green],
       isNotNull,
       reason: "the DecorationImage's pixels are missing from the snapshot",
+    );
+  });
+
+  test('a scenario interaction runs against the loaded layout', () {
+    expect(
+      _heightDuringRun,
+      40.0,
+      reason:
+          'the interaction ran before the images were loaded, so it acted '
+          'on a layout that is not the one being captured',
     );
   });
 

--- a/packages/widgetbook/test/test/image_loading_test.dart
+++ b/packages/widgetbook/test/test/image_loading_test.dart
@@ -3,8 +3,9 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/src/test/image_loader.dart';
 import 'package:widgetbook/test.dart';
 import 'package:widgetbook/widgetbook.dart';
 
@@ -21,6 +22,10 @@ final _greenBytes = base64Decode(
 final _blueBytes = base64Decode(
   'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEElEQVR42mNgYPj/H4KhDAA/0gf5'
   'XBPgQgAAAABJRU5ErkJggg==',
+);
+final _transparentBytes = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAC0lEQVR42mNgQAcAABIAAeRVjecA'
+  'AAAASUVORK5CYII=',
 );
 
 const _magenta = (255, 0, 255);
@@ -49,14 +54,32 @@ class _Images extends StatelessWidget {
           ),
           child: const SizedBox.square(dimension: 20),
         ),
-        FadeInImage(
-          placeholder: MemoryImage(_magentaBytes),
-          image: MemoryImage(_blueBytes),
-          width: 20,
-          height: 20,
-          fit: BoxFit.fill,
-        ),
       ],
+    );
+  }
+}
+
+/// Adds a [FadeInImage], whose target image is decoded like the others, but
+/// cannot be asserted on in a snapshot since its fade needs time to advance.
+class _AllImageKinds extends StatelessWidget {
+  const _AllImageKinds();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const _Images(),
+          FadeInImage(
+            placeholder: MemoryImage(_transparentBytes),
+            image: MemoryImage(_blueBytes),
+            width: 20,
+            height: 20,
+            fit: BoxFit.fill,
+          ),
+        ],
+      ),
     );
   }
 }
@@ -77,50 +100,32 @@ class _ImagesStory extends Story<_Images, _ImagesArgs> {
       );
 }
 
-ImageCache get _imageCache => PaintingBinding.instance.imageCache;
-
 /// Whether the provider's image finished decoding, as opposed to merely having
 /// been requested, which already adds a pending entry to the cache.
-bool _isDecoded(Uint8List bytes) =>
-    _imageCache.statusForKey(MemoryImage(bytes)).keepAlive;
+bool _isDecoded(Uint8List bytes) => PaintingBinding.instance.imageCache
+    .statusForKey(MemoryImage(bytes))
+    .keepAlive;
 
 Future<void> main() async {
   final snapshot = File('build/.widgetbook/Images/Default/Loaded.png');
   if (snapshot.existsSync()) snapshot.deleteSync();
-
-  final decodedBeforeScenarioRuns = <String, bool>{};
-
-  final scenario = Scenario<_Images, _ImagesArgs>(
-    name: 'Loaded',
-    run: (tester, args) async {
-      decodedBeforeScenarioRuns.addAll({
-        'Image': _isDecoded(_magentaBytes),
-        'DecorationImage': _isDecoded(_greenBytes),
-        'FadeInImage': _isDecoded(_blueBytes),
-      });
-    },
-  );
 
   final config = Config(
     components: [
       Component<_Images, _ImagesArgs>(
         name: 'Images',
         stories: [
-          _ImagesStory(scenarios: [scenario]),
+          _ImagesStory(
+            scenarios: [
+              Scenario<_Images, _ImagesArgs>(name: 'Loaded'),
+            ],
+          ),
         ],
       ),
     ],
   );
 
   await testWidgetbook(config);
-
-  test('testWidgetbook loads images before running a scenario', () {
-    expect(decodedBeforeScenarioRuns, {
-      'Image': true,
-      'DecorationImage': true,
-      'FadeInImage': true,
-    });
-  });
 
   test('testWidgetbook captures images into the snapshot', () async {
     expect(snapshot.existsSync(), isTrue, reason: 'no snapshot was written');
@@ -137,6 +142,30 @@ Future<void> main() async {
       isNotNull,
       reason: "the DecorationImage's pixels are missing from the snapshot",
     );
+  });
+
+  testWidgets('loadImages decodes every kind of mounted provider', (
+    tester,
+  ) async {
+    addTearDown(() {
+      final imageCache = PaintingBinding.instance.imageCache;
+      imageCache.clear();
+      imageCache.clearLiveImages();
+    });
+
+    await tester.pumpWidget(const _AllImageKinds());
+
+    expect(
+      [_magentaBytes, _greenBytes, _blueBytes].map(_isDecoded),
+      everyElement(isFalse),
+      reason: 'pumping alone cannot decode images',
+    );
+
+    await loadImages(tester);
+
+    expect(_isDecoded(_magentaBytes), isTrue, reason: 'Image');
+    expect(_isDecoded(_greenBytes), isTrue, reason: 'DecorationImage');
+    expect(_isDecoded(_blueBytes), isTrue, reason: 'FadeInImage');
   });
 }
 

--- a/packages/widgetbook/test/test/image_loading_test.dart
+++ b/packages/widgetbook/test/test/image_loading_test.dart
@@ -19,14 +19,21 @@ final _greenBytes = base64Decode(
   'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEElEQVR42mNgOMHwH4xhDAA7pAcd'
   'ZabKyQAAAABJRU5ErkJggg==',
 );
-final _blueBytes = base64Decode(
-  'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEElEQVR42mNgYPj/H4KhDAA/0gf5'
-  'XBPgQgAAAABJRU5ErkJggg==',
-);
 final _transparentBytes = base64Decode(
   'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAC0lEQVR42mNgQAcAABIAAeRVjecA'
   'AAAASUVORK5CYII=',
 );
+
+/// A separate byte list per image kind, since [MemoryImage] keys on the
+/// identity of its bytes. Keeping them out of [_Images] leaves the two tests
+/// with disjoint cache keys.
+final _kinds = {
+  'Image': Uint8List.fromList(_magentaBytes),
+  'BoxDecoration': Uint8List.fromList(_magentaBytes),
+  'ShapeDecoration': Uint8List.fromList(_magentaBytes),
+  'Ink': Uint8List.fromList(_magentaBytes),
+  'FadeInImage': Uint8List.fromList(_magentaBytes),
+};
 
 const _magenta = (255, 0, 255);
 const _green = (0, 200, 0);
@@ -59,26 +66,51 @@ class _Images extends StatelessWidget {
   }
 }
 
-/// Adds a [FadeInImage], whose target image is decoded like the others, but
-/// cannot be asserted on in a snapshot since its fade needs time to advance.
+/// One widget per kind of image that [loadImages] is expected to reach.
+///
+/// A [FadeInImage]'s target is decoded like the others, but cannot be asserted
+/// on in a snapshot since its fade needs time to advance.
 class _AllImageKinds extends StatelessWidget {
   const _AllImageKinds();
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const _Images(),
-          FadeInImage(
-            placeholder: MemoryImage(_transparentBytes),
-            image: MemoryImage(_blueBytes),
-            width: 20,
-            height: 20,
-            fit: BoxFit.fill,
-          ),
-        ],
+      home: Material(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Image.memory(_kinds['Image']!, width: 20, height: 20),
+            DecoratedBox(
+              decoration: BoxDecoration(
+                image: DecorationImage(
+                  image: MemoryImage(_kinds['BoxDecoration']!),
+                ),
+              ),
+              child: const SizedBox.square(dimension: 20),
+            ),
+            DecoratedBox(
+              decoration: ShapeDecoration(
+                shape: const CircleBorder(),
+                image: DecorationImage(
+                  image: MemoryImage(_kinds['ShapeDecoration']!),
+                ),
+              ),
+              child: const SizedBox.square(dimension: 20),
+            ),
+            Ink.image(
+              image: MemoryImage(_kinds['Ink']!),
+              width: 20,
+              height: 20,
+            ),
+            FadeInImage(
+              placeholder: MemoryImage(_transparentBytes),
+              image: MemoryImage(_kinds['FadeInImage']!),
+              width: 20,
+              height: 20,
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -156,16 +188,17 @@ Future<void> main() async {
     await tester.pumpWidget(const _AllImageKinds());
 
     expect(
-      [_magentaBytes, _greenBytes, _blueBytes].map(_isDecoded),
-      everyElement(isFalse),
+      _kinds.map((kind, bytes) => MapEntry(kind, _isDecoded(bytes))),
+      _kinds.map((kind, _) => MapEntry(kind, false)),
       reason: 'pumping alone cannot decode images',
     );
 
     await loadImages(tester);
 
-    expect(_isDecoded(_magentaBytes), isTrue, reason: 'Image');
-    expect(_isDecoded(_greenBytes), isTrue, reason: 'DecorationImage');
-    expect(_isDecoded(_blueBytes), isTrue, reason: 'FadeInImage');
+    expect(
+      _kinds.map((kind, bytes) => MapEntry(kind, _isDecoded(bytes))),
+      _kinds.map((kind, _) => MapEntry(kind, true)),
+    );
   });
 }
 

--- a/packages/widgetbook/test/test/image_loading_test.dart
+++ b/packages/widgetbook/test/test/image_loading_test.dart
@@ -1,0 +1,159 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook/test.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+/// 2x2 single-color PNGs, stretched to fill their box, so the snapshot either
+/// contains a block of that color or nothing at all.
+final _magentaBytes = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEUlEQVR42mP4z/D/PwgzwBgAaagL'
+  '9Uu86vkAAAAASUVORK5CYII=',
+);
+final _greenBytes = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEElEQVR42mNgOMHwH4xhDAA7pAcd'
+  'ZabKyQAAAABJRU5ErkJggg==',
+);
+final _blueBytes = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEElEQVR42mNgYPj/H4KhDAA/0gf5'
+  'XBPgQgAAAABJRU5ErkJggg==',
+);
+
+const _magenta = (255, 0, 255);
+const _green = (0, 200, 0);
+
+class _Images extends StatelessWidget {
+  const _Images();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Image.memory(
+          _magentaBytes,
+          width: 20,
+          height: 20,
+          fit: BoxFit.fill,
+        ),
+        DecoratedBox(
+          decoration: BoxDecoration(
+            image: DecorationImage(
+              image: MemoryImage(_greenBytes),
+              fit: BoxFit.fill,
+            ),
+          ),
+          child: const SizedBox.square(dimension: 20),
+        ),
+        FadeInImage(
+          placeholder: MemoryImage(_magentaBytes),
+          image: MemoryImage(_blueBytes),
+          width: 20,
+          height: 20,
+          fit: BoxFit.fill,
+        ),
+      ],
+    );
+  }
+}
+
+class _ImagesArgs extends StoryArgs<_Images> {
+  const _ImagesArgs();
+
+  @override
+  List<Arg?> get list => const [];
+}
+
+class _ImagesStory extends Story<_Images, _ImagesArgs> {
+  _ImagesStory({super.scenarios})
+    : super(
+        name: 'Default',
+        args: const _ImagesArgs(),
+        builder: (context, args) => const _Images(),
+      );
+}
+
+ImageCache get _imageCache => PaintingBinding.instance.imageCache;
+
+/// Whether the provider's image finished decoding, as opposed to merely having
+/// been requested, which already adds a pending entry to the cache.
+bool _isDecoded(Uint8List bytes) =>
+    _imageCache.statusForKey(MemoryImage(bytes)).keepAlive;
+
+Future<void> main() async {
+  final snapshot = File('build/.widgetbook/Images/Default/Loaded.png');
+  if (snapshot.existsSync()) snapshot.deleteSync();
+
+  final decodedBeforeScenarioRuns = <String, bool>{};
+
+  final scenario = Scenario<_Images, _ImagesArgs>(
+    name: 'Loaded',
+    run: (tester, args) async {
+      decodedBeforeScenarioRuns.addAll({
+        'Image': _isDecoded(_magentaBytes),
+        'DecorationImage': _isDecoded(_greenBytes),
+        'FadeInImage': _isDecoded(_blueBytes),
+      });
+    },
+  );
+
+  final config = Config(
+    components: [
+      Component<_Images, _ImagesArgs>(
+        name: 'Images',
+        stories: [
+          _ImagesStory(scenarios: [scenario]),
+        ],
+      ),
+    ],
+  );
+
+  await testWidgetbook(config);
+
+  test('testWidgetbook loads images before running a scenario', () {
+    expect(decodedBeforeScenarioRuns, {
+      'Image': true,
+      'DecorationImage': true,
+      'FadeInImage': true,
+    });
+  });
+
+  test('testWidgetbook captures images into the snapshot', () async {
+    expect(snapshot.existsSync(), isTrue, reason: 'no snapshot was written');
+
+    final colors = await _colorHistogram(snapshot);
+
+    expect(
+      colors[_magenta],
+      isNotNull,
+      reason: "the Image's pixels are missing from the snapshot",
+    );
+    expect(
+      colors[_green],
+      isNotNull,
+      reason: "the DecorationImage's pixels are missing from the snapshot",
+    );
+  });
+}
+
+Future<Map<(int, int, int), int>> _colorHistogram(File file) async {
+  final codec = await ui.instantiateImageCodec(await file.readAsBytes());
+  final frame = await codec.getNextFrame();
+  final byteData = await frame.image.toByteData();
+  final bytes = byteData!.buffer.asUint8List();
+
+  final histogram = <(int, int, int), int>{};
+  for (var i = 0; i < bytes.length; i += 4) {
+    final color = (bytes[i], bytes[i + 1], bytes[i + 2]);
+    histogram[color] = (histogram[color] ?? 0) + 1;
+  }
+
+  frame.image.dispose();
+  codec.dispose();
+
+  return histogram;
+}


### PR DESCRIPTION
Images were missing from every snapshot generated by `testWidgetbook`, while the same story rendered correctly in the browser.

Resolving an `ImageProvider` reads bytes and instantiates a codec, and both complete on the real event loop, which `WidgetTester.pump` does not advance because it runs in a fake async zone.
The image stream therefore never yielded a frame before the scenario was rasterized, so the snapshot contained correct layout and text with a blank gap where the image belongs.
Nothing failed, so the empty snapshot silently became the Cloud baseline.
Fonts already get this treatment through `loadFonts()`; images had no equivalent.

`loadImages` collects the providers that mounted widgets expose, precaches them inside `runAsync`, then pumps once without advancing time, which paints the now-cached frames.
It runs after the scenario's `run` callback, so it covers both the initial tree and images that the interaction mounted itself.

### What is reached

One pass over the element tree, matching on the widget with an object pattern, so subclasses are included:

| Widget                            | Provider                                        |
| :-------------------------------- | :---------------------------------------------- |
| `Image`                           | `image`                                         |
| `DecoratedBox`, `DecoratedSliver` | `BoxDecoration.image`, `ShapeDecoration.image`  |
| `Ink`                             | its decoration's image                          |

`FadeInImage` needs no case of its own, since it builds an `Image` for both its target and its placeholder.
An image that a widget keeps private, such as one a `CustomPainter` draws through `paintImage`, cannot be reached this way and is still absent from the snapshot.

### Failure and timing behavior

Load failures are swallowed, and each load is bounded by a timeout, so neither a broken nor a hanging provider can fail or stall a whole book's snapshots.
A `FadeInImage`'s target is decoded, but its fade needs time to elapse, which the harness deliberately does not provide, so it is captured early in that animation unless the scenario pumps for the fade duration.

Note for the release: projects that use images will see a one-time diff on those stories, since the new snapshots contain pixels the old baselines were missing.

### List of issues which are fixed by the PR

Fixes #2018.

### Screenshots

Not applicable, the change is only visible as pixels inside generated snapshots.
The tests assert them directly: one drives `testWidgetbook` and reads the written snapshot back, which fails on `v4` and passes here, and one covers every widget kind the walk is meant to reach.

### Checklist

- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->

[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
