### PR TITLE
fix: migrate widgetbook_cli to the platform 3.2 NativePlatform API

### DIFF
--- a/packages/widgetbook_cli/CHANGELOG.md
+++ b/packages/widgetbook_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FIX**: Migrate to the `platform` package's 3.2 `NativePlatform` API.
+
 ## 4.0.0-beta.13
 
 - **CHORE**: Align version with `widgetbook` so both packages share `4.0.0-beta.13`.

--- a/packages/widgetbook_cli/bin/widgetbook.dart
+++ b/packages/widgetbook_cli/bin/widgetbook.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:widgetbook_cli/widgetbook_cli.dart';
 
 void main(List<String> args) async {
-  const contextManager = ContextManager();
+  final contextManager = ContextManager();
   final repository = await Repository.load(
     Directory.current.path,
   );

--- a/packages/widgetbook_cli/lib/src/core/context_manager.dart
+++ b/packages/widgetbook_cli/lib/src/core/context_manager.dart
@@ -5,12 +5,12 @@ import '../utils/utils.dart';
 import 'context.dart';
 
 class ContextManager {
-  const ContextManager({
-    this.platform = const LocalPlatform(),
+  ContextManager({
+    NativePlatform? platform,
     this.ciManager = const CiManager(),
-  });
+  }) : platform = platform ?? NativePlatform.current!;
 
-  final Platform platform;
+  final NativePlatform platform;
   final CiManager ciManager;
 
   /// Returns the relevant [Context] for the current environment.

--- a/packages/widgetbook_cli/pubspec.yaml
+++ b/packages/widgetbook_cli/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   meta: ^1.16.0
   mime: ^2.0.0
   path: ^1.9.0
-  platform: ^3.1.0
+  platform: ^3.2.0
   pool: ^1.5.1
   process: ^5.0.3
   pub_updater: ">=0.4.0 <1.0.0"

--- a/packages/widgetbook_cli/test/helper/mocks.dart
+++ b/packages/widgetbook_cli/test/helper/mocks.dart
@@ -5,7 +5,6 @@ import 'package:ci/ci.dart';
 import 'package:file/file.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 import 'package:pub_updater/pub_updater.dart';
 import 'package:widgetbook_cli/src/storage/storage.dart';
@@ -52,8 +51,6 @@ class MockCiManager extends Mock implements CiManager {
     when(() => this.isGitLab).thenReturn(isGitLab);
   }
 }
-
-class MockPlatform extends Mock implements Platform {}
 
 class MockCacheReader extends Mock implements CacheReader {}
 

--- a/packages/widgetbook_cli/test/src/core/context_manager_test.dart
+++ b/packages/widgetbook_cli/test/src/core/context_manager_test.dart
@@ -1,4 +1,5 @@
 import 'package:mocktail/mocktail.dart';
+import 'package:platform/testing.dart';
 import 'package:test/test.dart';
 import 'package:widgetbook_cli/widgetbook_cli.dart';
 
@@ -10,17 +11,20 @@ void main() {
   const sha = '832e76a9899f560a90ffd62ae2ce83bbeff58f54';
 
   final ciManager = MockCiManager();
-  final platform = MockPlatform();
-  final contextManager = ContextManager(
-    ciManager: ciManager,
-    platform: platform,
-  );
+
+  ContextManager buildContextManager([Map<String, String>? environment]) {
+    return ContextManager(
+      ciManager: ciManager,
+      platform: TestNativePlatform(environment: environment),
+    );
+  }
 
   group('$ContextManager', () {
     final repository = MockRepository();
 
     test('Local', () async {
       ciManager.mock();
+      final contextManager = buildContextManager();
       when(() => repository.name).thenReturn(repoName);
       when(() => repository.user).thenAnswer((_) async => userName);
 
@@ -39,7 +43,7 @@ void main() {
 
     test('Azure', () {
       ciManager.mock(isAzure: true);
-      when(() => platform.environment).thenReturn({
+      final contextManager = buildContextManager({
         'BUILD_SOURCEVERSIONAUTHOR': userName,
         'BUILD_REPOSITORY_NAME': repoName,
       });
@@ -59,7 +63,7 @@ void main() {
 
     test('Bitbucket', () {
       ciManager.mock(isBitbucket: true);
-      when(() => platform.environment).thenReturn({
+      final contextManager = buildContextManager({
         'BITBUCKET_STEP_TRIGGERER_UUID': userName,
         'BITBUCKET_REPO_FULL_NAME': repoName,
       });
@@ -79,7 +83,7 @@ void main() {
 
     test('Codemagic', () {
       ciManager.mock(isCodemagic: true);
-      when(() => platform.environment).thenReturn({
+      final contextManager = buildContextManager({
         'CM_REPO_SLUG': repoName,
         'CM_COMMIT': userName,
       });
@@ -100,7 +104,7 @@ void main() {
 
     test('GitHub', () {
       ciManager.mock(isGitHub: true);
-      when(() => platform.environment).thenReturn({
+      final contextManager = buildContextManager({
         'GITHUB_ACTOR': userName,
         'GITHUB_REPOSITORY': repoName,
         'GITHUB_SHA': sha,
@@ -122,7 +126,7 @@ void main() {
 
     test('GitLab', () {
       ciManager.mock(isGitLab: true);
-      when(() => platform.environment).thenReturn({
+      final contextManager = buildContextManager({
         'GITLAB_USER_LOGIN': userName,
         'CI_PROJECT_PATH': repoName,
         'CI_COMMIT_BRANCH': 'main',


### PR DESCRIPTION
CLI CI (`lint`, `test`, `pana`) is red since `package:platform` 3.2.0 started resolving under the `^3.1.0` constraint: `LocalPlatform` and `Platform.environment` are now deprecated (fatal via `--fatal-infos`), and `Platform` became a `final` class, breaking the mocktail mock that implemented it. Nothing in the CLI had changed; the drift only surfaced with the next CLI-touching PR (#2032).

- `ContextManager` takes a `NativePlatform` and defaults to `NativePlatform.current!`; its constructor is no longer `const`.
- Tests construct `TestNativePlatform(environment: ...)` from `package:platform/testing.dart` instead of mocking.
- `platform` constraint bumped to `^3.2.0`, since the new API does not exist in 3.1.x.

Verified locally with the CI commands: `dart analyze . --fatal-infos`, `dart format --set-exit-if-changed .`, and `dart test` (54/54).