### PR TITLE
feat(widgetbook): add foldersExpandedByDefault config option

### DIFF
--- a/packages/widgetbook/CHANGELOG.md
+++ b/packages/widgetbook/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FEAT**: Add `foldersExpandedByDefault` to `Config` to start the navigation tree collapsed, while still expanding the ancestors of a deep-linked node on startup. ([#2028](https://github.com/widgetbook/widgetbook/pull/2028))
+
 ## 4.0.0-beta.13
 
 - **REFACTOR**: Allow `analyzer` 13.x and 14.x. ([#2025](https://github.com/widgetbook/widgetbook/pull/2025))

--- a/packages/widgetbook/lib/src/core/framework/config.dart
+++ b/packages/widgetbook/lib/src/core/framework/config.dart
@@ -65,6 +65,7 @@ class Config {
     this.scenarioConfig = const ScenarioConfig(),
     this.accessibilityConfig = const AccessibilityConfig(),
     this.docsBuilder = defaultDocsBuilder,
+    this.foldersExpandedByDefault = true,
   });
 
   /// The initial route for that will be used on first startup.
@@ -141,4 +142,11 @@ class Config {
   ///
   /// If not provided, defaults to [defaultDocsBuilder].
   final List<DocBlock> Function()? docsBuilder;
+
+  /// Whether folder and component nodes in the navigation tree start expanded.
+  ///
+  /// When `false`, only the root level is visible until the user expands a
+  /// folder. Story nodes are always collapsed by default regardless of this
+  /// setting.
+  final bool foldersExpandedByDefault;
 }

--- a/packages/widgetbook/lib/src/core/framework/config.dart
+++ b/packages/widgetbook/lib/src/core/framework/config.dart
@@ -147,6 +147,7 @@ class Config {
   ///
   /// When `false`, only the root level is visible until the user expands a
   /// folder. Story nodes are always collapsed by default regardless of this
-  /// setting.
+  /// setting. Ancestors of a node that is deep-linked via the `path` query
+  /// parameter are still expanded on startup, so that the node is visible.
   final bool foldersExpandedByDefault;
 }

--- a/packages/widgetbook/lib/src/core/layout/responsive_layout.dart
+++ b/packages/widgetbook/lib/src/core/layout/responsive_layout.dart
@@ -26,6 +26,7 @@ class ResponsiveLayout extends StatelessWidget {
       initialPath: state.path,
       root: state.root,
       header: state.config.header,
+      foldersExpandedByDefault: state.config.foldersExpandedByDefault,
       onLeafNodeTap: (node) {
         WidgetbookState.of(context).updatePath(node.path);
 

--- a/packages/widgetbook/lib/src/core/navigation/navigation_panel.dart
+++ b/packages/widgetbook/lib/src/core/navigation/navigation_panel.dart
@@ -37,6 +37,27 @@ class _NavigationPanelState extends State<NavigationPanel> {
   Timer? _debounce;
   final Set<String> _toggled = {};
 
+  @override
+  void initState() {
+    super.initState();
+    _revealInitialPath();
+  }
+
+  /// Expands all ancestors of [NavigationPanel.initialPath], so that the
+  /// deep-linked node is visible on startup.
+  void _revealInitialPath() {
+    final initialPath = widget.initialPath;
+    if (initialPath == null) return;
+
+    var node = widget.root.findByPath(initialPath)?.parent;
+    while (node != null && !node.isRoot) {
+      if (!_isExpanded(node)) {
+        _toggled.add(node.path);
+      }
+      node = node.parent;
+    }
+  }
+
   bool _isExpandedByDefault(TreeNode node) {
     if (node is TreeNode<Story>) return false;
     return widget.foldersExpandedByDefault;

--- a/packages/widgetbook/lib/src/core/navigation/navigation_panel.dart
+++ b/packages/widgetbook/lib/src/core/navigation/navigation_panel.dart
@@ -20,12 +20,14 @@ class NavigationPanel extends StatefulWidget {
     this.onLeafNodeTap,
     required this.root,
     this.header,
+    this.foldersExpandedByDefault = true,
   });
 
   final String? initialPath;
   final ValueChanged<TreeNode<dynamic>>? onLeafNodeTap;
   final TreeNode<Null> root;
   final Widget? header;
+  final bool foldersExpandedByDefault;
 
   @override
   State<NavigationPanel> createState() => _NavigationPanelState();
@@ -35,7 +37,10 @@ class _NavigationPanelState extends State<NavigationPanel> {
   Timer? _debounce;
   final Set<String> _toggled = {};
 
-  static bool _isExpandedByDefault(TreeNode node) => node is! TreeNode<Story>;
+  bool _isExpandedByDefault(TreeNode node) {
+    if (node is TreeNode<Story>) return false;
+    return widget.foldersExpandedByDefault;
+  }
 
   bool _filterNode(TreeNode node, String query) {
     final escapedQuery = RegExp.escape(query);

--- a/packages/widgetbook/test/core/navigation/navigation_panel_test.dart
+++ b/packages/widgetbook/test/core/navigation/navigation_panel_test.dart
@@ -84,6 +84,7 @@ void main() {
         expect(componentInSidebar, findsNothing);
       },
     );
+
     testWidgets(
       'given foldersExpandedByDefault is false, '
       'when the navigation panel is shown, '
@@ -120,6 +121,95 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('NestedComponent'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'given foldersExpandedByDefault is false, '
+      'when the app starts with a deep link to a story, '
+      'then only the ancestors of that story are expanded',
+      (tester) async {
+        tester.view.physicalSize = const Size(1200, 800);
+        tester.view.devicePixelRatio = 1.0;
+
+        await tester.pumpWidget(
+          WidgetbookApp(
+            config: Config(
+              foldersExpandedByDefault: false,
+              initialRoute: '/?path=Catalog/Group/NestedComponent/Primary',
+              components: [
+                Component(
+                  name: 'NestedComponent',
+                  path: 'Catalog/Group',
+                  stories: [TestStory(name: 'Primary')],
+                ),
+                Component(
+                  name: 'UnrelatedComponent',
+                  path: 'Elsewhere',
+                  stories: [TestStory(name: 'Secondary')],
+                ),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final storyInSidebar = find.descendant(
+          of: find.byType(FolderTreeTile),
+          matching: find.text('Primary'),
+        );
+
+        expect(find.text('Catalog'), findsOneWidget);
+        expect(find.text('Group'), findsOneWidget);
+        expect(find.text('NestedComponent'), findsOneWidget);
+        expect(storyInSidebar, findsOneWidget);
+
+        expect(find.text('Elsewhere'), findsOneWidget);
+        expect(find.text('UnrelatedComponent'), findsNothing);
+        expect(find.text('Secondary'), findsNothing);
+
+        addTearDown(tester.view.resetPhysicalSize);
+      },
+    );
+
+    testWidgets(
+      'given foldersExpandedByDefault is false, '
+      'when the app starts with a deep link to a scenario, '
+      'then the story node is expanded to reveal the scenario',
+      (tester) async {
+        tester.view.physicalSize = const Size(1200, 800);
+        tester.view.devicePixelRatio = 1.0;
+
+        await tester.pumpWidget(
+          WidgetbookApp(
+            config: Config(
+              foldersExpandedByDefault: false,
+              initialRoute: '/?path=Catalog/NestedComponent/Primary/Dark',
+              components: [
+                Component(
+                  name: 'NestedComponent',
+                  path: 'Catalog',
+                  stories: [
+                    TestStory(
+                      name: 'Primary',
+                      scenarios: [TestScenario(name: 'Dark')],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final scenarioInSidebar = find.descendant(
+          of: find.byType(FolderTreeTile),
+          matching: find.text('Dark'),
+        );
+
+        expect(scenarioInSidebar, findsOneWidget);
+
+        addTearDown(tester.view.resetPhysicalSize);
       },
     );
   });

--- a/packages/widgetbook/test/core/navigation/navigation_panel_test.dart
+++ b/packages/widgetbook/test/core/navigation/navigation_panel_test.dart
@@ -84,5 +84,43 @@ void main() {
         expect(componentInSidebar, findsNothing);
       },
     );
+    testWidgets(
+      'given foldersExpandedByDefault is false, '
+      'when the navigation panel is shown, '
+      'then nested entries are hidden until expanded',
+      (tester) async {
+        tester.view.physicalSize = const Size(1200, 800);
+        tester.view.devicePixelRatio = 1.0;
+
+        await tester.pumpWidget(
+          WidgetbookApp(
+            config: Config(
+              foldersExpandedByDefault: false,
+              components: [
+                Component(
+                  name: 'NestedComponent',
+                  path: 'Catalog/Group',
+                  stories: [TestStory(name: 'Primary')],
+                ),
+              ],
+            ),
+          ),
+        );
+
+        expect(find.text('NestedComponent'), findsNothing);
+        expect(find.text('Catalog'), findsOneWidget);
+
+        await tester.tap(find.text('Catalog'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Group'), findsOneWidget);
+        expect(find.text('NestedComponent'), findsNothing);
+
+        await tester.tap(find.text('Group'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('NestedComponent'), findsOneWidget);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

- Adds a `foldersExpandedByDefault` option to `Config` (defaults to `true` for backward compatibility).
- When set to `false`, folder and component nodes in the navigation tree start collapsed; story nodes remain collapsed regardless.
- Includes a widget test covering the collapsed-by-default behavior.

## Motivation

Large Widgetbook catalogs can feel overwhelming when every folder opens on startup. This lets consumers opt into a collapsed sidebar without changing the default experience for existing projects.

<img width="1196" height="700" alt="Screenshot 2026-08-30 at 6 21 32 PM" src="https://github.com/user-attachments/assets/08d518a7-d330-477d-8d99-a660a9d68c6b" />


## Test plan

- [x] `flutter test test/core/navigation/navigation_panel_test.dart` in `packages/widgetbook`
- [x] Verified locally in a consumer app by setting `foldersExpandedByDefault: false` in `Config`


Made with [Cursor](https://cursor.com)