### PR TITLE
docs: add Figma design comparison setup instructions

### DIFF
--- a/docs/cloud/for-designers/figma.mdx
+++ b/docs/cloud/for-designers/figma.mdx
@@ -3,7 +3,7 @@
 The comparison runs between Widgetbook Cloud and Figma, side by side.
 
 The developer sets a design link on a story, pointing at the matching component in the Figma file.
-In the review the link shows as a **View in Figma** button.
+The review then renders that component next to the implementation, and the link also shows as a **View in Figma** button for opening the real file.
 
 <Image src="/assets/cloud/reviews/view-in-figma.png" zoom caption="Click View in Figma on the story" />
 <Image src="/assets/cloud/reviews/figma-design.png" zoom caption="The matching component opens in the Figma file" />
@@ -18,14 +18,15 @@ The developer setup lives in [Figma Reviews](/cloud/reviews/figma).
 | Design the states that will be built | A developer can only link to a state that exists in Figma. Empty, loading, error, and edge states included. |
 | Specify tokens, not raw values | A named token gets implemented as that token and stays consistent. Raw values in the design invite raw values in the code. |
 
-<Info>
-  **Coming soon.**
-  Today a review compares two Flutter builds, so it catches regressions against the previous version but not deviations from the design.
-  Widgetbook Cloud will show the Figma design next to the implementation and diff the two directly.
-  Email [contact@widgetbook.io](mailto:contact@widgetbook.io) to be notified when it lands.
-</Info>
+## See the Design in the Review
+
+A review no longer only compares two Flutter builds.
+Once a developer has linked the story and connected the Figma file, the review shows the design itself: beside the implementation, or drawn over it at an opacity the reviewer controls.
+
+That means a review catches deviations from the design, not only regressions against the previous version.
+Nothing changes in how you work in Figma, but it does raise the value of the habits above: the review renders the exact node the link points at.
 
 ## Next
 
-- [Figma Reviews](/cloud/reviews/figma): how a developer adds the design link.
+- [Figma Reviews](/cloud/reviews/figma): how a developer links the story and connects the Figma file.
 - [Glossary](/cloud/for-designers/glossary): pull request, story, scenario, snapshot, build, base, head.

--- a/docs/cloud/for-designers/figma.mdx
+++ b/docs/cloud/for-designers/figma.mdx
@@ -20,10 +20,12 @@ The developer setup lives in [Figma Reviews](/cloud/reviews/figma).
 
 ## See the Design in the Review
 
-A review no longer only compares two Flutter builds.
+A review no longer only shows two Flutter builds side by side.
 Once a developer has linked the story and connected the Figma file, the review shows the design itself: beside the implementation, or drawn over it at an opacity the reviewer controls.
 
-That means a review catches deviations from the design, not only regressions against the previous version.
+Widgetbook does not compare the design to the implementation for you.
+It still flags changes by comparing the new build against the previous one, and puts the design alongside so a reviewer can see for themselves whether the result matches it.
+
 Nothing changes in how you work in Figma, but it does raise the value of the habits above: the review renders the exact node the link points at.
 
 ## Next

--- a/docs/cloud/reviews/figma.mdx
+++ b/docs/cloud/reviews/figma.mdx
@@ -1,6 +1,10 @@
 # Figma Reviews
 
-Widgetbook Cloud renders the Figma design behind a story next to its implementation, so a review catches deviations from the design and not only regressions against the previous build.
+Widgetbook Cloud renders the Figma design behind a story next to its implementation, so you can check a change against the design without leaving the review.
+
+The design is shown, not diffed.
+Widgetbook still detects changes by comparing the `base` and `head` builds, and it makes no judgement about whether an implementation matches its design.
+Putting the two side by side is what lets you make that judgement yourself.
 
 Setup is three steps: link a story to its design, connect a Figma account, and connect the file to your workspace.
 Do them in that order, because the file list is populated from the design links your stories already carry.
@@ -32,7 +36,7 @@ A link to a whole file has nothing to render, and shows only as a **View in Figm
 <Image src="/assets/cloud/figma-review.png" zoom caption="A linked story offers View in Figma on both sides of the diff" />
 
 <Info>
-  Design comparison requires a Widgetbook 4 build.
+  Showing the design requires a Widgetbook 4 build.
   On an older build the design controls stay disabled and the diff falls back to **Baseline**.
 </Info>
 

--- a/docs/cloud/reviews/figma.mdx
+++ b/docs/cloud/reviews/figma.mdx
@@ -1,12 +1,11 @@
 # Figma Reviews
 
-Widgetbook Cloud Review helps verify that developers meet **design requirements** by comparing **Flutter widgets** to their corresponding **Figma designs**.
+Widgetbook Cloud renders the Figma design behind a story next to its implementation, so a review catches deviations from the design and not only regressions against the previous build.
 
-<Image src="/assets/cloud/figma-review.png" zoom />
+Setup is three steps: link a story to its design, connect a Figma account, and connect the file to your workspace.
+Do them in that order, because the file list is populated from the design links your stories already carry.
 
-## Guide
-
-To display a "View in Figma" button in your reviews, add the Figma URL to your stories:
+## 1. Link a Story to Its Design
 
 1. In your Figma design file, navigate to the component that matches your widget.
 1. Copy the link to the component by right-clicking and selecting `Copy/Paste as` > `Copy Link`.
@@ -15,7 +14,7 @@ To display a "View in Figma" button in your reviews, add the Figma URL to your s
    ```dart
    final $Default = _Story(
      // ...
-     designLink: 'https://www.figma.com/file/EXuEpwiyksLAejYX1qr1v4/Fluttercon-Berlin-2023-Demo?type=design&node-id=277-3056&mode=design&t=nVL8hLmc1jlcilZL-4',
+     designLink: 'https://www.figma.com/design/EXuEpwiyksLAejYX1qr1v4/Demo?node-id=277-3056',
    )
    ```
 
@@ -27,5 +26,83 @@ To display a "View in Figma" button in your reviews, add the Figma URL to your s
 
 1. Commit your changes and push them to your repository to create a new build.
 
-The button then shows on every review of that story.
+The link must point at a specific node.
+A link to a whole file has nothing to render, and shows only as a **View in Figma** button.
+
+<Image src="/assets/cloud/figma-review.png" zoom caption="A linked story offers View in Figma on both sides of the diff" />
+
+<Info>
+  Design comparison requires a Widgetbook 4 build.
+  On an older build the design controls stay disabled and the diff falls back to **Baseline**.
+</Info>
+
+## 2. Connect a Figma Account
+
+Rendering borrows a connected member's Figma credentials, because Figma rate-limits per account rather than per organization.
+
+<Steps>
+  <Step title="Open workspace settings">
+    Go to **Settings** > **General** and find the **Figma Integration** card.
+  </Step>
+  <Step title="Connect your account">
+    Under **Your account**, click **Connect** and approve Widgetbook in Figma.
+    The badge on the card shows how many connected accounts can currently render.
+  </Step>
+</Steps>
+
+You can also connect from your own profile page, but the Figma card sits below the entire account section, so you have to scroll to the bottom of the page to reach it.
+Workspace settings is the shorter route, and it puts the connection next to the file list you need in step 3.
+
+<Warning>
+  Figma limits **View** and **Collab** seats to a handful of renders per month.
+  Connect an account on a **Dev** or **Full** seat, or the designs will stop rendering almost immediately.
+  Widgetbook flags a seat as soon as Figma tells it the seat cannot render.
+</Warning>
+
+Every member who connects adds capacity, since the limit is per account rather than per workspace.
+Only the member who connected an account can disconnect it.
+
+## 3. Connect the Figma File
+
+Widgetbook only renders designs from files connected to the workspace.
+Anything else a design link points at is ignored: design links come from your source code, and rendering one spends a colleague's Figma credentials.
+
+<Steps>
+  <Step title="Find the file">
+    Once a build carries design links, the files they reference appear under **Referenced by your stories** in the **Figma Files** card.
+  </Step>
+  <Step title="Connect it">
+    Click **Connect** next to the file.
+    You can also paste a file URL into the field at the bottom of the card.
+  </Step>
+</Steps>
+
+Connecting validates the file against your own Figma access, so you can only add files you can already open.
+Changing this list is restricted to workspace owners.
+
+## Review the Design
+
+Open a story diff in a review.
+The view switcher in the top-right offers three modes, and `f` cycles between them.
+
+| Mode | Shows |
+| --- | --- |
+| **Baseline** | The `base` and `head` implementations side by side |
+| **Design** | The Figma design beside the `head` implementation |
+| **Overlay** | The design drawn on top of the `head` implementation |
+
+In **Overlay**, the **Design** slider sets how strongly the design shows through.
+When the design and the implementation are different sizes, the anchor picker next to it aligns them on a shared edge or corner, so you compare the part you care about instead of two images centered against each other.
+
+Designs are rendered when a review's change set is computed, so they appear shortly after the build finishes rather than instantly.
+
+## Troubleshooting
+
+| Symptom | Cause |
+| --- | --- |
+| The design controls are disabled | The story has no `designLink`, or the build predates Widgetbook 4. |
+| The design never appears | The file is not connected to the workspace, or no connected account can render. Check both cards in **Settings** > **General**. |
+| Designs stopped rendering | The connected accounts are on **View** or **Collab** Figma seats, or a connection was revoked in Figma. |
+| The design is out of date | Renders are cached per change set. Push a new build to refresh them. |
+
 For the designer-facing side of this workflow, see [Compare against Figma](/cloud/for-designers/figma).


### PR DESCRIPTION
Widgetbook Cloud now renders the Figma design behind a story next to its implementation, but the docs only covered the older **View in Figma** button.
This documents the setup end to end.

**`cloud/reviews/figma`** (developer-facing) gains the two steps that were missing: connecting a Figma account, and connecting the Figma file to the workspace.
Both are required before anything renders, and neither was written down anywhere.
It also documents the three review modes (Baseline, Design, Overlay), the opacity and alignment controls, the `f` shortcut, the Figma seat requirement, and a troubleshooting table.

**`cloud/for-designers/figma`** had a "Coming soon" note promising exactly this feature.
Replaced with a short section on what a designer now sees in a review.

Two accuracy notes for reviewers:

- The connect control exists on both the profile page and workspace settings.
  The docs point at workspace settings, because the profile page renders the Figma card below the entire account section and you have to scroll to the bottom to find it.
  Worth fixing in the UI, at which point this paragraph can go.
- The existing `figma-review.png` screenshot predates the feature and shows two Flutter builds with **View in Figma** buttons.
  It moved from the top of the page down into the design-link section, where it is still correct.
  The new Design and Overlay modes have no screenshot yet.
