### PR TITLE
refactor: allow analyzer 13.x and 14.x

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **REFACTOR**: Allow `analyzer` 13.x.
+
 ## 4.0.0-beta.12
 
 - **FIX**: Load images before capturing a snapshot in `testWidgetbook`, so they are no longer missing from generated snapshots. ([#2019](https://github.com/widgetbook/widgetbook/pull/2019))

--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **REFACTOR**: Allow `analyzer` 13.x.
+- **REFACTOR**: Allow `analyzer` 13.x and 14.x. ([#2025](https://github.com/widgetbook/widgetbook/pull/2025))
 
 ## 4.0.0-beta.12
 

--- a/packages/widgetbook/lib/src/generator/framework/story_generator.dart
+++ b/packages/widgetbook/lib/src/generator/framework/story_generator.dart
@@ -250,13 +250,23 @@ class StoryGenerator extends Generator {
     }
 
     final match = matches.single;
+    // `NamedExpression` (analyzer <13) and its replacement `NamedArgument`
+    // (analyzer >=13) have incompatible APIs, so named arguments are read
+    // via their version-agnostic syntax structure `name ':' expression`,
+    // where the expression is the node's last child entity.
     final arguments = match.value.arguments.arguments
-        .whereType<NamedExpression>()
+        .cast<AstNode>()
+        .where((node) => node.beginToken.next?.lexeme == ':')
+        .map(
+          (node) => (
+            name: node.beginToken.lexeme,
+            expression: node.childEntities.last as AstNode,
+          ),
+        )
         .where((arg) => arg.expression is! NullLiteral);
 
     final args = {
-      for (final arg in arguments)
-        arg.name.label.name: Code(arg.expression.toString()),
+      for (final arg in arguments) arg.name: Code(arg.expression.toString()),
     };
 
     return (

--- a/packages/widgetbook/lib/src/generator/framework/story_generator.dart
+++ b/packages/widgetbook/lib/src/generator/framework/story_generator.dart
@@ -255,7 +255,6 @@ class StoryGenerator extends Generator {
     // via their version-agnostic syntax structure `name ':' expression`,
     // where the expression is the node's last child entity.
     final arguments = match.value.arguments.arguments
-        .cast<AstNode>()
         .where((node) => node.beginToken.next?.lexeme == ':')
         .map(
           (node) => (

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
   flutter: ">=3.38.0"
 
 dependencies:
-  analyzer: ">=8.0.0 <14.0.0"
+  analyzer: ">=8.0.0 <15.0.0"
   build: ^4.0.0
   code_builder: ^4.5.0
   collection: ^1.15.0

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
   flutter: ">=3.38.0"
 
 dependencies:
-  analyzer: ">=8.0.0 <13.0.0"
+  analyzer: ">=8.0.0 <14.0.0"
   build: ^4.0.0
   code_builder: ^4.5.0
   collection: ^1.15.0


### PR DESCRIPTION
## Description

Widens the `analyzer` constraint of the `widgetbook` package from `>=8.0.0 <13.0.0` to `>=8.0.0 <15.0.0`, so consumers whose dependency graph requires `analyzer` 13.x or 14.x can resolve.
`widgetbook_cli` already moved to `analyzer` 14.x in #1998.

Analyzer 13 removed `NamedExpression` in favour of `NamedArgument` and changed `Label` to hold a `Token` instead of a `SimpleIdentifier`, so the previous `arg.name.label.name` access breaks in two ways and neither node type exists on both sides of the boundary.
The single usage in `StoryGenerator.getDefaults` now reads named arguments through their version-agnostic syntax structure (`name ':' expression`) instead of naming either type.

Analyzer 14 needs no further changes: its breaking changes are limited to four `FormalParameterElement` members and `PackageConfigFileBuilder`, none of which this package uses.
The one `formalParameters` call site is on a `ConstructorElement`, which is unaffected.

## Verification

`dart analyze . --fatal-infos` and `dart test test/generator/ --platform vm` (15/15 goldens, generated output unchanged), against both the default resolution (analyzer 12.1.0) and `dependency_overrides` pinning analyzer 14.1.0.

CI resolves at most analyzer 13.3.0, because `flutter_test` pins `test_api 0.7.12` -> `test_core 0.6.18` -> `analyzer <14.0.0`.
Analyzer 14 support is therefore verified manually rather than guarded by CI until a Flutter release bumps `test_api`.
